### PR TITLE
imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test: check
-	coverage run --include "WDL/*" -m unittest discover
+	coverage run --include "WDL/*" -m unittest -v
 	coverage report
 
 check:

--- a/WDL/Document.py
+++ b/WDL/Document.py
@@ -135,13 +135,14 @@ class Call(SourceNode):
             outputs_env = Env.bind(outp.name, outp.type, outputs_env)
         return outputs_env
 
+TVScatter = TypeVar("TVScatter", bound="Scatter")
 class Scatter(SourceNode):
     """A scatter stanza within a workflow"""
     variable : str
     """The scatter variable name"""
     expr : E.Base
     """Expression for the array over which to scatter"""
-    elements: List[Union[Decl,Call]]
+    elements: List[Union[Decl,Call,TVScatter]]
     """Calls and/or bound declarations"""
 
     def __init__(self, pos : SourcePosition, variable : str, expr : E.Base, elements : List[Union[Decl,Call]]) -> None:

--- a/WDL/Document.py
+++ b/WDL/Document.py
@@ -1,6 +1,6 @@
 # pyre-strict
 """
-A WDL Document (source file) includes tasks and up to one workflow
+Abstract syntax tree (AST) for WDL documents, encompassing declarations, tasks, calls, and workflows. The AST is typically constructed and returned by :func:`~WDL.load` or :func:`~WDL.parse_document`.
 """
 
 from abc import ABC, abstractmethod
@@ -71,7 +71,6 @@ class Task(SourceNode):
         # TODO: complain of name collisions in inputs/postinputs
 
     def typecheck(self, type_env : Env.Types = []) -> None:
-        """Infer and check types on all input/output declarations and the command, including any expression placeholders within the command"""
         for decl in (self.inputs+self.postinputs):
             type_env = _typecheck_decl(decl, type_env)
         self.command.infer_type(type_env).typecheck(T.String())
@@ -83,13 +82,15 @@ class Task(SourceNode):
     def required_inputs(self) -> List[Decl]:
         return [decl for decl in (self.inputs+self.postinputs) if decl.expr is None]
 
+# type-check a declaration within a type environment, and return the type
+# environment with the new binding
 def _typecheck_decl(decl : Decl, type_env : Env.Types) -> Env.Types:
     if decl.expr is not None:
         decl.expr.infer_type(type_env).typecheck(decl.type)
     ans : Env.Types = Env.bind(decl.name, decl.type, type_env)
     return ans
 
-# forward-declaration of Document type
+# forward-declaration of Document and Workflow types
 TVDocument = TypeVar('TVDocument',bound='Document')
 TVWorkflow = TypeVar('TVWorkflow',bound='Workflow')
 
@@ -103,7 +104,7 @@ class Call(SourceNode):
     """Call inputs provided"""
 
     callee : Optional[Union[Task,TVWorkflow]]
-    """After typechecking, holds the task/workflow object to call"""
+    """After the AST is typechecked, refers to the Task or Workflow object to call"""
 
     def __init__(self, pos : SourcePosition, callee_id : E.Ident, alias : Optional[str], inputs : Dict[str,E.Base]) -> None:
         super().__init__(pos)
@@ -113,8 +114,6 @@ class Call(SourceNode):
         self.callee = None
 
     def typecheck(self, type_env : Env.Types, doc : TVDocument) -> Env.Types:
-        """Resolve the callee_id within the type environment, and check the types of provided inputs against the callee_id inputs. Return a type environment describing the call outputs only."""
-
         # resolve callee_id to a known task/workflow, either within the
         # current document or one of its imported sub-documents
         if len(self.callee_id.namespace) == 0:
@@ -160,6 +159,19 @@ class Call(SourceNode):
             outputs_env = Env.bind(outp.name, outp.type, outputs_env)
         return outputs_env
 
+
+# Given a type environment, recursively promote each binding of type T to Array[T]
+def _arrayize_types(type_env : Env.Types) -> Env.Types:
+    ans = []
+    for node in type_env:
+        if isinstance(node, Env.Binding):
+            ans.append(Env.Binding(node.name, T.Array(node.rhs)))
+        elif isinstance(node, Env.Namespace):
+            ans.append(Env.Namespace(node.namespace, _arrayize_types(node.bindings)))
+        else:
+            assert False
+    return ans
+
 TVScatter = TypeVar("TVScatter", bound="Scatter")
 class Scatter(SourceNode):
     """A scatter stanza within a workflow"""
@@ -177,8 +189,6 @@ class Scatter(SourceNode):
         self.elements = elements
 
     def typecheck(self, type_env : Env.Types, doc : TVDocument) -> Env.Types:
-        """Typecheck the scatter array and each element of the body; return a type environment describing the scatter outputs only (namespaced with their respective call names)."""
-
         # typecheck the array to determine the element type
         self.expr.infer_type(type_env)
         if not isinstance(self.expr.type, T.Array):
@@ -194,21 +204,25 @@ class Scatter(SourceNode):
 
         for element in self.elements:
             if isinstance(element, Decl):
+                # typecheck the declaration and add binding to type environment
                 type_env = _typecheck_decl(element, type_env)
-                # are declarations within scatters visible as arrays after the scatter?
+                # TODO: are declarations within scatters visible as arrays after the scatter?
             elif isinstance(element, Call):
                 call_outputs_env = element.typecheck(type_env, doc)
+                # add call outputs to type environment, under the call namespace
+                # TODO: complain of namespace collisions
                 type_env = Env.namespace(element.name, call_outputs_env, type_env)
                 outputs_env = Env.namespace(element.name, call_outputs_env, outputs_env)
             elif isinstance(element, Scatter):
+                # add outputs of calls within the subscatter to the type environment.
                 subscatter_outputs_env = element.typecheck(type_env, doc)
                 type_env = subscatter_outputs_env + type_env
                 outputs_env = subscatter_outputs_env + outputs_env
             else:
                 assert False
 
-        # promote each output type t to Array[t]
-        return Env.arrayize(outputs_env)
+        # promote each output type T to Array[T]
+        return _arrayize_types(outputs_env)
 
 class Workflow(SourceNode):
     name : str
@@ -231,17 +245,20 @@ class Workflow(SourceNode):
         self.meta = meta
 
     def typecheck(self, doc : TVDocument) -> None:
-        """Typecheck each workflow element and the outputs, given all the tasks/subworkflows available to be called."""
-
         type_env = []
         for element in self.elements:
             if isinstance(element, Decl):
+                # typecheck the declaration and add binding to type environment
                 type_env = _typecheck_decl(element, type_env)
             elif isinstance(element, Call):
                 outputs_env = element.typecheck(type_env, doc)
+                # add call outputs to type environment, under the call namespace
+                # TODO: complain of namespace collisions
                 type_env = Env.namespace(element.name, outputs_env, type_env)
             elif isinstance(element, Scatter):
                 outputs_env = element.typecheck(type_env, doc)
+                # add outputs of calls within the scatter to the type environment.
+                # Scatter.typecheck already "arrayized" them.
                 type_env = outputs_env + type_env
             else:
                 assert False
@@ -252,7 +269,7 @@ class Workflow(SourceNode):
                 _typecheck_decl(output, type_env)
 
 class Document(SourceNode):
-    """Top-level document"""
+    """Top-level document, with imports, tasks, and a workflow. Typically returned by :func:`~WDL.load` with imported sub-documents loaded, and everything typechecked. Alternatively, :func:`~WDL.parse_document` constructs the AST but doesn't process imports nor perform typechecking."""
     imports : List[Tuple[str,str,Optional[TVDocument]]]
     """Imports in the document (filename/URI, namespace, and later the sub-document)"""
     tasks : List[Task]
@@ -277,6 +294,7 @@ class Document(SourceNode):
         # TODO: complain about name collisions amongst tasks and/or the workflow
 
     def typecheck(self) -> None:
+        """Typecheck each task in the document, then the workflow, if any. Documents returned by :func:`~WDL.load` have already been typechecked."""
         # typecheck each task
         for task in self.tasks:
             task.typecheck()

--- a/WDL/Document.py
+++ b/WDL/Document.py
@@ -124,6 +124,7 @@ class Call(SourceNode):
                 if ns == self.callee_id.namespace[0]:
                     callee_doc = subdoc
         if callee_doc:
+            assert isinstance(callee_doc,Document)
             if callee_doc.workflow and callee_doc.workflow.name == self.callee_id.name:
                 self.callee = callee_doc.workflow
             else:
@@ -274,3 +275,11 @@ class Document(SourceNode):
         self.workflow = workflow
 
         # TODO: complain about name collisions amongst tasks and/or the workflow
+
+    def typecheck(self) -> None:
+        # typecheck each task
+        for task in self.tasks:
+            task.typecheck()
+        # typecheck the workflow
+        if self.workflow:
+            self.workflow.typecheck(self)

--- a/WDL/Document.py
+++ b/WDL/Document.py
@@ -228,12 +228,16 @@ class Workflow(SourceNode):
 
 class Document(SourceNode):
     """Top-level document"""
+    imports : List[Tuple[str,str]]
+    """Import statements in the document (filename/URI and namespace)"""
     tasks : List[Task]
     """Tasks in the document"""
     workflow : Optional[Workflow]
     """Workflow in the document, if any"""
 
-    def __init__(self, pos : SourcePosition, tasks : List[Task], workflow : Optional[Workflow]) -> None:
+    def __init__(self, pos : SourcePosition, imports : List[Tuple[str,str]],
+                 tasks : List[Task], workflow : Optional[Workflow]) -> None:
         super().__init__(pos)
+        self.imports = imports
         self.tasks = tasks
         self.workflow = workflow

--- a/WDL/Env.py
+++ b/WDL/Env.py
@@ -1,6 +1,6 @@
 # pyre-strict
 """
-Environments, for name resolution during WDL type-checking and evaluation
+Environments, for identifier resolution during WDL typechecking and evaluation
 """
 from typing import List, TypeVar, Generic, Union
 import WDL.Type as T
@@ -74,18 +74,6 @@ def resolve(tree : 'Tree[R]', namespace : List[str], name : str) -> R:
         else:
             assert False
     raise KeyError()
-
-def arrayize(type_env : Types) -> Types:
-    """Given a type environment, recursively promote each binding of type x to Array[x]"""
-    ans = []
-    for node in type_env:
-        if isinstance(node, Binding):
-            ans.append(Binding(node.name, T.Array(node.rhs)))
-        elif isinstance(node, Namespace):
-            ans.append(Namespace(node.namespace, arrayize(node.bindings)))
-        else:
-            assert False
-    return ans
 
 #print(arrayize([Binding('x',T.Int())])[0].rhs)
 #assert resolve([Binding('x',T.Int())], [], 'x') == T.Int()

--- a/WDL/Error.py
+++ b/WDL/Error.py
@@ -4,14 +4,14 @@ from typing import Any, List, Optional, Dict, Callable, NamedTuple, TypeVar
 import WDL.Type as T
 from WDL.Expr import TVApply, TVIdent
 
+class ParserError(Exception):
+    def __init__(self, filename : str) -> None:
+        super().__init__(filename)
+
 SourcePosition = NamedTuple("SourcePosition",
                             [('filename',str), ('line',int), ('column',int),
                              ('end_line',int), ('end_column',int)])
 """Source file, line, and column, attached to each AST node"""
-
-class ParserError(Exception):
-    def __init__(self, filename : str) -> None:
-        super().__init__(filename)
 
 class SourceNode:
     """Base class for an AST node, recording the source position"""

--- a/WDL/Error.py
+++ b/WDL/Error.py
@@ -9,6 +9,10 @@ SourcePosition = NamedTuple("SourcePosition",
                              ('end_line',int), ('end_column',int)])
 """Source file, line, and column, attached to each AST node"""
 
+class ParserError(Exception):
+    def __init__(self, filename : str) -> None:
+        super().__init__(filename)
+
 class SourceNode:
     """Base class for an AST node, recording the source position"""
 

--- a/WDL/Error.py
+++ b/WDL/Error.py
@@ -5,9 +5,9 @@ import WDL.Type as T
 from WDL.Expr import TVApply, TVIdent
 
 SourcePosition = NamedTuple("SourcePosition",
-                            [('line',int), ('column',int),
+                            [('filename',str), ('line',int), ('column',int),
                              ('end_line',int), ('end_column',int)])
-"""Source file line/column for each nodeession, attached to each AST node"""
+"""Source file, line, and column, attached to each AST node"""
 
 class SourceNode:
     """Base class for an AST node, recording the source position"""
@@ -69,3 +69,7 @@ class NoSuchInput(Base):
 class NullValue(Base):
     def __init__(self, node : SourceNode) -> None:
         super().__init__(node, "Null value")
+
+class MultipleDefinitions(Base):
+    def __init__(self, node : SourceNode, message : str) -> None:
+        super().__init__(node, message)

--- a/WDL/__init__.py
+++ b/WDL/__init__.py
@@ -290,10 +290,12 @@ def parse_expr(txt : str) -> E.Base:
 def parse_tasks(txt : str) -> List[D.Task]:
     return _DocTransformer('').transform(WDL._parser.parse(txt, "tasks")) # pyre-fixme
 
-def parse_document(txt : str, uri='') -> D.Document:
+def parse_document(txt : str, uri : str = '') -> D.Document:
     """
     Parse WDL document text into an abstract syntax tree. Doesn't descend into
     imported documents nor typecheck the AST.
+
+    :param uri: filename/URI for error reporting (not otherwise used)
     """
     try:
         return _DocTransformer(uri).transform(WDL._parser.parse(txt, "document"))

--- a/WDL/_parser.py
+++ b/WDL/_parser.py
@@ -172,6 +172,9 @@ COMMENT: "#" /[^\r\n]*/ NEWLINE
 %ignore COMMENT
 """
 
+larks_by_start = {} # memoize Lark parsers constructed for various start symbols
 def parse(txt : str, start : str) -> lark.Tree:
-  return lark.Lark(grammar, start=start, parser="lalr", propagate_positions=True).parse(txt)
+    if start not in larks_by_start:
+        larks_by_start[start] = lark.Lark(grammar, start=start, parser="lalr", propagate_positions=True)
+    return larks_by_start[start].parse(txt)
 

--- a/WDL/_parser.py
+++ b/WDL/_parser.py
@@ -151,10 +151,12 @@ scatter: "scatter" "(" CNAME "in" expr ")" "{" [scatter_element*] "}"
 ?workflow_element: any_decl | call | scatter | meta_section | output_decls
 workflow: "workflow" CNAME "{" workflow_element* "}"
 
-// WDL document: tasks and (at most one) workflow
+// WDL document: version, imports, tasks and (at most one) workflow
 version: "version" /[^ \t\r\n]+/
-document: version? task* workflow?
-        | version? workflow task*
+import: "import" string_literal ["as" CNAME]
+?document_element: import | task | workflow
+document: version? document_element*
+        | version? document_element*
 
 COMMENT: "#" /[^\r\n]*/ NEWLINE
 

--- a/WDL/_parser.py
+++ b/WDL/_parser.py
@@ -153,8 +153,8 @@ workflow: "workflow" CNAME "{" workflow_element* "}"
 
 // WDL document: version, imports, tasks and (at most one) workflow
 version: "version" /[^ \t\r\n]+/
-import: "import" string_literal ["as" CNAME]
-?document_element: import | task | workflow
+import_doc: "import" string_literal ["as" CNAME]
+?document_element: import_doc | task | workflow
 document: version? document_element*
         | version? document_element*
 

--- a/WDL/_parser.py
+++ b/WDL/_parser.py
@@ -140,7 +140,7 @@ tasks: task*
 
 // WDL workflows
 call_input: CNAME "=" expr
-call_inputs: "input" ":" [call_input ("," call_input)*]
+call_inputs: "input" ":" [call_input ("," call_input)*] ","?
 ?call_body: "{" call_inputs? "}"
 call: "call" ident call_body? -> call
     | "call" ident "as" CNAME call_body? -> call_as

--- a/tests/test_HCAskylab.py
+++ b/tests/test_HCAskylab.py
@@ -17,3 +17,12 @@ for fn in task_files:
     def t(self, fn=fn):
         WDL.load(fn)
     setattr(TestHCAskylab, name, t)
+workflow_files = glob.glob(os.path.join(tdn, 'skylab-*', 'pipelines', '**', '*.wdl'), recursive=True)
+for fn in workflow_files:
+    name = os.path.split(fn)[1]
+    name = name[:-4]
+    if name not in ['Optimus','count','make_fastq']:
+        name = 'test_HCAskylab_workflow_' + name.replace('.', '_')
+        def t(self, fn=fn):
+            WDL.load(fn, path=[glob.glob(os.path.join(tdn, 'skylab-*', 'library', 'tasks'))[0]])
+        setattr(TestHCAskylab, name, t)

--- a/tests/test_HCAskylab.py
+++ b/tests/test_HCAskylab.py
@@ -15,7 +15,5 @@ for fn in task_files:
     name = name[:-4]
     name = 'test_HCAskylab_task_' + name.replace('.', '_')
     def t(self, fn=fn):
-        with open(fn) as infile:
-            for task in WDL.parse_tasks(infile.read()):
-                task.typecheck()
+        WDL.load(fn)
     setattr(TestHCAskylab, name, t)

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -376,6 +376,7 @@ class TestDoc(unittest.TestCase):
 
     def test_nested_scatter(self):
         doc = r"""
+        import "x.wdl"
         task sum {
             Int x
             Int y
@@ -386,6 +387,7 @@ class TestDoc(unittest.TestCase):
                 Int z = stdout()
             }
         }
+        import "y.wdl" as z
         workflow contrived {
             Array[Int] xs = [1, 2, 3]
             Array[Int] ys = [4, 5, 6]
@@ -408,6 +410,7 @@ class TestDoc(unittest.TestCase):
         self.assertIsInstance(doc.workflow.elements[2].elements[0], WDL.Document.Scatter)
         self.assertEqual(len(doc.tasks), 1)
         doc.workflow.typecheck(doc.tasks)
+        self.assertEqual(doc.imports, [("x.wdl","x"), ("y.wdl","z")])
 
     def test_errors(self):
         doc = r"""

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -312,7 +312,7 @@ class TestDoc(unittest.TestCase):
         self.assertIsInstance(doc.workflow, WDL.Document.Workflow)
         self.assertEqual(len(doc.workflow.elements), 2)
         self.assertEqual(len(doc.tasks), 2)
-        doc.workflow.typecheck(doc.tasks)
+        doc.workflow.typecheck(doc)
 
     def test_bam_chrom_counter(self):
         doc = r"""
@@ -372,7 +372,7 @@ class TestDoc(unittest.TestCase):
         self.assertIsInstance(doc.workflow.elements[2], WDL.Document.Scatter)
         self.assertEqual(len(doc.workflow.elements[2].elements), 1)
         self.assertEqual(len(doc.tasks), 2)
-        doc.workflow.typecheck(doc.tasks)
+        doc.workflow.typecheck(doc)
 
     def test_nested_scatter(self):
         doc = r"""
@@ -409,8 +409,8 @@ class TestDoc(unittest.TestCase):
         self.assertIsInstance(doc.workflow.elements[2], WDL.Document.Scatter)
         self.assertIsInstance(doc.workflow.elements[2].elements[0], WDL.Document.Scatter)
         self.assertEqual(len(doc.tasks), 1)
-        doc.workflow.typecheck(doc.tasks)
-        self.assertEqual(doc.imports, [("x.wdl","x"), ("y.wdl","z")])
+        doc.workflow.typecheck(doc)
+        self.assertEqual(doc.imports, [("x.wdl","x",None), ("y.wdl","z",None)])
 
     def test_errors(self):
         doc = r"""
@@ -432,7 +432,7 @@ class TestDoc(unittest.TestCase):
         """
         doc = WDL.parse_document(doc)
         with self.assertRaises(WDL.Error.NotAnArray):
-            doc.workflow.typecheck(doc.tasks)
+            doc.workflow.typecheck(doc)
 
         doc = r"""
         task sum {
@@ -454,7 +454,7 @@ class TestDoc(unittest.TestCase):
         """
         doc = WDL.parse_document(doc)
         with self.assertRaises(WDL.Error.NoSuchInput):
-            doc.workflow.typecheck(doc.tasks)
+            doc.workflow.typecheck(doc)
 
         doc = r"""
         version 1.0
@@ -480,7 +480,7 @@ class TestDoc(unittest.TestCase):
         """
         doc = WDL.parse_document(doc)
         with self.assertRaises(WDL.Error.UnknownIdentifier):
-            doc.workflow.typecheck(doc.tasks)
+            doc.workflow.typecheck(doc)
 
         doc = r"""
         workflow contrived {
@@ -492,4 +492,4 @@ class TestDoc(unittest.TestCase):
         """
         doc = WDL.parse_document(doc)
         with self.assertRaises(WDL.Error.UnknownIdentifier):
-            doc.workflow.typecheck(doc.tasks)
+            doc.workflow.typecheck(doc)


### PR DESCRIPTION
Handle import statements.

* `WDL.load(filename)` parses and type-checks a WDL document, recursively descending into any imported documents
* Resolve calls into imported tasks/workflows
* Several (not all) of the HumanCellAtlas/skylab workflows are now loaded in the tests
