### PR TITLE
Tighten checking of optional types

### DIFF
--- a/WDL/Error.py
+++ b/WDL/Error.py
@@ -72,7 +72,7 @@ class StaticTypeMismatch(Base):
     def __init__(self, node : SourceNode, expected : T.Base, actual : T.Base, message : Optional[str] = None) -> None:
         msg = "Expected {} instead of {}".format(str(expected), str(actual))
         if message is not None:
-            msg = msg + "; " + message
+            msg = msg + " " + message
         super().__init__(node, msg)
 
 class IncompatibleOperand(Base):

--- a/WDL/Expr.py
+++ b/WDL/Expr.py
@@ -195,7 +195,7 @@ class Array(Base):
         for item in self.items:
             item.infer_type(type_env)
         # Start by assuming the type of the first item is the item type
-        item_type = self.items[0].type
+        item_type : T.Base = self.items[0].type
         # Allow a mixture of Int and Float to construct Array[Float]
         if isinstance(item_type, T.Int):
             for item in self.items:
@@ -207,7 +207,7 @@ class Array(Base):
             if isinstance(item.type, T.String):
                 item_type = T.String(optional=item_type.optional)
             if item.type.optional:
-                item_type.optional = True
+                item_type = item_type.copy(optional=True)
         # Check all items are coercible to item_type
         for item in self.items:
             try:
@@ -253,7 +253,7 @@ class IfThenElse(Base):
         assert isinstance(self_type, T.Base)
         self.alternative.infer_type(type_env)
         if self.alternative.type.optional:
-            self_type.optional = True
+            self_type = self_type.copy(optional=True)
         if isinstance(self_type, T.Int) and isinstance(self.alternative.type, T.Float):
             self_type = T.Float(optional=self_type.optional)
         try:

--- a/WDL/StdLib.py
+++ b/WDL/StdLib.py
@@ -203,7 +203,7 @@ class _AddOperator(_ArithmeticOperator):
         if t2 is None:
             # neither operand is a string; defer to _ArithmeticOperator
             return super().infer_type(expr)
-        if not t2.coerces(T.String()):
+        if not t2.coerces(T.String(optional=True)):
             raise Error.IncompatibleOperand(expr, "Cannot add/concatenate {} and {}".format(str(expr.arguments[0].type), str(expr.arguments[1].type)))
         return T.String()
 

--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -87,9 +87,18 @@ class Task(SourceNode):
 # type-check a declaration within a type environment, and return the type
 # environment with the new binding
 def _typecheck_decl(decl : Decl, type_env : Env.Types) -> Env.Types:
+    # subtlety: in a declaration like: String? x = "who"
+    # we record x in the type environment as String instead of String?
+    # since it can't actually be null at runtime
+    nonnull = False
     if decl.expr is not None:
         decl.expr.infer_type(type_env).typecheck(decl.type)
-    ans : Env.Types = Env.bind(decl.name, decl.type, type_env)
+        if decl.expr.type.optional is False:
+            nonnull = True
+    ty = copy.copy(decl.type)
+    if nonnull:
+        ty.optional = False
+    ans : Env.Types = Env.bind(decl.name, ty, type_env)
     return ans
 
 # forward-declaration of Document and Workflow types

--- a/WDL/Type.py
+++ b/WDL/Type.py
@@ -42,10 +42,10 @@ class Base(ABC):
         """True if ``rhs`` is the same type, or can be coerced to, ``self``. Optional/nonempty quantifiers are disregarded for this purpose."""
         if isinstance(rhs, Array) and rhs.item_type == self: # coerce T to Array[T]
             return True
-        return (self == rhs)
+        return (type(self).__name__ == type(rhs).__name__) and (not self.optional or rhs.optional)
 
     def __str__(self) -> str:
-        return type(self).__name__
+        return type(self).__name__ + ('?' if self.optional else '')
     def __eq__(self, rhs) -> bool:
         return isinstance(rhs,Base) and str(self) == str(rhs)
 

--- a/WDL/Type.py
+++ b/WDL/Type.py
@@ -24,6 +24,7 @@ for example
 """
 from abc import ABC, abstractmethod
 from typing import Optional, TypeVar, Tuple
+import copy
 
 TVBase = TypeVar("TVBase", bound="Base")
 class Base(ABC):
@@ -35,14 +36,31 @@ class Base(ABC):
         assert isinstance(WDL.Type.Array(WDL.Type.Int()), WDL.Type.Base)
     """
 
-    optional : bool
-    """True in declarations with the optional quantifier, ``Type?``"""
+    _optional : bool # immutable!!!
 
     def coerces(self, rhs : TVBase) -> bool:
-        """True if ``rhs`` is the same type, or can be coerced to, ``self``. Optional/nonempty quantifiers are disregarded for this purpose."""
+        """
+        True if ``rhs`` is the same type, or can be coerced to, ``self``.
+
+        ``T`` coerces to ``Array[T]`` (an array of length 1).
+
+        ``T`` coerces to ``T?`` but the reverse is not true in general.
+        """
         if isinstance(rhs, Array) and rhs.item_type == self: # coerce T to Array[T]
             return True
         return (type(self).__name__ == type(rhs).__name__) and (not self.optional or rhs.optional)
+
+    @property
+    def optional(self) -> bool:
+        """True in declarations with the optional quantifier, ``T?``"""
+        return self._optional
+
+    def copy(self, optional : Optional[bool] = None) -> TVBase:
+        """Return a copy of the type with a different setting of the ``optional`` quantifier."""
+        ans : Base = copy.copy(self)
+        if optional is not None:
+            ans._optional = optional
+        return ans
 
     def __str__(self) -> str:
         return type(self).__name__ + ('?' if self.optional else '')
@@ -51,7 +69,7 @@ class Base(ABC):
 
 class Boolean(Base):
     def __init__(self, optional : bool = False) -> None:
-        self.optional = optional
+        self._optional = optional
     def coerces(self, rhs : Base) -> bool:
         if isinstance(rhs, String):
             return True
@@ -59,7 +77,7 @@ class Boolean(Base):
 
 class Float(Base):
     def __init__(self, optional : bool = False) -> None:
-        self.optional = optional
+        self._optional = optional
     def coerces(self, rhs : Base) -> bool:
         if isinstance(rhs, String):
             return True
@@ -67,7 +85,7 @@ class Float(Base):
 
 class Int(Base):
     def __init__(self, optional : bool = False) -> None:
-        self.optional = optional
+        self._optional = optional
     def coerces(self, rhs : Base) -> bool:
         if isinstance(rhs, Float) or isinstance(rhs, String):
             return True
@@ -75,7 +93,7 @@ class Int(Base):
 
 class File(Base):
     def __init__(self, optional : bool = False) -> None:
-        self.optional = optional
+        self._optional = optional
     def coerces(self, rhs : Base) -> bool:
         if isinstance(rhs, String):
             return True
@@ -83,7 +101,7 @@ class File(Base):
 
 class String(Base):
     def __init__(self, optional : bool = False) -> None:
-        self.optional = optional
+        self._optional = optional
     def coerces(self, rhs : Base) -> bool:
         if isinstance(rhs, File):
             return True
@@ -99,14 +117,14 @@ class Array(Base):
     statically coercible to any array type (but may fail at runtime)
     """
     item_type : Optional[Base]
-    nonempty : bool
+    _nonempty : bool
     """True in declarations with the nonempty quantifier, ``Array[type]+``"""
 
     def __init__(self, item_type : Optional[Base], optional : bool = False, nonempty : bool = False) -> None:
         self.item_type = item_type
         assert isinstance(nonempty, bool)
-        self.optional = optional
-        self.nonempty = nonempty
+        self._optional = optional
+        self._nonempty = nonempty
     def __str__(self) -> str:
         ans = "Array[" + (str(self.item_type) if self.item_type is not None else "") + "]"
         return ans
@@ -119,6 +137,14 @@ class Array(Base):
         if isinstance(rhs, String):
             return self.item_type is None or self.item_type.coerces(String())
         return super().coerces(rhs)
+    def copy(self, optional : Optional[bool] = None, nonempty : Optional[bool] = None) -> Base:
+        ans : Array = super().copy(optional)
+        if nonempty is not None:
+            ans._nonempty = nonempty
+        return ans
+    @property
+    def nonempty(self) -> bool:
+        return self._nonempty
 
 class Map(Base):
     """
@@ -132,7 +158,7 @@ class Map(Base):
     item_type : Optional[Tuple[Base,Base]]
 
     def __init__(self, item_type : Optional[Tuple[Base,Base]], optional : bool = False) -> None:
-        self.optional = optional
+        self._optional = optional
         self.item_type = item_type
     def __str__(self) -> str:
         return "Map[" + (str(self.item_type[0]) + "," + str(self.item_type[1]) if self.item_type is not None else "") + "]" # pyre-fixme
@@ -152,7 +178,7 @@ class Pair(Base):
     right_type : Base
 
     def __init__(self, left_type : Base, right_type : Base, optional : bool = False) -> None:
-        self.optional = optional
+        self._optional = optional
         self.left_type = left_type
         self.right_type = right_type
     def __str__(self) -> str:

--- a/tests/test_2calls.py
+++ b/tests/test_2calls.py
@@ -74,3 +74,23 @@ class TestCalls(unittest.TestCase):
         """
         with self.assertRaises(WDL.Error.MultipleDefinitions):
             doc = WDL.parse_document(txt)
+
+    def test_optional(self):
+        txt = tsk + r"""
+        workflow contrived {
+            Int? x
+            call sum { input: x = x }
+        }
+        """
+        doc = WDL.parse_document(txt)
+        with self.assertRaises(WDL.Error.StaticTypeMismatch):
+            doc.typecheck()
+
+        txt = tsk + r"""
+        workflow contrived {
+            Int? x = 0
+            call sum { input: x = x }
+        }
+        """
+        doc = WDL.parse_document(txt)
+        doc.typecheck()


### PR DESCRIPTION
Refine treatment of optional types so that `T?` does not in general satisfy `T` (although it sometimes may)

Test corpi seem to demand a couple of workarounds:
1. `T?` satisfies `T` for standard library function arguments during typechecking (may fail at runtime)
2. A declaration like `T? name = <expr>`satisfies `T` during typechecking since the right-hand side suggests it cannot be null at runtime. In this case `name` is bound to `T` in the type environment, although the declaration type is still considered `T?`.

Partial #11
