### PR TITLE
pylint & autopep8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ script:
       set -ex -o pipefail
       make docker
       docker run --env TRAVIS_JOB_ID=${TRAVIS_JOB_ID} --env TRAVIS_BRANCH=${TRAVIS_BRANCH} miniwdl coveralls
+      docker run --env TRAVIS_JOB_ID=${TRAVIS_JOB_ID} --env TRAVIS_BRANCH=${TRAVIS_BRANCH} miniwdl make sopretty

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ typecheck:
 		--typeshed $(HOME)/.local/lib/pyre_check/typeshed \
 		--show-parse-errors check
 
+pylint:
+	pylint -d cyclic-import,empty-docstring,missing-docstring,invalid-name WDL
+
 docker:
 	docker build -t miniwdl .
 
@@ -32,4 +35,4 @@ doc:
 
 docs: doc
 
-.PHONY: typecheck test docker doc docs pypi_test pypi bdist
+.PHONY: typecheck pylint test docker doc docs pypi_test pypi bdist

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,9 @@ pretty:
 	pylint -d cyclic-import,empty-docstring,missing-docstring,invalid-name --exit-zero WDL
 
 # for use in CI: complain if the source code is not at a fixed point for autopep8
+# (assumes we start from a clean checkout)
 sopretty: pretty
-	git diff --quiet || (echo "Source files were modified by `autopep8`; please fix up this commit with `make pretty`"; exit 1)
+	git diff --quiet || (echo "Source files were modified by autopep8; please fix up this commit with 'make pretty'"; exit 1)
 
 # run tests in a docker image
 docker:

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,9 @@ pretty:
 	pylint -d cyclic-import,empty-docstring,missing-docstring,invalid-name --exit-zero WDL
 
 # for use in CI: complain if source code isn't at a fixed point for autopep8
-# (assumes we start from a clean checkout)
-sopretty: pretty
+sopretty:
+	@git diff --quiet || (echo "ERROR: 'make sopretty' must start with a clean working tree"; exit 1)
+	$(MAKE) pretty
 	@git diff --quiet || (echo "ERROR: source files were modified by autopep8; please fix up this commit with 'make pretty'"; exit 1)
 
 # run tests in a docker image

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ typecheck:
 pylint:
 	pylint -d cyclic-import,empty-docstring,missing-docstring,invalid-name WDL
 
+autopep8:
+	autopep8 --aggressive --aggressive --in-place WDL/*.py
+
 docker:
 	docker build -t miniwdl .
 
@@ -35,4 +38,4 @@ doc:
 
 docs: doc
 
-.PHONY: typecheck pylint test docker doc docs pypi_test pypi bdist
+.PHONY: typecheck pylint autopep8 test docker doc docs pypi_test pypi bdist

--- a/Makefile
+++ b/Makefile
@@ -1,41 +1,51 @@
 SHELL := /bin/bash
 
-test: typecheck
+test: check
 	coverage run --include "WDL/*" -m unittest -v
 	coverage report
 
+# fail fast
 qtest:
 	python -m unittest -v -f
 
-typecheck:
+check:
+	pylint --errors-only WDL
 	pyre \
 		--search-path $(HOME)/.local/lib/python3.6/site-packages/lark \
 		--typeshed $(HOME)/.local/lib/pyre_check/typeshed \
 		--show-parse-errors check
 
-pylint:
-	pylint -d cyclic-import,empty-docstring,missing-docstring,invalid-name WDL
-
-autopep8:
+# uses autopep8 to rewrite source files!
+pretty:
 	autopep8 --aggressive --aggressive --in-place WDL/*.py
+	pylint -d cyclic-import,empty-docstring,missing-docstring,invalid-name --exit-zero WDL
 
+# for use in CI: complain if the source code is not at a fixed point for autopep8
+sopretty: pretty
+	git diff --quiet || (echo "Source files were modified by `autopep8`; please fix up this commit with `make pretty`"; exit 1)
+
+# run tests in a docker image
 docker:
 	docker build -t miniwdl .
 
+# push to pypi test
 pypi_test: bdist
 	twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 
+# push to pypi live
 pypi: bdist
 	echo -e "\033[0;31;5m -- Not a test: pushing $$(basename `ls -1 dist/*.tar.gz` .tar.gz) to PyPI! -- \033[0m"
 	twine upload dist/*
 
+# build dist
 bdist:
 	rm -rf dist/
 	python3 setup.py sdist bdist_wheel
 
+# sphinx
 doc:
 	$(MAKE) -C docs html
 
 docs: doc
 
-.PHONY: typecheck pylint autopep8 test docker doc docs pypi_test pypi bdist
+.PHONY: check sopretty pretty test docker doc docs pypi_test pypi bdist

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ pretty:
 	autopep8 --aggressive --aggressive --in-place WDL/*.py
 	pylint -d cyclic-import,empty-docstring,missing-docstring,invalid-name --exit-zero WDL
 
-# for use in CI: complain if the source code is not at a fixed point for autopep8
+# for use in CI: complain if source code isn't at a fixed point for autopep8
 # (assumes we start from a clean checkout)
 sopretty: pretty
 	@git diff --quiet || (echo "Source files were modified by autopep8; please fix up this commit with 'make pretty'"; exit 1)

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ pretty:
 # for use in CI: complain if source code isn't at a fixed point for autopep8
 # (assumes we start from a clean checkout)
 sopretty: pretty
-	@git diff --quiet || (echo "ERROR: Source files were modified by autopep8; please fix up this commit with 'make pretty'"; exit 1)
+	@git diff --quiet || (echo "ERROR: source files were modified by autopep8; please fix up this commit with 'make pretty'"; exit 1)
 
 # run tests in a docker image
 docker:

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ pretty:
 # for use in CI: complain if the source code is not at a fixed point for autopep8
 # (assumes we start from a clean checkout)
 sopretty: pretty
-	git diff --quiet || (echo "Source files were modified by autopep8; please fix up this commit with 'make pretty'"; exit 1)
+	@git diff --quiet || (echo "Source files were modified by autopep8; please fix up this commit with 'make pretty'"; exit 1)
 
 # run tests in a docker image
 docker:

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ pretty:
 # for use in CI: complain if source code isn't at a fixed point for autopep8
 # (assumes we start from a clean checkout)
 sopretty: pretty
-	@git diff --quiet || (echo "Source files were modified by autopep8; please fix up this commit with 'make pretty'"; exit 1)
+	@git diff --quiet || (echo "ERROR: Source files were modified by autopep8; please fix up this commit with 'make pretty'"; exit 1)
 
 # run tests in a docker image
 docker:

--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ File barcoded_bam
 
 ## Contributing
 
-Feedback and contributions are welcome on this repository. Please send pull requests on a dedicated branch, and ensure their compatibility with this project's MIT license.
+Feedback and contributions are welcome on this repository. Please:
+
+1. Send pull requests from a dedicated branch without unrelated edits
+2. Add appropriate tests to the automatic suite
+3. Use `make pretty` to reformat the code with [autopep8](https://github.com/hhatto/autopep8)
+4. Ensure compatibility with this project's MIT license
 
 The [Project board](https://github.com/chanzuckerberg/miniwdl/projects/1) is our up-to-date tracker.

--- a/WDL/CLI.py
+++ b/WDL/CLI.py
@@ -1,14 +1,15 @@
 """
 miniwdl command-line interface
 """
-import sys, os
+import sys
+import os
 from argparse import ArgumentParser
 import WDL
 import WDL.Lint
 
 def main(args=None):
     parser = ArgumentParser()
-    
+
     subparsers = parser.add_subparsers()
     subparsers.required = True
     subparsers.dest = 'command'
@@ -55,9 +56,9 @@ def outline(obj, level, file=sys.stdout):
     first_descent = []
     def descend(dobj=None, first_descent=first_descent):
         # show lint for the node just prior to first descent beneath it
-        if len(first_descent) == 0 and hasattr(obj, 'lint'):
-            for (node,klass,msg) in sorted(obj.lint, key=lambda t: t[0]):
-                print('{}  (Ln {}, Col {}) {}: {}'.format(s,node.pos.line,node.pos.column,klass,msg), file=file)
+        if not first_descent and hasattr(obj, 'lint'):
+            for (node, klass, msg) in sorted(obj.lint, key=lambda t: t[0]):
+                print('{}  (Ln {}, Col {}) {}: {}'.format(s, node.pos.line, node.pos.column, klass, msg), file=file)
         first_descent.append(False)
         if dobj:
             outline(dobj, level+1, file=file)
@@ -68,7 +69,7 @@ def outline(obj, level, file=sys.stdout):
         if obj.workflow:
             descend(obj.workflow)
         # tasks
-        for task in sorted(obj.tasks, key=lambda task: (not task.called,task.name)):
+        for task in sorted(obj.tasks, key=lambda task: (not task.called, task.name)):
             descend(task)
         # imports
         for uri, namespace, subdoc in sorted(obj.imports, key=lambda t: t[1]):
@@ -76,7 +77,7 @@ def outline(obj, level, file=sys.stdout):
             descend(subdoc)
     # workflow
     elif isinstance(obj, WDL.Workflow):
-        if level<=1 or obj.called:
+        if level <= 1 or obj.called:
             print("{}workflow {}".format(s, obj.name), file=file)
             for elt in obj.elements:
                 descend(elt)

--- a/WDL/CLI.py
+++ b/WDL/CLI.py
@@ -16,11 +16,17 @@ def main(args=None):
     subparsers.dest = 'command'
 
     check_parser = subparsers.add_parser(
-        'check', help='Load and typecheck a WDL document; show an outline with lint warnings')
+        'check',
+        help='Load and typecheck a WDL document; show an outline with lint warnings')
     check_parser.add_argument('uri', metavar='URI',
                               type=str, help="WDL document filename/URI")
-    check_parser.add_argument('-p', '--path', metavar='DIR', type=str,
-                              action='append', help="local directory to search for imports")
+    check_parser.add_argument(
+        '-p',
+        '--path',
+        metavar='DIR',
+        type=str,
+        action='append',
+        help="local directory to search for imports")
 
     args = parser.parse_args(args if args is not None else sys.argv[1:])
 
@@ -58,7 +64,7 @@ def check(args):
 
 
 def outline(obj, level, file=sys.stdout):
-    s = ''.join(' ' for i in range(level*4))
+    s = ''.join(' ' for i in range(level * 4))
 
     first_descent = []
 
@@ -70,7 +76,7 @@ def outline(obj, level, file=sys.stdout):
                     s, node.pos.line, node.pos.column, klass, msg), file=file)
         first_descent.append(False)
         if dobj:
-            outline(dobj, level+1, file=file)
+            outline(dobj, level + 1, file=file)
 
     # document
     if isinstance(obj, WDL.Document):
@@ -78,7 +84,8 @@ def outline(obj, level, file=sys.stdout):
         if obj.workflow:
             descend(obj.workflow)
         # tasks
-        for task in sorted(obj.tasks, key=lambda task: (not task.called, task.name)):
+        for task in sorted(obj.tasks, key=lambda task: (
+                not task.called, task.name)):
             descend(task)
         # imports
         for uri, namespace, subdoc in sorted(obj.imports, key=lambda t: t[1]):
@@ -97,8 +104,12 @@ def outline(obj, level, file=sys.stdout):
             print("{}workflow {} (not called)".format(s, obj.name), file=file)
     # task
     elif isinstance(obj, WDL.Task):
-        print("{}task {}{}".format(s, obj.name,
-                                   " (not called)" if not obj.called else ""), file=file)
+        print(
+            "{}task {}{}".format(
+                s,
+                obj.name,
+                " (not called)" if not obj.called else ""),
+            file=file)
         for decl in obj.inputs + obj.postinputs + obj.outputs:
             descend(decl)
     # call

--- a/WDL/CLI.py
+++ b/WDL/CLI.py
@@ -7,6 +7,7 @@ from argparse import ArgumentParser
 import WDL
 import WDL.Lint
 
+
 def main(args=None):
     parser = ArgumentParser()
 
@@ -14,9 +15,12 @@ def main(args=None):
     subparsers.required = True
     subparsers.dest = 'command'
 
-    check_parser = subparsers.add_parser('check', help='Load and typecheck a WDL document; show an outline with lint warnings')
-    check_parser.add_argument('uri', metavar='URI', type=str, help="WDL document filename/URI")
-    check_parser.add_argument('-p', '--path', metavar='DIR', type=str, action='append', help="local directory to search for imports")
+    check_parser = subparsers.add_parser(
+        'check', help='Load and typecheck a WDL document; show an outline with lint warnings')
+    check_parser.add_argument('uri', metavar='URI',
+                              type=str, help="WDL document filename/URI")
+    check_parser.add_argument('-p', '--path', metavar='DIR', type=str,
+                              action='append', help="local directory to search for imports")
 
     args = parser.parse_args(args if args is not None else sys.argv[1:])
 
@@ -24,6 +28,7 @@ def main(args=None):
         check(args)
     else:
         assert False
+
 
 def check(args):
     # Load the document (read, parse, and typecheck)
@@ -47,18 +52,22 @@ def check(args):
 
     # Print an outline
     print(os.path.basename(args.uri))
-    outline(doc,0)
+    outline(doc, 0)
 
 # recursively pretty-print a brief outline of the workflow
+
+
 def outline(obj, level, file=sys.stdout):
     s = ''.join(' ' for i in range(level*4))
 
     first_descent = []
+
     def descend(dobj=None, first_descent=first_descent):
         # show lint for the node just prior to first descent beneath it
         if not first_descent and hasattr(obj, 'lint'):
             for (node, klass, msg) in sorted(obj.lint, key=lambda t: t[0]):
-                print('{}  (Ln {}, Col {}) {}: {}'.format(s, node.pos.line, node.pos.column, klass, msg), file=file)
+                print('{}  (Ln {}, Col {}) {}: {}'.format(
+                    s, node.pos.line, node.pos.column, klass, msg), file=file)
         first_descent.append(False)
         if dobj:
             outline(dobj, level+1, file=file)
@@ -73,7 +82,8 @@ def outline(obj, level, file=sys.stdout):
             descend(task)
         # imports
         for uri, namespace, subdoc in sorted(obj.imports, key=lambda t: t[1]):
-            print("    {}{} : {}".format(s, namespace, os.path.basename(uri)), file=file)
+            print("    {}{} : {}".format(s, namespace,
+                                         os.path.basename(uri)), file=file)
             descend(subdoc)
     # workflow
     elif isinstance(obj, WDL.Workflow):
@@ -87,12 +97,14 @@ def outline(obj, level, file=sys.stdout):
             print("{}workflow {} (not called)".format(s, obj.name), file=file)
     # task
     elif isinstance(obj, WDL.Task):
-        print("{}task {}{}".format(s, obj.name, " (not called)" if not obj.called else ""), file=file)
+        print("{}task {}{}".format(s, obj.name,
+                                   " (not called)" if not obj.called else ""), file=file)
         for decl in obj.inputs + obj.postinputs + obj.outputs:
             descend(decl)
     # call
     elif isinstance(obj, WDL.Call):
-        print("{}call {}".format(s, '.'.join(obj.callee_id.namespace + [obj.callee_id.name])), file=file)
+        print("{}call {}".format(s, '.'.join(
+            obj.callee_id.namespace + [obj.callee_id.name])), file=file)
     # scatter
     elif isinstance(obj, WDL.Scatter):
         print("{}scatter {}".format(s, obj.variable), file=file)

--- a/WDL/Env.py
+++ b/WDL/Env.py
@@ -66,7 +66,8 @@ def bind(name: str, rhs: R, tree: 'Tree[R]') -> 'Tree[R]':
     return [Binding(name, rhs)] + tree
 
 
-def namespace(namespace: str, bindings: 'Tree[R]', tree: 'Tree[R]') -> 'Tree[R]':
+def namespace(namespace: str,
+              bindings: 'Tree[R]', tree: 'Tree[R]') -> 'Tree[R]':
     """Prepend a namespace to an environment"""
     return [Namespace(namespace, bindings)] + tree
 

--- a/WDL/Env.py
+++ b/WDL/Env.py
@@ -24,30 +24,33 @@ to share code for both type and value environments.
 R = TypeVar('R')
 Tree = TypeVar('Tree', bound='List[Node[R]]')
 
+
 class Binding(Generic[R]):
     """A single binding"""
-    name : str
+    name: str
     ":type: str"
-    rhs : R
+    rhs: R
     """:type: Union[WDL.Type.Base,WDL.Value.Base]"""
 
-    def __init__(self, name : str, rhs : R) -> None:
+    def __init__(self, name: str, rhs: R) -> None:
         self.name = name
         self.rhs = rhs
 
+
 class Namespace(Generic[R]):
     """Encapsulates binding(s) under a namespace"""
-    namespace : str
+    namespace: str
     """:type: str"""
-    bindings : 'Tree[R]'
+    bindings: 'Tree[R]'
     """
     :type: List[Union[WDL.Env.Binding,WDL.Env.Namespace]]
 
     a list of bindings and/or sub-namespaces"""
 
-    def __init__(self, namespace : str, bindings : 'Tree[R]') -> None:
+    def __init__(self, namespace: str, bindings: 'Tree[R]') -> None:
         self.namespace = namespace
         self.bindings = bindings
+
 
 Node = TypeVar('Node', Binding[R], Namespace[R])
 
@@ -57,15 +60,18 @@ Types = TypeVar('Types', bound='Tree[Type.Base]')
 Values = TypeVar('Values', bound='Tree[Value.Base]')
 """Environment of values, an immutable list of bindings to values and/or namespaces"""
 
-def bind(name : str, rhs : R, tree : 'Tree[R]') -> 'Tree[R]':
+
+def bind(name: str, rhs: R, tree: 'Tree[R]') -> 'Tree[R]':
     """Prepend a new binding to an environment"""
     return [Binding(name, rhs)] + tree
 
-def namespace(namespace : str, bindings : 'Tree[R]', tree : 'Tree[R]') -> 'Tree[R]':
+
+def namespace(namespace: str, bindings: 'Tree[R]', tree: 'Tree[R]') -> 'Tree[R]':
     """Prepend a namespace to an environment"""
     return [Namespace(namespace, bindings)] + tree
 
-def resolve_namespace(tree : 'Tree[R]', namespace : List[str]) -> R:
+
+def resolve_namespace(tree: 'Tree[R]', namespace: List[str]) -> R:
     if len(namespace) == 0:
         return tree
     for node in tree:
@@ -74,7 +80,8 @@ def resolve_namespace(tree : 'Tree[R]', namespace : List[str]) -> R:
                 return resolve_namespace(node.bindings, namespace[1:])
     raise KeyError()
 
-def resolve(tree : 'Tree[R]', namespace : List[str], name : str) -> R:
+
+def resolve(tree: 'Tree[R]', namespace: List[str], name: str) -> R:
     """Resolve a name within an environment"""
     ns = resolve_namespace(tree, namespace)
     for node in ns:
@@ -82,5 +89,5 @@ def resolve(tree : 'Tree[R]', namespace : List[str], name : str) -> R:
             return node.rhs
     raise KeyError()
 
-#print(arrayize([Binding('x',T.Int())])[0].rhs)
+# print(arrayize([Binding('x',T.Int())])[0].rhs)
 #assert resolve([Binding('x',T.Int())], [], 'x') == T.Int()

--- a/WDL/Env.py
+++ b/WDL/Env.py
@@ -2,7 +2,7 @@
 """
 Environments, for identifier resolution during WDL typechecking and evaluation.
 """
-from typing import List, TypeVar, Generic, Union
+from typing import List, TypeVar, Generic
 import WDL.Type as T
 import WDL.Value as V
 
@@ -73,11 +73,11 @@ def namespace(namespace: str,
 
 
 def resolve_namespace(tree: 'Tree[R]', namespace: List[str]) -> R:
-    if len(namespace) == 0:
+    if not namespace:
         return tree
     for node in tree:
         if isinstance(node, Namespace):
-            if len(namespace) > 0 and namespace[0] == node.namespace:
+            if namespace and namespace[0] == node.namespace:
                 return resolve_namespace(node.bindings, namespace[1:])
     raise KeyError()
 

--- a/WDL/Error.py
+++ b/WDL/Error.py
@@ -1,8 +1,7 @@
 # pyre-strict
-from abc import ABC
-from typing import Any, List, Optional, Dict, Callable, NamedTuple, TypeVar, Union, Iterable
-import WDL.Type as T
+from typing import List, Optional, NamedTuple, Union, Iterable
 from functools import total_ordering
+import WDL.Type as T
 
 
 class ParserError(Exception):

--- a/WDL/Error.py
+++ b/WDL/Error.py
@@ -11,7 +11,8 @@ class ParserError(Exception):
 
 
 class ImportError(Exception):
-    def __init__(self, document: str, import_uri: str, message: Optional[str] = None) -> None:
+    def __init__(self, document: str, import_uri: str,
+                 message: Optional[str] = None) -> None:
         msg = "Failed to import {} to {}".format(import_uri, document)
         if message:
             msg = msg + ": " + message
@@ -36,8 +37,15 @@ class SourceNode:
 
     def __lt__(self, rhs) -> bool:
         if isinstance(rhs, SourceNode):
-            return ((self.pos.filename, self.pos.line, self.pos.column, self.pos.end_line, self.pos.end_column) <
-                    (rhs.pos.filename, rhs.pos.line, rhs.pos.column, rhs.pos.end_line, rhs.pos.end_column))
+            return ((self.pos.filename,
+                     self.pos.line,
+                     self.pos.column,
+                     self.pos.end_line,
+                     self.pos.end_column) < (rhs.pos.filename,
+                                             rhs.pos.line,
+                                             rhs.pos.column,
+                                             rhs.pos.end_line,
+                                             rhs.pos.end_column))
         return False
 
     def __eq__(self, rhs) -> bool:
@@ -47,7 +55,8 @@ class SourceNode:
 class Base(Exception):
     node: Optional[SourceNode]
 
-    def __init__(self, node: Union[SourceNode, SourcePosition], message: str) -> None:
+    def __init__(self, node: Union[SourceNode,
+                                   SourcePosition], message: str) -> None:
         if isinstance(node, SourceNode):
             self.node = node
             self.pos = node.pos
@@ -82,7 +91,8 @@ class NotAPair(Base):
 
 
 class StaticTypeMismatch(Base):
-    def __init__(self, node: SourceNode, expected: T.Base, actual: T.Base, message: Optional[str] = None) -> None:
+    def __init__(self, node: SourceNode, expected: T.Base,
+                 actual: T.Base, message: Optional[str] = None) -> None:
         msg = "Expected {} instead of {}".format(str(expected), str(actual))
         if message is not None:
             msg = msg + " " + message
@@ -120,8 +130,11 @@ class NoSuchInput(Base):
 
 
 class MissingInput(Base):
-    def __init__(self, node: SourceNode, name: str, inputs: Iterable[str]) -> None:
-        super().__init__(node, "Call {} missing required input(s) {}".format(name, ', '.join(inputs)))
+    def __init__(self, node: SourceNode, name: str,
+                 inputs: Iterable[str]) -> None:
+        super().__init__(
+            node, "Call {} missing required input(s) {}".format(
+                name, ', '.join(inputs)))
 
 
 class NullValue(Base):
@@ -130,5 +143,6 @@ class NullValue(Base):
 
 
 class MultipleDefinitions(Base):
-    def __init__(self, node: Union[SourceNode, SourcePosition], message: str) -> None:
+    def __init__(self, node: Union[SourceNode,
+                                   SourcePosition], message: str) -> None:
         super().__init__(node, message)

--- a/WDL/Error.py
+++ b/WDL/Error.py
@@ -2,33 +2,36 @@
 from abc import ABC
 from typing import Any, List, Optional, Dict, Callable, NamedTuple, TypeVar, Union, Iterable
 import WDL.Type as T
-from WDL.Expr import TVApply, TVIdent
 from functools import total_ordering
 
+
 class ParserError(Exception):
-    def __init__(self, filename : str) -> None:
+    def __init__(self, filename: str) -> None:
         super().__init__(filename)
 
+
 class ImportError(Exception):
-    def __init__(self, document : str, import_uri : str, message : Optional[str] = None) -> None:
+    def __init__(self, document: str, import_uri: str, message: Optional[str] = None) -> None:
         msg = "Failed to import {} to {}".format(import_uri, document)
         if message:
             msg = msg + ": " + message
         super().__init__(msg)
 
+
 SourcePosition = NamedTuple("SourcePosition",
-                            [('filename',str), ('line',int), ('column',int),
-                             ('end_line',int), ('end_column',int)])
+                            [('filename', str), ('line', int), ('column', int),
+                             ('end_line', int), ('end_column', int)])
 """Source file, line, and column, attached to each AST node"""
+
 
 @total_ordering
 class SourceNode:
     """Base class for an AST node, recording the source position"""
 
-    pos : SourcePosition
+    pos: SourcePosition
     """Source position for this AST node"""
 
-    def __init__(self, pos : SourcePosition) -> None:
+    def __init__(self, pos: SourcePosition) -> None:
         self.pos = pos
 
     def __lt__(self, rhs) -> bool:
@@ -40,70 +43,92 @@ class SourceNode:
     def __eq__(self, rhs) -> bool:
         return self.pos == rhs.pos
 
+
 class Base(Exception):
-    node : Optional[SourceNode]
-    def __init__(self, node : Union[SourceNode,SourcePosition], message : str) -> None:
-        if isinstance(node,SourceNode):
+    node: Optional[SourceNode]
+
+    def __init__(self, node: Union[SourceNode, SourcePosition], message: str) -> None:
+        if isinstance(node, SourceNode):
             self.node = node
             self.pos = node.pos
         else:
             self.pos = node
-        message = "({} Ln {}, Col {}) {}".format(self.pos.filename, self.pos.line, self.pos.column, message)
+        message = "({} Ln {}, Col {}) {}".format(
+            self.pos.filename, self.pos.line, self.pos.column, message)
         super().__init__(message)
 
+
 class NoSuchFunction(Base):
-    def __init__(self, node : SourceNode, name : str) -> None:
+    def __init__(self, node: SourceNode, name: str) -> None:
         super().__init__(node, "No such function: " + name)
 
+
 class WrongArity(Base):
-    def __init__(self, node : TVApply, expected : int) -> None:
-        super().__init__(node, "{} expects {} argument(s)".format(node.function_name, expected))
+    def __init__(self, node: SourceNode, expected: int) -> None:
+        # avoiding circular dep:
+        # assert isinstance(node, WDL.Expr.Apply)
+        super().__init__(node, "{} expects {} argument(s)".format(
+            getattr(node, 'function_name'), expected))
+
 
 class NotAnArray(Base):
-    def __init__(self, node : SourceNode) -> None:
+    def __init__(self, node: SourceNode) -> None:
         super().__init__(node, "Not an array")
 
+
 class NotAPair(Base):
-    def __init__(self, node : SourceNode) -> None:
+    def __init__(self, node: SourceNode) -> None:
         super().__init__(node, "Not a pair (taking left or right)")
 
+
 class StaticTypeMismatch(Base):
-    def __init__(self, node : SourceNode, expected : T.Base, actual : T.Base, message : Optional[str] = None) -> None:
+    def __init__(self, node: SourceNode, expected: T.Base, actual: T.Base, message: Optional[str] = None) -> None:
         msg = "Expected {} instead of {}".format(str(expected), str(actual))
         if message is not None:
             msg = msg + " " + message
         super().__init__(node, msg)
 
+
 class IncompatibleOperand(Base):
-    def __init__(self, node : SourceNode, message : str) -> None:
+    def __init__(self, node: SourceNode, message: str) -> None:
         super().__init__(node, message)
+
 
 class OutOfBounds(Base):
     def __init__(self, node: SourceNode) -> None:
         super().__init__(node, "Array index out of bounds")
 
+
 class EmptyArray(Base):
     def __init__(self, node: SourceNode) -> None:
         super().__init__(node, "Empty array for Array+ input/declaration")
 
+
 class UnknownIdentifier(Base):
-    def __init__(self, node : TVIdent) -> None:
-        id = node.namespace
-        id.append(node.name)
-        super().__init__(node, "Unknown identifier " + '.'.join(id))
+    def __init__(self, node: SourceNode) -> None:
+        # avoiding circular dep:
+        # assert isinstance(node, WDL.Expr.Ident)
+        namespace: List[str] = getattr(node, 'namespace')
+        name: str = getattr(node, 'name')
+        super().__init__(node, "Unknown identifier " +
+                         '.'.join(namespace + [name]))
+
 
 class NoSuchInput(Base):
-    def __init__(self, node : SourceNode, name : str) -> None:
+    def __init__(self, node: SourceNode, name: str) -> None:
         super().__init__(node, "No such input " + name)
 
+
 class MissingInput(Base):
-    def __init__(self, node : SourceNode, name : str, inputs : Iterable[str]) -> None:
+    def __init__(self, node: SourceNode, name: str, inputs: Iterable[str]) -> None:
         super().__init__(node, "Call {} missing required input(s) {}".format(name, ', '.join(inputs)))
 
+
 class NullValue(Base):
-    def __init__(self, node : SourceNode) -> None:
+    def __init__(self, node: SourceNode) -> None:
         super().__init__(node, "Null value")
 
+
 class MultipleDefinitions(Base):
-    def __init__(self, node : Union[SourceNode,SourcePosition], message : str) -> None:
+    def __init__(self, node: Union[SourceNode, SourcePosition], message: str) -> None:
         super().__init__(node, message)

--- a/WDL/Expr.py
+++ b/WDL/Expr.py
@@ -9,7 +9,7 @@ nodes attached "beneath" it. An expression can be evaluated to a Value given
 a suitable Env.
 """
 from abc import ABC, abstractmethod
-from typing import Any, List, Optional, Dict, Callable, TypeVar, Tuple, Union
+from typing import List, Optional, Dict, TypeVar, Tuple, Union
 import WDL.Type as T
 import WDL.Value as V
 import WDL.Env as Env
@@ -31,7 +31,8 @@ class Base(SourceNode, ABC):
         """
         :type: WDL.Type.Base
 
-        WDL type of this expression. Undefined on construction; populated by one invocation of ``infer_type``.
+        WDL type of this expression. Undefined on construction; populated by one
+        invocation of ``infer_type``.
         """
         # Failure of this assertion indicates use of an Expr object without
         # first calling _infer_type
@@ -223,7 +224,11 @@ class String(Base):
     """
     :type: List[Union[str,WDL.Expr.Placeholder]]
 
-    The parts list begins and ends with matching single- or double- quote marks. Between these is a sequence of literal strings and/or interleaved placeholder expressions. Escape sequences in the literals have NOT been decoded."""
+    The parts list begins and ends with matching single- or double- quote
+    marks. Between these is a sequence of literal strings and/or
+    interleaved placeholder expressions. Escape sequences in the literals
+    have NOT been decoded.
+    """
 
     def __init__(self, pos: SourcePosition,
                  parts: List[Union[str, Placeholder]]) -> None:
@@ -271,7 +276,7 @@ class Array(Base):
         self.items = items
 
     def _infer_type(self, type_env: Env.Types) -> T.Base:
-        if len(self.items) == 0:
+        if not self.items:
             return T.Array(None)
         for item in self.items:
             item.infer_type(type_env)
@@ -307,7 +312,7 @@ class Array(Base):
 
     def typecheck(self, expected: Optional[T.Base]) -> Base:
         ""
-        if len(self.items) == 0 and isinstance(expected, T.Array):
+        if not self.items and isinstance(expected, T.Array):
             # the literal empty array satisfies any array type
             # (unless it has the nonempty quantifier)
             if expected.nonempty:
@@ -471,12 +476,12 @@ class Ident(Base):
 
     def __init__(self, pos: SourcePosition, parts: List[str]) -> None:
         super().__init__(pos)
-        assert len(parts) > 0
+        assert parts
         self.name = parts[-1]
         self.namespace = parts[:-1]
 
     def _infer_type(self, type_env: Env.Types) -> T.Base:
-        if len(self.namespace) > 0 and (self.name in ['left', 'right']):
+        if self.namespace and (self.name in ['left', 'right']):
             # Special case for pair access, IDENT.left or IDENT.right
             # Pair access through non-identifier expressions goes a different
             # path, through the get_left and get_right terminals.
@@ -498,7 +503,7 @@ class Ident(Base):
 
     def eval(self, env: Env.Values) -> V.Base:
         ""
-        if len(self.namespace) > 0 and (self.name in ['left', 'right']):
+        if self.namespace and (self.name in ['left', 'right']):
             pair_name = self.namespace[-1]
             pair_namespace = self.namespace[:-1]
             try:

--- a/WDL/Expr.py
+++ b/WDL/Expr.py
@@ -13,18 +13,17 @@ from typing import Any, List, Optional, Dict, Callable, TypeVar, Tuple, Union
 import WDL.Type as T
 import WDL.Value as V
 import WDL.Env as Env
-
-# Forward-declare certain types needed for Error definitions, then import them.
-TVApply = TypeVar('TVApply', bound='Apply')
-TVIdent = TypeVar('TVIdent', bound='Ident')
-import WDL.Error as Error
 from WDL.Error import SourcePosition, SourceNode
+import WDL.Error as Error
 
 TVBase = TypeVar('TVBase', bound='Base')
+
+
 class Base(SourceNode, ABC):
     """Superclass of all expression AST nodes"""
-    _type : Optional[T.Base] = None
-    def __init__(self, pos : SourcePosition) -> None:
+    _type: Optional[T.Base] = None
+
+    def __init__(self, pos: SourcePosition) -> None:
         super().__init__(pos)
 
     @property
@@ -40,10 +39,10 @@ class Base(SourceNode, ABC):
         return self._type
 
     @abstractmethod
-    def _infer_type(self, type_env : Env.Types) -> T.Base:
+    def _infer_type(self, type_env: Env.Types) -> T.Base:
         pass
 
-    def infer_type(self, type_env : Env.Types) -> TVBase:
+    def infer_type(self, type_env: Env.Types) -> TVBase:
         """infer_type(self, type_env : Env.Types) -> WDL.Expr.Base
 
         Infer the expression's type within the given type environment. Must be
@@ -59,7 +58,7 @@ class Base(SourceNode, ABC):
         assert isinstance(self.type, T.Base), str(self.pos)
         return self
 
-    def typecheck(self, expected : T.Base) -> TVBase:
+    def typecheck(self, expected: T.Base) -> TVBase:
         """typecheck(self, expected : T.Base) -> WDL.Expr.Base
 
         Check that this expression's type is, or can be coerced to,
@@ -73,97 +72,119 @@ class Base(SourceNode, ABC):
         return self
 
     @abstractmethod
-    def eval(self, env : Env.Values) -> V.Base:
+    def eval(self, env: Env.Values) -> V.Base:
         """Evaluate the expression in the given environment"""
         pass
 
 # Boolean literal
+
+
 class Boolean(Base):
-    value : bool
+    value: bool
     """
     :type: bool
 
     Literal value
     """
-    def __init__(self, pos : SourcePosition, literal : bool) -> None:
+
+    def __init__(self, pos: SourcePosition, literal: bool) -> None:
         super().__init__(pos)
         self.value = literal
-    def _infer_type(self, type_env : Env.Types) -> T.Base:
+
+    def _infer_type(self, type_env: Env.Types) -> T.Base:
         return T.Boolean()
-    def eval(self, env : Env.Values) -> V.Boolean:
+
+    def eval(self, env: Env.Values) -> V.Boolean:
         ""
         return V.Boolean(self.value)
 
 # Integer literal
+
+
 class Int(Base):
-    value : int
+    value: int
     """
     :type: int
 
     Literal value
     """
-    def __init__(self, pos : SourcePosition, literal : int) -> None:
+
+    def __init__(self, pos: SourcePosition, literal: int) -> None:
         super().__init__(pos)
         self.value = literal
-    def _infer_type(self, type_env : Env.Types) -> T.Base:
+
+    def _infer_type(self, type_env: Env.Types) -> T.Base:
         return T.Int()
-    def eval(self, env : Env.Values) -> V.Int:
+
+    def eval(self, env: Env.Values) -> V.Int:
         ""
         return V.Int(self.value)
 
 # Float literal
+
+
 class Float(Base):
-    value : float
+    value: float
     """
     :type: float
 
     Literal value
     """
-    def __init__(self, pos : SourcePosition, literal : float) -> None:
+
+    def __init__(self, pos: SourcePosition, literal: float) -> None:
         super().__init__(pos)
         self.value = literal
-    def _infer_type(self, type_env : Env.Types) -> T.Base:
+
+    def _infer_type(self, type_env: Env.Types) -> T.Base:
         return T.Float()
-    def eval(self, env : Env.Values) -> V.Float:
+
+    def eval(self, env: Env.Values) -> V.Float:
         ""
         return V.Float(self.value)
+
 
 class Placeholder(Base):
     """Expression interpolated within a string or command"""
 
-    options : Dict[str,str]
+    options: Dict[str, str]
     """
     :type: Dict[str,str]
 
     Placeholder options (sep, true, false, default)"""
 
-    expr : Base
+    expr: Base
     """
     :type: WDL.Expr.Base
 
     Expression for evaluation
     """
 
-    def __init__(self, pos : SourcePosition, options : Dict[str,str], expr : Base) -> None:
+    def __init__(self, pos: SourcePosition, options: Dict[str, str], expr: Base) -> None:
         super().__init__(pos)
         self.options = options
         self.expr = expr
-    def _infer_type(self, type_env : Env.Types) -> T.Base:
+
+    def _infer_type(self, type_env: Env.Types) -> T.Base:
         self.expr.infer_type(type_env)
         if isinstance(self.expr.type, T.Array):
             if 'sep' not in self.options:
-                raise Error.StaticTypeMismatch(self, T.Array(None), self.expr.type, "array command placeholder must have 'sep'")
-            #if sum(1 for t in [T.Int, T.Float, T.Boolean, T.String, T.File] if isinstance(self.expr.type.item_type, t)) == 0:
+                raise Error.StaticTypeMismatch(self, T.Array(
+                    None), self.expr.type, "array command placeholder must have 'sep'")
+            # if sum(1 for t in [T.Int, T.Float, T.Boolean, T.String, T.File] if isinstance(self.expr.type.item_type, t)) == 0:
             #    raise Error.StaticTypeMismatch(self, T.Array(None), self.expr.type, "cannot use array of complex types for command placeholder")
         elif 'sep' in self.options:
-                raise Error.StaticTypeMismatch(self, T.Array(None), self.expr.type, "command placeholder has 'sep' option for non-Array expression")
+            raise Error.StaticTypeMismatch(self, T.Array(
+                None), self.expr.type, "command placeholder has 'sep' option for non-Array expression")
         if ('true' in self.options or 'false' in self.options):
             if not isinstance(self.expr.type, T.Boolean):
-                raise Error.StaticTypeMismatch(self, T.Boolean(), self.expr.type, "command placeholder 'true' and 'false' options used with non-Boolean expression")
+                raise Error.StaticTypeMismatch(self, T.Boolean(
+                ), self.expr.type, "command placeholder 'true' and 'false' options used with non-Boolean expression")
             if not ('true' in self.options and 'false' in self.options):
-                raise Error.StaticTypeMismatch(self, T.Boolean(), self.expr.type, "command placeholder with only one of 'true' and 'false' options")
+                raise Error.StaticTypeMismatch(self, T.Boolean(
+                ), self.expr.type, "command placeholder with only one of 'true' and 'false' options")
         return T.String()
-    def eval(self, env : Env.Values) -> V.String:
+
+    def eval(self, env: Env.Values) -> V.String:
         ""
         v = self.expr.eval(env)
         if isinstance(v, V.Null):
@@ -180,26 +201,31 @@ class Placeholder(Base):
             return V.String(self.options['false'])
         return V.String(str(v))
 
+
 class String(Base):
     """Text, possibly interleaved with expression placeholders for interpolation"""
 
-    parts : List[Union[str,Placeholder]]
+    parts: List[Union[str, Placeholder]]
     """
     :type: List[Union[str,WDL.Expr.Placeholder]]
 
     The parts list begins and ends with matching single- or double- quote marks. Between these is a sequence of literal strings and/or interleaved placeholder expressions. Escape sequences in the literals have NOT been decoded."""
-    def __init__(self, pos : SourcePosition, parts : List[Union[str,Placeholder]]) -> None:
+
+    def __init__(self, pos: SourcePosition, parts: List[Union[str, Placeholder]]) -> None:
         super().__init__(pos)
         self.parts = parts
-    def _infer_type(self, type_env : Env.Types) -> T.Base:
+
+    def _infer_type(self, type_env: Env.Types) -> T.Base:
         for part in self.parts:
             if isinstance(part, Placeholder):
                 part.infer_type(type_env)
         return T.String()
-    def typecheck(self, expected : Optional[T.Base]) -> Base:
+
+    def typecheck(self, expected: Optional[T.Base]) -> Base:
         ""
-        return super().typecheck(expected) # pyre-ignore
-    def eval(self, env : Env.Values) -> V.String:
+        return super().typecheck(expected)  # pyre-ignore
+
+    def eval(self, env: Env.Values) -> V.String:
         ""
         ans = []
         for part in self.parts:
@@ -212,28 +238,30 @@ class String(Base):
             else:
                 assert False
         # concatenate the stringified parts and trim the surrounding quotes
-        return V.String(''.join(ans)[1:-1]) # pyre-ignore
+        return V.String(''.join(ans)[1:-1])  # pyre-ignore
 
 # Array
+
+
 class Array(Base):
-    items : List[Base]
+    items: List[Base]
     """
     :type: List[WDL.Expr.Base]
 
     Expression for each item in the array literal
     """
 
-    def __init__(self, pos : SourcePosition, items : List[Base]) -> None:
+    def __init__(self, pos: SourcePosition, items: List[Base]) -> None:
         super(Array, self).__init__(pos)
         self.items = items
 
-    def _infer_type(self, type_env : Env.Types) -> T.Base:
+    def _infer_type(self, type_env: Env.Types) -> T.Base:
         if len(self.items) == 0:
             return T.Array(None)
         for item in self.items:
             item.infer_type(type_env)
         # Start by assuming the type of the first item is the item type
-        item_type : T.Base = self.items[0].type
+        item_type: T.Base = self.items[0].type
         # Allow a mixture of Int and Float to construct Array[Float]
         if isinstance(item_type, T.Int):
             for item in self.items:
@@ -258,10 +286,11 @@ class Array(Base):
                 item.typecheck(item_type)
             except Error.StaticTypeMismatch:
                 self._type = T.Array(item_type, optional=False, nonempty=True)
-                raise Error.StaticTypeMismatch(self, item_type, item.type, "(inconsistent types within array)") from None
+                raise Error.StaticTypeMismatch(
+                    self, item_type, item.type, "(inconsistent types within array)") from None
         return T.Array(item_type, optional=False, nonempty=True)
 
-    def typecheck(self, expected : Optional[T.Base]) -> Base:
+    def typecheck(self, expected: Optional[T.Base]) -> Base:
         ""
         if len(self.items) == 0 and isinstance(expected, T.Array):
             # the literal empty array satisfies any array type
@@ -269,45 +298,48 @@ class Array(Base):
             if expected.nonempty:
                 raise Error.EmptyArray(self)
             return self
-        return super().typecheck(expected) # pyre-ignore
+        return super().typecheck(expected)  # pyre-ignore
 
-    def eval(self, env : Env.Values) -> V.Array:
+    def eval(self, env: Env.Values) -> V.Array:
         ""
         assert isinstance(self.type, T.Array)
         return V.Array(self.type, [item.eval(env).coerce(self.type.item_type) for item in self.items])
 
 # If
+
+
 class IfThenElse(Base):
-    condition : Base
+    condition: Base
     """
     :type: WDL.Expr.Base
 
     A Boolean expression for the condition
     """
 
-    consequent : Base
+    consequent: Base
     """
     :type: WDL.Expr.Base
 
     Expression evaluated when the condition is true
     """
 
-    alternative : Base
+    alternative: Base
     """
     :type: WDL.Expr.Base
 
     Expression evaluated when the condition is false
     """
 
-    def __init__(self, pos : SourcePosition, condition : Base, consequent : Base, alternative : Base) -> None:
+    def __init__(self, pos: SourcePosition, condition: Base, consequent: Base, alternative: Base) -> None:
         super().__init__(pos)
         self.condition = condition
         self.consequent = consequent
         self.alternative = alternative
 
-    def _infer_type(self, type_env : Env.Types) -> T.Base:
+    def _infer_type(self, type_env: Env.Types) -> T.Base:
         if self.condition.infer_type(type_env).type != T.Boolean():
-            raise Error.StaticTypeMismatch(self, T.Boolean(), self.condition.type, "in if condition")
+            raise Error.StaticTypeMismatch(
+                self, T.Boolean(), self.condition.type, "in if condition")
         self_type = self.consequent.infer_type(type_env).type
         assert isinstance(self_type, T.Base)
         self.alternative.infer_type(type_env)
@@ -317,16 +349,17 @@ class IfThenElse(Base):
         if self.alternative.type.optional:
             self_type = self_type.copy(optional=True)
         if isinstance(self_type, T.Array) and isinstance(self.consequent.type, T.Array) and isinstance(self.alternative.type, T.Array):
-            self_type = self_type.copy(nonempty=(self.consequent.type.nonempty and self.alternative.type.nonempty)) # pyre-fixme
+            self_type = self_type.copy(nonempty=(  # pyre-fixme
+                self.consequent.type.nonempty and self.alternative.type.nonempty))  # pyre-fixme
         try:
             self.consequent.typecheck(self_type)
             self.alternative.typecheck(self_type)
         except Error.StaticTypeMismatch:
-            raise Error.StaticTypeMismatch(self, self.consequent.type, self.alternative.type, # pyre-fixme
+            raise Error.StaticTypeMismatch(self, self.consequent.type, self.alternative.type,  # pyre-fixme
                                            " (if consequent & alternative must have the same type)") from None
         return self_type
-    
-    def eval(self, env : Env.Values) -> V.Base:
+
+    def eval(self, env: Env.Values) -> V.Base:
         ""
         try:
             if self.condition.eval(env).expect(T.Boolean()).value != False:
@@ -341,36 +374,44 @@ class IfThenElse(Base):
 
 # Abstract interface to an internal function implementation
 # (see StdLib.py for concrete implementations)
+
+
+TVApply = TypeVar('TVApply', bound='Apply')
+
+
 class _Function(ABC):
 
     # Typecheck the function invocation (incl. argument expressions); raise an
     # exception or return the type of the value that the function will return
     @abstractmethod
-    def infer_type(self, expr : TVApply) -> T.Base:
+    def infer_type(self, expr: TVApply) -> T.Base:
         pass
 
     @abstractmethod
-    def __call__(self, expr : TVApply, env : Env.Values) -> V.Base:
+    def __call__(self, expr: TVApply, env: Env.Values) -> V.Base:
         pass
+
+
 # Table of standard library functions, filled in below and in StdLib.py
-_stdlib : Dict[str,_Function] = {}
+_stdlib: Dict[str, _Function] = {}
+
 
 class Apply(Base):
     """Application of a built-in or standard library function"""
-    function_name : str
+    function_name: str
     """Name of the function applied
 
     :type: str"""
-    arguments : List[Base]
+    arguments: List[Base]
     """
     :type: List[WDL.Expr.Base]
 
     Expressions for each function argument
     """
 
-    function : _Function
+    function: _Function
 
-    def __init__(self, pos : SourcePosition, function : str, arguments : List[Base]) -> None:
+    def __init__(self, pos: SourcePosition, function: str, arguments: List[Base]) -> None:
         super().__init__(pos)
         try:
             self.function = _stdlib[function]
@@ -379,12 +420,12 @@ class Apply(Base):
             raise Error.NoSuchFunction(self, function) from None
         self.arguments = arguments
 
-    def _infer_type(self, type_env : Env.Types) -> T.Base:
+    def _infer_type(self, type_env: Env.Types) -> T.Base:
         for arg in self.arguments:
             arg.infer_type(type_env)
         return self.function.infer_type(self)
 
-    def eval(self, env : Env.Values) -> V.Base:
+    def eval(self, env: Env.Values) -> V.Base:
         ""
         return self.function(self, env)
 
@@ -393,22 +434,22 @@ class Apply(Base):
 
 class Ident(Base):
     """An identifier expected to resolve in the environment given during evaluation"""
-    namespace : List[str]
+    namespace: List[str]
     """
     :type: List[str]
 
     Namespace (empty for an unqualified name)
     """
-    name : str
+    name: str
     ":type: str"
 
-    def __init__(self, pos : SourcePosition, parts : List[str]) -> None:
+    def __init__(self, pos: SourcePosition, parts: List[str]) -> None:
         super().__init__(pos)
         assert len(parts) > 0
         self.name = parts[-1]
         self.namespace = parts[:-1]
 
-    def _infer_type(self, type_env : Env.Types) -> T.Base:
+    def _infer_type(self, type_env: Env.Types) -> T.Base:
         if len(self.namespace) > 0 and (self.name in ['left', 'right']):
             # Special case for pair access, IDENT.left or IDENT.right
             # Pair access through non-identifier expressions goes a different
@@ -418,84 +459,88 @@ class Ident(Base):
             pair_name = self.namespace[-1]
             pair_namespace = self.namespace[:-1]
             try:
-                ans : T.Base = Env.resolve(type_env, pair_namespace, pair_name)
+                ans: T.Base = Env.resolve(type_env, pair_namespace, pair_name)
             except KeyError:
                 pass
             if isinstance(ans, T.Pair):
                 return ans.left_type if self.name == 'left' else ans.right_type
         try:
-            ans : T.Base = Env.resolve(type_env, self.namespace, self.name)
+            ans: T.Base = Env.resolve(type_env, self.namespace, self.name)
             return ans
         except KeyError:
             raise Error.UnknownIdentifier(self) from None
 
-    def eval(self, env : Env.Values) -> V.Base:
+    def eval(self, env: Env.Values) -> V.Base:
         ""
         if len(self.namespace) > 0 and (self.name in ['left', 'right']):
             pair_name = self.namespace[-1]
             pair_namespace = self.namespace[:-1]
             try:
-                ans : V.Base = Env.resolve(env, pair_namespace, pair_name)
+                ans: V.Base = Env.resolve(env, pair_namespace, pair_name)
                 if isinstance(ans, V.Pair):
                     assert ans.value is not None
                     return ans.value[0] if self.name == 'left' else ans.value[1]
             except KeyError:
                 pass
         try:
-            ans : V.Base = Env.resolve(env, self.namespace, self.name)
+            ans: V.Base = Env.resolve(env, self.namespace, self.name)
             return ans
         except KeyError:
             raise Error.UnknownIdentifier(self) from None
 
 # Pair literal
+
+
 class Pair(Base):
-    left : Base
+    left: Base
     """
     :type: WDL.Expr.Base
 
     Left-hand expression in the pair literal
     """
-    right : Base
+    right: Base
     """
     :type: WDL.Expr.Base
 
     Right-hand expression in the pair literal
     """
 
-    def __init__(self, pos : SourcePosition, left : Base, right : Base) -> None:
+    def __init__(self, pos: SourcePosition, left: Base, right: Base) -> None:
         super().__init__(pos)
         self.left = left
         self.right = right
 
-    def _infer_type(self, type_env : Env.Types) -> T.Base:
+    def _infer_type(self, type_env: Env.Types) -> T.Base:
         self.left.infer_type(type_env)
         self.right.infer_type(type_env)
         return T.Pair(self.left.type, self.right.type)
 
-    def eval(self, env : Env.Values) -> V.Base:
+    def eval(self, env: Env.Values) -> V.Base:
         ""
         assert isinstance(self.type, T.Pair)
         lv = self.left.eval(env)
         rv = self.right.eval(env)
-        return V.Pair(self.type, (lv,rv))
+        return V.Pair(self.type, (lv, rv))
 
 # Map literal
+
+
 class Map(Base):
-    items : List[Tuple[Base,Base]]
+    items: List[Tuple[Base, Base]]
     """
     :type: List[Tuple[WDL.Expr.Base,WDL.Expr.Base]]
 
     Expressions for the map literal keys and values
     """
 
-    def __init__(self, pos : SourcePosition, items : List[Tuple[Base,Base]]) -> None:
+    def __init__(self, pos: SourcePosition, items: List[Tuple[Base, Base]]) -> None:
         super().__init__(pos)
         self.items = items
 
-    def _infer_type(self, type_env : Env.Types) -> T.Base:
+    def _infer_type(self, type_env: Env.Types) -> T.Base:
         kty = None
         vty = None
-        for k,v in self.items:
+        for k, v in self.items:
             k.infer_type(type_env)
             if kty is None:
                 kty = k.type
@@ -509,13 +554,13 @@ class Map(Base):
         if kty is None:
             return T.Map(None)
         assert vty is not None
-        return T.Map((kty,vty))
+        return T.Map((kty, vty))
 
-    def eval(self, env : Env.Values) -> V.Base:
+    def eval(self, env: Env.Values) -> V.Base:
         ""
         assert isinstance(self.type, T.Map)
         eitems = []
-        for k,v in self.items:
+        for k, v in self.items:
             eitems.append((k.eval(env), v.eval(env)))
         # TODO: complain of duplicate keys
         return V.Map(self.type, eitems)

--- a/WDL/Lint.py
+++ b/WDL/Lint.py
@@ -13,7 +13,8 @@ class Linter(WDL.Walker.Base):
     node it's attached to), short codename, and message.
     """
 
-    def add(self, obj: WDL.SourceNode, message: str, subnode: Optional[WDL.SourceNode] = None):
+    def add(self, obj: WDL.SourceNode, message: str,
+            subnode: Optional[WDL.SourceNode] = None):
         if not hasattr(obj, 'lint'):
             obj.lint = []
         obj.lint.append((subnode or obj, self.__class__.__name__, message))
@@ -41,20 +42,34 @@ class StringCoercion(Linter):
                         any_string = True
                     else:
                         all_string = False
-                if any_string and not all_string and not isinstance(getattr(obj, 'parent'), WDL.Task):
+                if any_string and not all_string and not isinstance(
+                        getattr(obj, 'parent'), WDL.Task):
                     # exception when parent is Task (i.e. we're in the task
                     # command) because the coercion is probably intentional
-                    self.add(getattr(obj, 'parent'),
-                             "string concatenation (+) has non-String argument", obj)
+                    self.add(
+                        getattr(
+                            obj,
+                            'parent'),
+                        "string concatenation (+) has non-String argument",
+                        obj)
             else:
                 F = WDL.Expr._stdlib[obj.function_name]
                 if isinstance(F, WDL.StdLib._StaticFunction):
-                    for i in range(min(len(F.argument_types), len(obj.arguments))):
-                        if isinstance(F.argument_types[i], WDL.Type.String) \
-                           and not isinstance(obj.arguments[i].type, WDL.Type.String) \
-                           and not isinstance(obj.arguments[i].type, WDL.Type.File):
-                            self.add(getattr(
-                                obj, 'parent'), "non-String value for String function argument", obj.arguments[i])
+                    for i in range(min(len(F.argument_types),
+                                       len(obj.arguments))):
+                        if isinstance(
+                            F.argument_types[i],
+                            WDL.Type.String) and not isinstance(
+                            obj.arguments[i].type,
+                            WDL.Type.String) and not isinstance(
+                            obj.arguments[i].type,
+                                WDL.Type.File):
+                            self.add(
+                                getattr(
+                                    obj,
+                                    'parent'),
+                                "non-String value for String function argument",
+                                obj.arguments[i])
         super().expr(obj)
 
 
@@ -64,7 +79,8 @@ class OptionalCoercion(Linter):
         if isinstance(obj, WDL.Expr.Apply):
             if obj.function_name == "_add":
                 for arg in obj.arguments:
-                    if arg.type.optional and not isinstance(getattr(obj, 'parent'), WDL.Task):
+                    if arg.type.optional and not isinstance(
+                            getattr(obj, 'parent'), WDL.Task):
                         # exception when parent is Task (i.e. we're in the
                         # task command) because the coercion is probably
                         # intentional, per "Prepending a String to an
@@ -74,10 +90,15 @@ class OptionalCoercion(Linter):
             else:
                 F = WDL.Expr._stdlib[obj.function_name]
                 if isinstance(F, WDL.StdLib._StaticFunction):
-                    for i in range(min(len(F.argument_types), len(obj.arguments))):
+                    for i in range(min(len(F.argument_types),
+                                       len(obj.arguments))):
                         if obj.arguments[i].type.optional and not F.argument_types[i].optional:
-                            self.add(getattr(
-                                obj, 'parent'), "optional value passed for mandatory function argument", obj.arguments[i])
+                            self.add(
+                                getattr(
+                                    obj,
+                                    'parent'),
+                                "optional value passed for mandatory function argument",
+                                obj.arguments[i])
         super().expr(obj)
 
 
@@ -90,8 +111,11 @@ class IncompleteCall(Linter):
             if name in required_inputs:
                 required_inputs.remove(name)
         if len(required_inputs) > 0:
-            self.add(obj, "required input(s) {} omitted in call to {}; these become workflow inputs and prevent composition".format(
-                ", ".join(required_inputs), obj.callee.name))
+            self.add(
+                obj,
+                "required input(s) {} omitted in call to {}; these become workflow inputs and prevent composition".format(
+                    ", ".join(required_inputs),
+                    obj.callee.name))
         super().call(obj)
 
 
@@ -105,7 +129,9 @@ class CallImportNameCollision(Linter):
         for uri, namespace, subdoc in doc.imports:
             if namespace == obj.name:
                 self.add(
-                    obj, "call name {} collides with imported document namespace".format(obj.name))
+                    obj,
+                    "call name {} collides with imported document namespace".format(
+                        obj.name))
         super().call(obj)
 
 

--- a/WDL/Lint.py
+++ b/WDL/Lint.py
@@ -4,6 +4,7 @@ Linting: annotate WDL AST with hygiene warning
 import WDL
 from typing import Any, Optional, Set
 
+
 class Linter(WDL.Walker.Base):
     """
     Linters are Walkers which annotate each tree node with
@@ -12,23 +13,25 @@ class Linter(WDL.Walker.Base):
     node it's attached to), short codename, and message.
     """
 
-    def add(self, obj : WDL.SourceNode, message : str, subnode : Optional[WDL.SourceNode] = None):
+    def add(self, obj: WDL.SourceNode, message: str, subnode: Optional[WDL.SourceNode] = None):
         if not hasattr(obj, 'lint'):
             obj.lint = []
         obj.lint.append((subnode or obj, self.__class__.__name__, message))
 
+
 class StringCoercion(Linter):
     # String declaration with non-String rhs expression
-    def decl(self, obj : WDL.Decl) -> Any:
+    def decl(self, obj: WDL.Decl) -> Any:
         if isinstance(obj.type, WDL.Type.String) \
-            and obj.expr is not None \
-            and not isinstance(obj.expr.type, WDL.Type.String) \
-            and not isinstance(obj.expr.type, WDL.Type.File):
-            self.add(obj, "String {} = <{}>".format(obj.name, str(obj.expr.type)))
+                and obj.expr is not None \
+                and not isinstance(obj.expr.type, WDL.Type.String) \
+                and not isinstance(obj.expr.type, WDL.Type.File):
+            self.add(obj, "String {} = <{}>".format(
+                obj.name, str(obj.expr.type)))
         super().decl(obj)
 
     # String function operands with non-String expression
-    def expr(self, obj : WDL.Expr.Base) -> Any:
+    def expr(self, obj: WDL.Expr.Base) -> Any:
         if isinstance(obj, WDL.Expr.Apply):
             if obj.function_name == "_add":
                 any_string = False
@@ -38,67 +41,77 @@ class StringCoercion(Linter):
                         any_string = True
                     else:
                         all_string = False
-                if any_string and not all_string and not isinstance(getattr(obj,'parent'), WDL.Task):
+                if any_string and not all_string and not isinstance(getattr(obj, 'parent'), WDL.Task):
                     # exception when parent is Task (i.e. we're in the task
                     # command) because the coercion is probably intentional
-                    self.add(getattr(obj,'parent'), "string concatenation (+) has non-String argument", obj)
+                    self.add(getattr(obj, 'parent'),
+                             "string concatenation (+) has non-String argument", obj)
             else:
                 F = WDL.Expr._stdlib[obj.function_name]
                 if isinstance(F, WDL.StdLib._StaticFunction):
-                    for i in range(min(len(F.argument_types),len(obj.arguments))):
+                    for i in range(min(len(F.argument_types), len(obj.arguments))):
                         if isinstance(F.argument_types[i], WDL.Type.String) \
                            and not isinstance(obj.arguments[i].type, WDL.Type.String) \
                            and not isinstance(obj.arguments[i].type, WDL.Type.File):
-                            self.add(getattr(obj,'parent'), "non-String value for String function argument", obj.arguments[i])
+                            self.add(getattr(
+                                obj, 'parent'), "non-String value for String function argument", obj.arguments[i])
         super().expr(obj)
+
 
 class OptionalCoercion(Linter):
     # Expressions that could blow up at runtime with empty optional values
-    def expr(self, obj : WDL.Expr.Base) -> Any:
+    def expr(self, obj: WDL.Expr.Base) -> Any:
         if isinstance(obj, WDL.Expr.Apply):
             if obj.function_name == "_add":
                 for arg in obj.arguments:
-                    if arg.type.optional and not isinstance(getattr(obj,'parent'), WDL.Task):
+                    if arg.type.optional and not isinstance(getattr(obj, 'parent'), WDL.Task):
                         # exception when parent is Task (i.e. we're in the
                         # task command) because the coercion is probably
                         # intentional, per "Prepending a String to an
                         # Optional Parameter"
-                        self.add(getattr(obj,'parent'), "optional value passed to +", arg)
+                        self.add(getattr(obj, 'parent'),
+                                 "optional value passed to +", arg)
             else:
                 F = WDL.Expr._stdlib[obj.function_name]
                 if isinstance(F, WDL.StdLib._StaticFunction):
-                    for i in range(min(len(F.argument_types),len(obj.arguments))):
+                    for i in range(min(len(F.argument_types), len(obj.arguments))):
                         if obj.arguments[i].type.optional and not F.argument_types[i].optional:
-                            self.add(getattr(obj,'parent'), "optional value passed for mandatory function argument", obj.arguments[i])
+                            self.add(getattr(
+                                obj, 'parent'), "optional value passed for mandatory function argument", obj.arguments[i])
         super().expr(obj)
+
 
 class IncompleteCall(Linter):
     # Call without all required inputs (allowed for top-level workflow)
-    def call(self, obj : WDL.Call) -> Any:
+    def call(self, obj: WDL.Call) -> Any:
         assert obj.callee is not None
         required_inputs = set(decl.name for decl in obj.callee.required_inputs)
         for name, expr in obj.inputs.items():
             if name in required_inputs:
                 required_inputs.remove(name)
         if len(required_inputs) > 0:
-            self.add(obj, "required input(s) {} omitted in call to {}; these become workflow inputs and prevent composition".format(", ".join(required_inputs), obj.callee.name))
+            self.add(obj, "required input(s) {} omitted in call to {}; these become workflow inputs and prevent composition".format(
+                ", ".join(required_inputs), obj.callee.name))
         super().call(obj)
+
 
 class CallImportNameCollision(Linter):
     # A call name collides with the namespace of an imported document; allowed
     # but potentially confusing.
-    def call(self, obj : WDL.Call) -> Any:
+    def call(self, obj: WDL.Call) -> Any:
         doc = obj
         while not isinstance(doc, WDL.Document):
             doc = getattr(doc, 'parent')
         for uri, namespace, subdoc in doc.imports:
             if namespace == obj.name:
-                self.add(obj, "call name {} collides with imported document namespace".format(obj.name))
+                self.add(
+                    obj, "call name {} collides with imported document namespace".format(obj.name))
         super().call(obj)
+
 
 class UnusedImport(Linter):
     # Nothing used from an imported document
-    def document(self, obj : WDL.Document) -> Any:
+    def document(self, obj: WDL.Document) -> Any:
         for uri, namespace, subdoc in obj.imports:
             assert subdoc is not None
             any_called = False

--- a/WDL/StdLib.py
+++ b/WDL/StdLib.py
@@ -1,4 +1,5 @@
 # pyre-strict
+# pylint: disable=protected-access,exec-used
 from typing import List, Tuple, Callable, Any
 import WDL.Type as T
 import WDL.Value as V
@@ -41,7 +42,7 @@ class _Get(E._Function):
         assert len(expr.arguments) == 2
         lhs = expr.arguments[0]
         rhs = expr.arguments[1]
-        if isinstance(lhs.type, T.Array):  # pyre-fixme
+        if isinstance(lhs.type, T.Array):
             arr = lhs.eval(env)
             assert isinstance(arr, V.Array)
             assert isinstance(arr.type, T.Array)
@@ -50,7 +51,7 @@ class _Get(E._Function):
             if idx < 0 or idx >= len(arr.value):
                 raise Error.OutOfBounds(rhs)
             return arr.value[idx]  # pyre-fixme
-        elif isinstance(lhs.type, T.Map):
+        if isinstance(lhs.type, T.Map):
             mp = lhs.eval(env)
             assert isinstance(mp, V.Map)
             assert isinstance(mp.type, T.Map)
@@ -64,8 +65,7 @@ class _Get(E._Function):
             if ans is None:
                 raise Error.OutOfBounds(rhs)  # TODO: KeyNotFound
             return ans  # pyre-fixme
-        else:
-            assert False
+        assert False  # pyre-fixme
 
 
 E._stdlib["_get"] = _Get()
@@ -442,10 +442,9 @@ class _Flatten(E._Function):
         assert isinstance(expr.arguments[0].type, T.Array)
         if expr.arguments[0].type.item_type is None:
             return T.Array(None)
-        elif not isinstance(expr.arguments[0].type.item_type, T.Array):
+        if not isinstance(expr.arguments[0].type.item_type, T.Array):
             raise Error.StaticTypeMismatch(expr.arguments[0], T.Array(
                 T.Array(None)), expr.arguments[0].type)
-        # pyre-fixme
         return T.Array(expr.arguments[0].type.item_type.item_type)
 
     def __call__(self, expr: E.Apply, env: Env.Values) -> V.Base:
@@ -465,7 +464,7 @@ class _Transpose(E._Function):
         assert isinstance(expr.arguments[0].type, T.Array)
         if expr.arguments[0].type.item_type is None:
             return T.Array(None)
-        elif not isinstance(expr.arguments[0].type.item_type, T.Array):
+        if not isinstance(expr.arguments[0].type.item_type, T.Array):
             raise Error.StaticTypeMismatch(expr.arguments[0], T.Array(
                 T.Array(None)), expr.arguments[0].type)
         return expr.arguments[0].type

--- a/WDL/StdLib.py
+++ b/WDL/StdLib.py
@@ -8,8 +8,10 @@ import WDL.Error as Error
 
 # Special function for array access arr[index], returning the element type
 #                      or map access map[key], returning the value type
+
+
 class _Get(E._Function):
-    def infer_type(self, expr : E.Apply) -> T.Base:
+    def infer_type(self, expr: E.Apply) -> T.Base:
         assert len(expr.arguments) == 2
         lhs = expr.arguments[0]
         rhs = expr.arguments[1]
@@ -20,7 +22,8 @@ class _Get(E._Function):
             try:
                 rhs.typecheck(T.Int())
             except Error.StaticTypeMismatch:
-                raise Error.StaticTypeMismatch(rhs, T.Int(), rhs.type, "Array index") from None
+                raise Error.StaticTypeMismatch(
+                    rhs, T.Int(), rhs.type, "Array index") from None
             return lhs.type.item_type
         elif isinstance(lhs.type, T.Map):
             if lhs.type.item_type is None:
@@ -28,16 +31,17 @@ class _Get(E._Function):
             try:
                 rhs.typecheck(lhs.type.item_type[0])
             except Error.StaticTypeMismatch:
-                raise Error.StaticTypeMismatch(rhs, lhs.type.item_type[0], rhs.type, "Map key") from None
+                raise Error.StaticTypeMismatch(
+                    rhs, lhs.type.item_type[0], rhs.type, "Map key") from None
             return lhs.type.item_type[1]
         else:
             raise Error.NotAnArray(lhs)
 
-    def __call__(self, expr : E.Apply, env : E.Env) -> V.Base:
+    def __call__(self, expr: E.Apply, env: E.Env) -> V.Base:
         assert len(expr.arguments) == 2
         lhs = expr.arguments[0]
         rhs = expr.arguments[1]
-        if isinstance(lhs.type, T.Array): # pyre-fixme
+        if isinstance(lhs.type, T.Array):  # pyre-fixme
             arr = lhs.eval(env)
             assert isinstance(arr, V.Array)
             assert isinstance(arr.type, T.Array)
@@ -45,7 +49,7 @@ class _Get(E._Function):
             idx = rhs.eval(env).expect(T.Int()).value
             if idx < 0 or idx >= len(arr.value):
                 raise Error.OutOfBounds(rhs)
-            return arr.value[idx] # pyre-fixme
+            return arr.value[idx]  # pyre-fixme
         elif isinstance(lhs.type, T.Map):
             mp = lhs.eval(env)
             assert isinstance(mp, V.Map)
@@ -54,51 +58,62 @@ class _Get(E._Function):
             assert isinstance(mp.value, list)
             ans = None
             key = rhs.eval(env).expect(mp.type.item_type[0])
-            for k,v in mp.value:
+            for k, v in mp.value:
                 if key == k:
                     ans = v.expect(mp.type.item_type[1])
             if ans is None:
-                raise Error.OutOfBounds(rhs) # TODO: KeyNotFound
-            return ans # pyre-fixme
+                raise Error.OutOfBounds(rhs)  # TODO: KeyNotFound
+            return ans  # pyre-fixme
         else:
             assert False
+
+
 E._stdlib["_get"] = _Get()
 
 # Pair get (EXPR.left/EXPR.right)
 # The special case where EXPR is an identifier goes a different path, through
 # Expr.Ident.
+
+
 class _PairGet(E._Function):
-    left : bool
-    def __init__(self, left : bool) -> None:
+    left: bool
+
+    def __init__(self, left: bool) -> None:
         self.left = left
-    def infer_type(self, expr : E.Apply) -> T.Base:
+
+    def infer_type(self, expr: E.Apply) -> T.Base:
         assert len(expr.arguments) == 1
         if not isinstance(expr.arguments[0].type, T.Pair):
             raise Error.NotAPair(expr.arguments[0])
         return expr.arguments[0].type.left_type if self.left else expr.arguments[0].type.right_type
-    def __call__(self, expr : E.Apply, env : E.Env) -> V.Base:
+
+    def __call__(self, expr: E.Apply, env: E.Env) -> V.Base:
         assert len(expr.arguments) == 1
         pair = expr.arguments[0].eval(env)
         assert isinstance(pair.type, T.Pair)
         assert isinstance(pair.value, tuple)
         return pair.value[0] if self.left else pair.value[1]
+
+
 E._stdlib["_get_left"] = _PairGet(True)
 E._stdlib["_get_right"] = _PairGet(False)
 
 # _Function helper for simple functions with fixed argument and return types
-class _StaticFunction(E._Function):
-    name : str
-    argument_types : List[T.Base]
-    return_type : T.Base
-    F : Callable
 
-    def __init__(self, name : str, argument_types : List[T.Base], return_type : T.Base, F : Callable) -> None:
+
+class _StaticFunction(E._Function):
+    name: str
+    argument_types: List[T.Base]
+    return_type: T.Base
+    F: Callable
+
+    def __init__(self, name: str, argument_types: List[T.Base], return_type: T.Base, F: Callable) -> None:
         self.name = name
         self.argument_types = argument_types
         self.return_type = return_type
         self.F = F
 
-    def infer_type(self, expr : E.Apply) -> T.Base:
+    def infer_type(self, expr: E.Apply) -> T.Base:
         min_args = len(self.argument_types)
         for ty in reversed(self.argument_types):
             if ty.optional:
@@ -111,44 +126,69 @@ class _StaticFunction(E._Function):
             try:
                 expr.arguments[i].typecheck(self.argument_types[i])
             except Error.StaticTypeMismatch:
-                raise Error.StaticTypeMismatch(expr.arguments[i], self.argument_types[i], expr.arguments[i].type, "for {} argument #{}".format(self.name, i+1)) from None
+                raise Error.StaticTypeMismatch(
+                    expr.arguments[i], self.argument_types[i], expr.arguments[i].type, "for {} argument #{}".format(self.name, i+1)) from None
         return self.return_type
 
-    def __call__(self, expr : E.Apply, env : E.Env) -> V.Base:
+    def __call__(self, expr: E.Apply, env: E.Env) -> V.Base:
         assert len(expr.arguments) == len(self.argument_types)
-        argument_values = [arg.eval(env).coerce(ty) for arg, ty in zip(expr.arguments, self.argument_types)]
-        ans : V.Base = self.F(*argument_values)
+        argument_values = [arg.eval(env).coerce(ty) for arg, ty in zip(
+            expr.arguments, self.argument_types)]
+        ans: V.Base = self.F(*argument_values)
         return ans.coerce(self.return_type)
 
-_static_functions : List[Tuple[str, List[T.Base], T.Base, Any]] = [
-    ("_negate", [T.Boolean()], T.Boolean(), lambda x : V.Boolean(not x.value)), # pyre-fixme
-    ("_land", [T.Boolean(), T.Boolean()], T.Boolean(), lambda l,r: V.Boolean(l.value and r.value)), # pyre-fixme
-    ("_lor", [T.Boolean(), T.Boolean()], T.Boolean(), lambda l,r: V.Boolean(l.value or r.value)), # pyre-fixme
-    ("_rem", [T.Int(), T.Int()], T.Int(), lambda l,r: V.Int(l.value % r.value)), # pyre-fixme
+
+_static_functions: List[Tuple[str, List[T.Base], T.Base, Any]] = [
+    ("_negate", [T.Boolean()], T.Boolean(),
+     lambda x: V.Boolean(not x.value)),  # pyre-fixme
+    ("_land", [T.Boolean(), T.Boolean()], T.Boolean(),
+     lambda l, r: V.Boolean(l.value and r.value)),  # pyre-fixme
+    ("_lor", [T.Boolean(), T.Boolean()], T.Boolean(),
+     lambda l, r: V.Boolean(l.value or r.value)),  # pyre-fixme
+    ("_rem", [T.Int(), T.Int()], T.Int(), lambda l,
+     r: V.Int(l.value % r.value)),  # pyre-fixme
     ("stdout", [], T.File(), lambda: exec('raise NotImplementedError()')),
-    ("basename", [T.String(), T.String(optional=True)], T.String(), lambda file: exec('raise NotImplementedError()')),
+    ("basename", [T.String(), T.String(optional=True)],
+     T.String(), lambda file: exec('raise NotImplementedError()')),
     # TODO: size() argument is optional to admit a pattern seen in the test corpi:
     #         if (defined(f)) then size(f) else 100
     #       unclear how this should apply generaly to functions other than size().
     #       alternatively, during typechecking, we could infer that the f can't
     #       be null in the consequent branch specifically.
-    ("size", [T.File(optional=True), T.String(optional=True)], T.Float(), lambda file: exec('raise NotImplementedError()')),
-    ("ceil", [T.Float()], T.Int(), lambda x: exec('raise NotImplementedError()')),
-    ("round", [T.Float()], T.Int(), lambda x: exec('raise NotImplementedError()')),
-    ("glob", [T.String()], T.Array(T.File()), lambda pattern: exec('raise NotImplementedError()')),
-    ("read_int", [T.String()], T.Int(), lambda pattern: exec('raise NotImplementedError()')),
-    ("read_boolean", [T.String()], T.Boolean(), lambda pattern: exec('raise NotImplementedError()')),
-    ("read_string", [T.String()], T.String(), lambda pattern: exec('raise NotImplementedError()')),
-    ("read_float", [T.String()], T.Float(), lambda pattern: exec('raise NotImplementedError()')),
-    ("read_array", [T.String()], T.Array(None), lambda pattern: exec('raise NotImplementedError()')),
-    ("read_map", [T.String()], T.Map(None), lambda pattern: exec('raise NotImplementedError()')),
-    ("read_lines", [T.String()], T.Array(None), lambda pattern: exec('raise NotImplementedError()')),
-    ("read_tsv", [T.String()], T.Array(T.Array(T.String())), lambda pattern: exec('raise NotImplementedError()')),
-    ("write_lines", [T.Array(T.String())], T.File(), lambda pattern: exec('raise NotImplementedError()')),
-    ("write_tsv", [T.Array(T.Array(T.String()))], T.File(), lambda pattern: exec('raise NotImplementedError()')),
-    ("write_map", [T.Map(None)], T.File(), lambda pattern: exec('raise NotImplementedError()')),
-    ("range", [T.Int()], T.Array(T.Int()), lambda high: exec('raise NotImplementedError()')),
-    ("sub", [T.String(), T.String(), T.String()], T.String(), lambda high: exec('raise NotImplementedError()')),
+    ("size", [T.File(optional=True), T.String(optional=True)],
+     T.Float(), lambda file: exec('raise NotImplementedError()')),
+    ("ceil", [T.Float()], T.Int(), lambda x: exec(
+        'raise NotImplementedError()')),
+    ("round", [T.Float()], T.Int(), lambda x: exec(
+        'raise NotImplementedError()')),
+    ("glob", [T.String()], T.Array(T.File()),
+     lambda pattern: exec('raise NotImplementedError()')),
+    ("read_int", [T.String()], T.Int(),
+     lambda pattern: exec('raise NotImplementedError()')),
+    ("read_boolean", [T.String()], T.Boolean(),
+     lambda pattern: exec('raise NotImplementedError()')),
+    ("read_string", [T.String()], T.String(),
+     lambda pattern: exec('raise NotImplementedError()')),
+    ("read_float", [T.String()], T.Float(),
+     lambda pattern: exec('raise NotImplementedError()')),
+    ("read_array", [T.String()], T.Array(None),
+     lambda pattern: exec('raise NotImplementedError()')),
+    ("read_map", [T.String()], T.Map(None),
+     lambda pattern: exec('raise NotImplementedError()')),
+    ("read_lines", [T.String()], T.Array(None),
+     lambda pattern: exec('raise NotImplementedError()')),
+    ("read_tsv", [T.String()], T.Array(T.Array(T.String())),
+     lambda pattern: exec('raise NotImplementedError()')),
+    ("write_lines", [T.Array(T.String())], T.File(),
+     lambda pattern: exec('raise NotImplementedError()')),
+    ("write_tsv", [T.Array(T.Array(T.String()))], T.File(),
+     lambda pattern: exec('raise NotImplementedError()')),
+    ("write_map", [T.Map(None)], T.File(),
+     lambda pattern: exec('raise NotImplementedError()')),
+    ("range", [T.Int()], T.Array(T.Int()),
+     lambda high: exec('raise NotImplementedError()')),
+    ("sub", [T.String(), T.String(), T.String()], T.String(),
+     lambda high: exec('raise NotImplementedError()')),
 ]
 for name, argument_types, return_type, F in _static_functions:
     E._stdlib[name] = _StaticFunction(name, argument_types, return_type, F)
@@ -157,15 +197,17 @@ for name, argument_types, return_type, F in _static_functions:
 
 # arithmetic infix operators
 # operands may be Int or Float; return Float iff either operand is Float
-class _ArithmeticOperator(E._Function):
-    name : str
-    op : Callable
 
-    def __init__(self, name : str, op : Callable) -> None:
+
+class _ArithmeticOperator(E._Function):
+    name: str
+    op: Callable
+
+    def __init__(self, name: str, op: Callable) -> None:
         self.name = name
         self.op = op
 
-    def infer_type(self, expr : E.Apply) -> T.Base:
+    def infer_type(self, expr: E.Apply) -> T.Base:
         assert len(expr.arguments) == 2
         rt = T.Int()
         if isinstance(expr.arguments[0].type, T.Float) or isinstance(expr.arguments[1].type, T.Float):
@@ -174,11 +216,11 @@ class _ArithmeticOperator(E._Function):
             expr.arguments[0].typecheck(rt)
             expr.arguments[1].typecheck(rt)
         except Error.StaticTypeMismatch:
-            raise Error.IncompatibleOperand(expr, "Non-numeric operand to " + self.name + " operator") from None
+            raise Error.IncompatibleOperand(
+                expr, "Non-numeric operand to " + self.name + " operator") from None
         return rt
 
-
-    def __call__(self, expr : E.Apply, env : E.Env) -> V.Base:
+    def __call__(self, expr: E.Apply, env: E.Env) -> V.Base:
         ans_type = self.infer_type(expr)
         ans = self.op(expr.arguments[0].eval(env).coerce(ans_type).value,
                       expr.arguments[1].eval(env).coerce(ans_type).value)
@@ -188,16 +230,19 @@ class _ArithmeticOperator(E._Function):
         assert isinstance(ans, float)
         return V.Float(ans)
 
-E._stdlib["_sub"] = _ArithmeticOperator("-", lambda l,r: l-r)  # pyre-ignore
-E._stdlib["_mul"] = _ArithmeticOperator("*", lambda l,r: l*r)  # pyre-ignore
-E._stdlib["_div"] = _ArithmeticOperator("/", lambda l,r: l//r) # pyre-ignore
+
+E._stdlib["_sub"] = _ArithmeticOperator("-", lambda l, r: l-r)  # pyre-ignore
+E._stdlib["_mul"] = _ArithmeticOperator("*", lambda l, r: l*r)  # pyre-ignore
+E._stdlib["_div"] = _ArithmeticOperator("/", lambda l, r: l//r)  # pyre-ignore
 
 # + operator can also serve as concatenation for String.
+
+
 class _AddOperator(_ArithmeticOperator):
     def __init__(self) -> None:
-        super().__init__("+", lambda l,r: l+r) # pyre-ignore
+        super().__init__("+", lambda l, r: l+r)  # pyre-ignore
 
-    def infer_type(self, expr : E.Apply) -> T.Base:
+    def infer_type(self, expr: E.Apply) -> T.Base:
         assert len(expr.arguments) == 2
         t2 = None
         if isinstance(expr.arguments[0].type, T.String):
@@ -208,10 +253,11 @@ class _AddOperator(_ArithmeticOperator):
             # neither operand is a string; defer to _ArithmeticOperator
             return super().infer_type(expr)
         if not t2.coerces(T.String(optional=True)):
-            raise Error.IncompatibleOperand(expr, "Cannot add/concatenate {} and {}".format(str(expr.arguments[0].type), str(expr.arguments[1].type)))
+            raise Error.IncompatibleOperand(expr, "Cannot add/concatenate {} and {}".format(
+                str(expr.arguments[0].type), str(expr.arguments[1].type)))
         return T.String()
 
-    def __call__(self, expr: E.Apply, env : E.Env) -> V.Base:
+    def __call__(self, expr: E.Apply, env: E.Env) -> V.Base:
         ans_type = self.infer_type(expr)
         if not isinstance(ans_type, T.String):
             return super().__call__(expr, env)
@@ -220,122 +266,156 @@ class _AddOperator(_ArithmeticOperator):
         assert isinstance(ans, str)
         return V.String(ans)
 
+
 E._stdlib["_add"] = _AddOperator()
 
 # Comparison operators can compare any two operands of the same type.
 # Furthermore,
 # - given one Int and one Float, coerces the Int to Float for comparison.
-class _ComparisonOperator(E._Function):
-    name : str
-    op : Callable
 
-    def __init__(self, name : str, op : Callable) -> None:
+
+class _ComparisonOperator(E._Function):
+    name: str
+    op: Callable
+
+    def __init__(self, name: str, op: Callable) -> None:
         self.name = name
         self.op = op
 
-    def infer_type(self, expr : E.Apply) -> T.Base:
+    def infer_type(self, expr: E.Apply) -> T.Base:
         assert len(expr.arguments) == 2
         if not (expr.arguments[0].type == expr.arguments[1].type or
                 (expr.arguments[0].type == T.Int() and expr.arguments[1].type == T.Float()) or
                 (expr.arguments[0].type == T.Float() and expr.arguments[1].type == T.Int())):
-           raise Error.IncompatibleOperand(expr, "Cannot compare {} and {}".format(str(expr.arguments[0].type), str(expr.arguments[1].type)))
+            raise Error.IncompatibleOperand(expr, "Cannot compare {} and {}".format(
+                str(expr.arguments[0].type), str(expr.arguments[1].type)))
         return T.Boolean()
 
-    def __call__(self, expr : E.Apply, env : E.Env) -> V.Base:
+    def __call__(self, expr: E.Apply, env: E.Env) -> V.Base:
         assert len(expr.arguments) == 2
-        return V.Boolean(self.op(expr.arguments[0].eval(env).value, expr.arguments[1].eval(env).value)) # pyre-ignore
+        # pyre-ignore
+        return V.Boolean(self.op(expr.arguments[0].eval(env).value, expr.arguments[1].eval(env).value))
 
-E._stdlib["_eqeq"] = _ComparisonOperator("==", lambda l,r: l == r)
-E._stdlib["_neq"] = _ComparisonOperator("!=", lambda l,r: l != r)
-E._stdlib["_lt"] = _ComparisonOperator("<", lambda l,r: l < r) # pyre-fixme
-E._stdlib["_lte"] = _ComparisonOperator("<=", lambda l,r: l <= r) # pyre-fixme
-E._stdlib["_gt"] = _ComparisonOperator(">", lambda l,r: l > r) # pyre-fixme
-E._stdlib["_gte"] = _ComparisonOperator(">=", lambda l,r: l >= r) # pyre-fixme
+
+E._stdlib["_eqeq"] = _ComparisonOperator("==", lambda l, r: l == r)
+E._stdlib["_neq"] = _ComparisonOperator("!=", lambda l, r: l != r)
+E._stdlib["_lt"] = _ComparisonOperator("<", lambda l, r: l < r)  # pyre-fixme
+E._stdlib["_lte"] = _ComparisonOperator(
+    "<=", lambda l, r: l <= r)  # pyre-fixme
+E._stdlib["_gt"] = _ComparisonOperator(">", lambda l, r: l > r)  # pyre-fixme
+E._stdlib["_gte"] = _ComparisonOperator(
+    ">=", lambda l, r: l >= r)  # pyre-fixme
 
 # defined(): accepts any type...
+
+
 class _Defined(E._Function):
-    def infer_type(self, expr : E.Apply) -> T.Base:
+    def infer_type(self, expr: E.Apply) -> T.Base:
         if len(expr.arguments) != 1:
             raise Error.WrongArity(expr, 1)
         return T.Boolean()
 
-    def __call__(self, expr : E.Apply, env : Env.Values) -> V.Base:
+    def __call__(self, expr: E.Apply, env: Env.Values) -> V.Base:
         if isinstance(expr.arguments[0].eval(env), V.Null):
             return V.Boolean(False)
         return V.Boolean(True)
+
+
 E._stdlib["defined"] = _Defined()
 
+
 class _Length(E._Function):
-    def infer_type(self, expr : E.Apply) -> T.Base:
+    def infer_type(self, expr: E.Apply) -> T.Base:
         if len(expr.arguments) != 1:
             raise Error.WrongArity(expr, 1)
         if not isinstance(expr.arguments[0].type, T.Array):
-            raise Error.StaticTypeMismatch(expr, T.Array(None), expr.arguments[0].type)
+            raise Error.StaticTypeMismatch(
+                expr, T.Array(None), expr.arguments[0].type)
         return T.Int()
 
-    def __call__(self, expr : E.Apply, env : Env.Values) -> V.Base:
+    def __call__(self, expr: E.Apply, env: Env.Values) -> V.Base:
         v = expr.arguments[0].eval(env)
         if isinstance(v, V.Null):
             return V.Int(0)
         assert isinstance(v.value, list)
         return V.Int(len(v.value))
+
+
 E._stdlib["length"] = _Length()
 
+
 class _SelectFirst(E._Function):
-    def infer_type(self, expr : E.Apply) -> T.Base:
+    def infer_type(self, expr: E.Apply) -> T.Base:
         if len(expr.arguments) != 1:
             raise Error.WrongArity(expr, 1)
         if not isinstance(expr.arguments[0].type, T.Array):
-            raise Error.StaticTypeMismatch(expr.arguments[0], T.Array(None), expr.arguments[0].type)
+            raise Error.StaticTypeMismatch(
+                expr.arguments[0], T.Array(None), expr.arguments[0].type)
         if expr.arguments[0].type.item_type is None:
-            raise Error.EmptyArray(expr.arguments[0]) # TODO: error for 'indeterminate type'
+            # TODO: error for 'indeterminate type'
+            raise Error.EmptyArray(expr.arguments[0])
         ty = expr.arguments[0].type.item_type
         assert isinstance(ty, T.Base)
         return ty.copy(optional=False)
 
-    def __call__(self, expr : E.Apply, env : Env.Values) -> V.Base:
+    def __call__(self, expr: E.Apply, env: Env.Values) -> V.Base:
         raise NotImplementedError()
+
+
 E._stdlib["select_first"] = _SelectFirst()
 
+
 class _SelectAll(E._Function):
-    def infer_type(self, expr : E.Apply) -> T.Base:
+    def infer_type(self, expr: E.Apply) -> T.Base:
         if len(expr.arguments) != 1:
             raise Error.WrongArity(expr, 1)
         if not isinstance(expr.arguments[0].type, T.Array):
-            raise Error.StaticTypeMismatch(expr.arguments[0], T.Array(None), expr.arguments[0].type)
+            raise Error.StaticTypeMismatch(
+                expr.arguments[0], T.Array(None), expr.arguments[0].type)
         if expr.arguments[0].type.item_type is None:
-            raise Error.EmptyArray(expr.arguments[0]) # TODO: error for 'indeterminate type'
+            # TODO: error for 'indeterminate type'
+            raise Error.EmptyArray(expr.arguments[0])
         ty = expr.arguments[0].type.item_type
         assert isinstance(ty, T.Base)
         return T.Array(ty.copy(optional=False))
 
-    def __call__(self, expr : E.Apply, env : Env.Values) -> V.Base:
+    def __call__(self, expr: E.Apply, env: Env.Values) -> V.Base:
         raise NotImplementedError()
+
+
 E._stdlib["select_all"] = _SelectAll()
+
 
 class _Zip(E._Function):
     # 'a array -> 'b array -> ('a,'b) array
-    def infer_type(self, expr : E.Apply) -> T.Base:
+    def infer_type(self, expr: E.Apply) -> T.Base:
         if len(expr.arguments) != 2:
             raise Error.WrongArity(expr, 2)
         if not isinstance(expr.arguments[0].type, T.Array):
-            raise Error.StaticTypeMismatch(expr.arguments[0], T.Array(None), expr.arguments[0].type)
+            raise Error.StaticTypeMismatch(
+                expr.arguments[0], T.Array(None), expr.arguments[0].type)
         if expr.arguments[0].type.item_type is None:
-            raise Error.EmptyArray(expr.arguments[0]) # TODO: error for 'indeterminate type'
+            # TODO: error for 'indeterminate type'
+            raise Error.EmptyArray(expr.arguments[0])
         if not isinstance(expr.arguments[1].type, T.Array):
-            raise Error.StaticTypeMismatch(expr.arguments[1], T.Array(None), expr.arguments[0].type)
+            raise Error.StaticTypeMismatch(
+                expr.arguments[1], T.Array(None), expr.arguments[0].type)
         if expr.arguments[1].type.item_type is None:
-            raise Error.EmptyArray(expr.arguments[1]) # TODO: error for 'indeterminate type'
+            # TODO: error for 'indeterminate type'
+            raise Error.EmptyArray(expr.arguments[1])
         return T.Array(T.Pair(expr.arguments[0].type.item_type, expr.arguments[1].type.item_type))
 
-    def __call__(self, expr : E.Apply, env : Env.Values) -> V.Base:
+    def __call__(self, expr: E.Apply, env: Env.Values) -> V.Base:
         raise NotImplementedError()
+
+
 E._stdlib["zip"] = _Zip()
-E._stdlib["cross"] = _Zip() # TODO
+E._stdlib["cross"] = _Zip()  # TODO
+
 
 class _Flatten(E._Function):
     # t array array -> t array
-    def infer_type(self, expr : E.Apply) -> T.Base:
+    def infer_type(self, expr: E.Apply) -> T.Base:
         if len(expr.arguments) != 1:
             raise Error.WrongArity(expr, 1)
         expr.arguments[0].typecheck(T.Array(None))
@@ -344,15 +424,21 @@ class _Flatten(E._Function):
         if expr.arguments[0].type.item_type is None:
             return T.Array(None)
         elif not isinstance(expr.arguments[0].type.item_type, T.Array):
-            raise Error.StaticTypeMismatch(expr.arguments[0], T.Array(T.Array(None)), expr.arguments[0].type)
-        return T.Array(expr.arguments[0].type.item_type.item_type) #pyre-fixme
-    def __call__(self, expr : E.Apply, env : Env.Values) -> V.Base:
+            raise Error.StaticTypeMismatch(expr.arguments[0], T.Array(
+                T.Array(None)), expr.arguments[0].type)
+        # pyre-fixme
+        return T.Array(expr.arguments[0].type.item_type.item_type)
+
+    def __call__(self, expr: E.Apply, env: Env.Values) -> V.Base:
         raise NotImplementedError()
+
+
 E._stdlib["flatten"] = _Flatten()
+
 
 class _Transpose(E._Function):
     # t array array -> t array array
-    def infer_type(self, expr : E.Apply) -> T.Base:
+    def infer_type(self, expr: E.Apply) -> T.Base:
         if len(expr.arguments) != 1:
             raise Error.WrongArity(expr, 1)
         expr.arguments[0].typecheck(T.Array(None))
@@ -361,8 +447,12 @@ class _Transpose(E._Function):
         if expr.arguments[0].type.item_type is None:
             return T.Array(None)
         elif not isinstance(expr.arguments[0].type.item_type, T.Array):
-            raise Error.StaticTypeMismatch(expr.arguments[0], T.Array(T.Array(None)), expr.arguments[0].type)
+            raise Error.StaticTypeMismatch(expr.arguments[0], T.Array(
+                T.Array(None)), expr.arguments[0].type)
         return expr.arguments[0].type
-    def __call__(self, expr : E.Apply, env : Env.Values) -> V.Base:
+
+    def __call__(self, expr: E.Apply, env: Env.Values) -> V.Base:
         raise NotImplementedError()
+
+
 E._stdlib["transpose"] = _Transpose()

--- a/WDL/StdLib.py
+++ b/WDL/StdLib.py
@@ -107,7 +107,11 @@ class _StaticFunction(E._Function):
     return_type: T.Base
     F: Callable
 
-    def __init__(self, name: str, argument_types: List[T.Base], return_type: T.Base, F: Callable) -> None:
+    def __init__(self,
+                 name: str,
+                 argument_types: List[T.Base],
+                 return_type: T.Base,
+                 F: Callable) -> None:
         self.name = name
         self.argument_types = argument_types
         self.return_type = return_type
@@ -127,7 +131,12 @@ class _StaticFunction(E._Function):
                 expr.arguments[i].typecheck(self.argument_types[i])
             except Error.StaticTypeMismatch:
                 raise Error.StaticTypeMismatch(
-                    expr.arguments[i], self.argument_types[i], expr.arguments[i].type, "for {} argument #{}".format(self.name, i+1)) from None
+                    expr.arguments[i],
+                    self.argument_types[i],
+                    expr.arguments[i].type,
+                    "for {} argument #{}".format(
+                        self.name,
+                        i + 1)) from None
         return self.return_type
 
     def __call__(self, expr: E.Apply, env: E.Env) -> V.Base:
@@ -210,14 +219,18 @@ class _ArithmeticOperator(E._Function):
     def infer_type(self, expr: E.Apply) -> T.Base:
         assert len(expr.arguments) == 2
         rt = T.Int()
-        if isinstance(expr.arguments[0].type, T.Float) or isinstance(expr.arguments[1].type, T.Float):
+        if isinstance(expr.arguments[0].type, T.Float) or isinstance(
+                expr.arguments[1].type, T.Float):
             rt = T.Float()
         try:
             expr.arguments[0].typecheck(rt)
             expr.arguments[1].typecheck(rt)
         except Error.StaticTypeMismatch:
             raise Error.IncompatibleOperand(
-                expr, "Non-numeric operand to " + self.name + " operator") from None
+                expr,
+                "Non-numeric operand to " +
+                self.name +
+                " operator") from None
         return rt
 
     def __call__(self, expr: E.Apply, env: E.Env) -> V.Base:
@@ -231,16 +244,17 @@ class _ArithmeticOperator(E._Function):
         return V.Float(ans)
 
 
-E._stdlib["_sub"] = _ArithmeticOperator("-", lambda l, r: l-r)  # pyre-ignore
-E._stdlib["_mul"] = _ArithmeticOperator("*", lambda l, r: l*r)  # pyre-ignore
-E._stdlib["_div"] = _ArithmeticOperator("/", lambda l, r: l//r)  # pyre-ignore
+E._stdlib["_sub"] = _ArithmeticOperator("-", lambda l, r: l - r)  # pyre-ignore
+E._stdlib["_mul"] = _ArithmeticOperator("*", lambda l, r: l * r)  # pyre-ignore
+E._stdlib["_div"] = _ArithmeticOperator(
+    "/", lambda l, r: l // r)  # pyre-ignore
 
 # + operator can also serve as concatenation for String.
 
 
 class _AddOperator(_ArithmeticOperator):
     def __init__(self) -> None:
-        super().__init__("+", lambda l, r: l+r)  # pyre-ignore
+        super().__init__("+", lambda l, r: l + r)  # pyre-ignore
 
     def infer_type(self, expr: E.Apply) -> T.Base:
         assert len(expr.arguments) == 2
@@ -284,9 +298,10 @@ class _ComparisonOperator(E._Function):
 
     def infer_type(self, expr: E.Apply) -> T.Base:
         assert len(expr.arguments) == 2
-        if not (expr.arguments[0].type == expr.arguments[1].type or
-                (expr.arguments[0].type == T.Int() and expr.arguments[1].type == T.Float()) or
-                (expr.arguments[0].type == T.Float() and expr.arguments[1].type == T.Int())):
+        if not (
+            expr.arguments[0].type == expr.arguments[1].type or (
+                expr.arguments[0].type == T.Int() and expr.arguments[1].type == T.Float()) or (
+                expr.arguments[0].type == T.Float() and expr.arguments[1].type == T.Int())):
             raise Error.IncompatibleOperand(expr, "Cannot compare {} and {}".format(
                 str(expr.arguments[0].type), str(expr.arguments[1].type)))
         return T.Boolean()
@@ -294,7 +309,8 @@ class _ComparisonOperator(E._Function):
     def __call__(self, expr: E.Apply, env: E.Env) -> V.Base:
         assert len(expr.arguments) == 2
         # pyre-ignore
-        return V.Boolean(self.op(expr.arguments[0].eval(env).value, expr.arguments[1].eval(env).value))
+        return V.Boolean(self.op(expr.arguments[0].eval(
+            env).value, expr.arguments[1].eval(env).value))
 
 
 E._stdlib["_eqeq"] = _ComparisonOperator("==", lambda l, r: l == r)
@@ -403,7 +419,10 @@ class _Zip(E._Function):
         if expr.arguments[1].type.item_type is None:
             # TODO: error for 'indeterminate type'
             raise Error.EmptyArray(expr.arguments[1])
-        return T.Array(T.Pair(expr.arguments[0].type.item_type, expr.arguments[1].type.item_type))
+        return T.Array(
+            T.Pair(
+                expr.arguments[0].type.item_type,
+                expr.arguments[1].type.item_type))
 
     def __call__(self, expr: E.Apply, env: Env.Values) -> V.Base:
         raise NotImplementedError()

--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -13,23 +13,25 @@ import WDL.Expr as E
 import WDL.Env as Env
 import WDL.Error as Err
 from WDL.Error import SourcePosition, SourceNode
-import os, errno
+import os
+import errno
 import WDL._parser
+
 
 class Decl(SourceNode):
     """A variable declaration within a task or workflow"""
-    type : T.Base
+    type: T.Base
     ":type: WDL.Type.Base"
-    name : str
+    name: str
     """Declared variable name
 
     :type: str"""
-    expr : Optional[E.Base]
+    expr: Optional[E.Base]
     """Bound expression, if any
 
     :type: Optional[WDL.Expr.Base]"""
 
-    def __init__(self, pos : SourcePosition, type : T.Base, name: str, expr : Optional[E.Base] = None) -> None:
+    def __init__(self, pos: SourcePosition, type: T.Base, name: str, expr: Optional[E.Base] = None) -> None:
         super().__init__(pos)
         self.type = type
         self.name = name
@@ -44,11 +46,12 @@ class Decl(SourceNode):
     #  - the optional/nonempty type quantifiers should be checked
     #  - String to File coercion
 
+
 class Task(SourceNode):
     """WDL Task"""
-    name : str
+    name: str
     """:type: str"""
-    inputs : List[Decl]
+    inputs: List[Decl]
     """:type: List[WDL.Tree.Decl]
 
     Inputs declared within the ``input{}`` task section
@@ -63,22 +66,22 @@ class Task(SourceNode):
     """:type: List[WDL.Tree.Decl]
 
     Output declarations"""
-    parameter_meta : Dict[str,Any]
+    parameter_meta: Dict[str, Any]
     """:type: Dict[str,Any]
 
     ``parameter_meta{}`` section as a JSON-like dict"""
-    runtime : Dict[str,E.Base]
+    runtime: Dict[str, E.Base]
     """:type: Dict[str,WDL.Expr.Base]
 
     ``runtime{}`` section, with keys and corresponding expressions to be evaluated"""
-    meta : Dict[str,Any]
+    meta: Dict[str, Any]
     """:type: Dict[str,Any]
 
     ``meta{}`` section as a JSON-like dict"""
 
-    def __init__(self, pos : SourcePosition, name : str, inputs : List[Decl], postinputs : List[Decl],
-                 command : E.String, outputs : List[Decl], parameter_meta : Dict[str,Any],
-                 runtime : Dict[str,E.Base], meta : Dict[str,Any]) -> None:
+    def __init__(self, pos: SourcePosition, name: str, inputs: List[Decl], postinputs: List[Decl],
+                 command: E.String, outputs: List[Decl], parameter_meta: Dict[str, Any],
+                 runtime: Dict[str, E.Base], meta: Dict[str, Any]) -> None:
         super().__init__(pos)
         self.name = name
         self.inputs = inputs
@@ -91,7 +94,7 @@ class Task(SourceNode):
         # TODO: enforce validity constraints on parameter_meta and runtime
         # TODO: complain of name collisions in inputs/postinputs
 
-    def typecheck(self, type_env : Env.Types = []) -> None:
+    def typecheck(self, type_env: Env.Types = []) -> None:
         for decl in (self.inputs+self.postinputs):
             type_env = _typecheck_decl(decl, type_env)
         self.command.infer_type(type_env).typecheck(T.String())
@@ -105,10 +108,13 @@ class Task(SourceNode):
 
 # type-check a declaration within a type environment, and return the type
 # environment with the new binding
-def _typecheck_decl(decl : Decl, type_env : Env.Types) -> Env.Types:
+
+
+def _typecheck_decl(decl: Decl, type_env: Env.Types) -> Env.Types:
     try:
         Env.resolve(type_env, [], decl.name)
-        raise Err.MultipleDefinitions(decl, "Multiple declarations of " + decl.name)
+        raise Err.MultipleDefinitions(
+            decl, "Multiple declarations of " + decl.name)
     except KeyError:
         pass
     # Subtleties:
@@ -129,54 +135,56 @@ def _typecheck_decl(decl : Decl, type_env : Env.Types) -> Env.Types:
         if decl.expr.type.optional is False:
             nonnull = True
     ty = decl.type.copy(optional=False) if nonnull else decl.type
-    ans : Env.Types = Env.bind(decl.name,ty, type_env)
+    ans: Env.Types = Env.bind(decl.name, ty, type_env)
     return ans
 
+
 # forward-declaration of Document and Workflow types
-TVDocument = TypeVar('TVDocument',bound='Document')
-TVWorkflow = TypeVar('TVWorkflow',bound='Workflow')
+TVDocument = TypeVar('TVDocument', bound='Document')
+TVWorkflow = TypeVar('TVWorkflow', bound='Workflow')
+
 
 class Call(SourceNode):
     """A call (within a workflow) to a task or sub-workflow"""
-    callee_id : E.Ident
+    callee_id: E.Ident
     """
     :type: WDL.Expr.Ident
 
     Identifier of the desired task/workflow"""
-    name : str
+    name: str
     """:type: string
 
     defaults to task/workflow name"""
-    inputs: Dict[str,E.Base]
+    inputs: Dict[str, E.Base]
     """
     :type: Dict[str,WDL.Expr.Base]
 
     Call inputs provided"""
 
-    callee : Optional[Union[Task,TVWorkflow]]
+    callee: Optional[Union[Task, TVWorkflow]]
     """
     :type: Union[WDL.Tree.Task, WDL.Tree.Workflow]
 
     After the AST is typechecked, refers to the Task or Workflow object to call"""
 
-    def __init__(self, pos : SourcePosition, callee_id : E.Ident, alias : Optional[str], inputs : Dict[str,E.Base]) -> None:
+    def __init__(self, pos: SourcePosition, callee_id: E.Ident, alias: Optional[str], inputs: Dict[str, E.Base]) -> None:
         super().__init__(pos)
         self.callee_id = callee_id
         self.name = alias if alias is not None else self.callee_id.name
         self.inputs = inputs
         self.callee = None
 
-    def typecheck(self, type_env : Env.Types, doc : TVDocument) -> Env.Types:
+    def typecheck(self, type_env: Env.Types, doc: TVDocument) -> Env.Types:
         # resolve callee_id to a known task/workflow, either within the
         # current document or one of its imported sub-documents
         if len(self.callee_id.namespace) == 0:
             callee_doc = doc
         elif len(self.callee_id.namespace) == 1:
-            for (uri,ns,subdoc) in doc.imports:
+            for (uri, ns, subdoc) in doc.imports:
                 if ns == self.callee_id.namespace[0]:
                     callee_doc = subdoc
         if callee_doc:
-            assert isinstance(callee_doc,Document)
+            assert isinstance(callee_doc, Document)
             if callee_doc.workflow and callee_doc.workflow.name == self.callee_id.name:
                 self.callee = callee_doc.workflow
             else:
@@ -185,12 +193,14 @@ class Call(SourceNode):
                         self.callee = task
         if self.callee is None:
             raise Err.UnknownIdentifier(self.callee_id)
-        assert isinstance(self.callee, Task) or isinstance(self.callee, Workflow)
+        assert isinstance(self.callee, Task) or isinstance(
+            self.callee, Workflow)
 
         # Make a set of the input names which are required for this call to
         # typecheck. In the top-level workflow, nothing is actually required
         # as missing call inputs become workflow inputs required at runtime.
-        required_inputs = set(decl.name for decl in self.callee.required_inputs) if doc.imported else set()
+        required_inputs = set(
+            decl.name for decl in self.callee.required_inputs) if doc.imported else set()
 
         # typecheck call inputs against task/workflow input declarations
         for name, expr in self.inputs.items():
@@ -223,36 +233,45 @@ class Call(SourceNode):
         return outputs_env
 
 # Given a type environment, recursively promote each binding of type T to Array[T]
-def _arrayize_types(type_env : Env.Types) -> Env.Types:
+
+
+def _arrayize_types(type_env: Env.Types) -> Env.Types:
     ans = []
     for node in type_env:
         if isinstance(node, Env.Binding):
             ans.append(Env.Binding(node.name, T.Array(node.rhs)))
         elif isinstance(node, Env.Namespace):
-            ans.append(Env.Namespace(node.namespace, _arrayize_types(node.bindings)))
+            ans.append(Env.Namespace(node.namespace,
+                                     _arrayize_types(node.bindings)))
         else:
             assert False
     return ans
 
 # Given a type environment, recursively make each binding optional
-def _optionalize_types(type_env : Env.Types) -> Env.Types:
+
+
+def _optionalize_types(type_env: Env.Types) -> Env.Types:
     ans = []
     for node in type_env:
         if isinstance(node, Env.Binding):
             ty = node.rhs.copy(optional=True)
             ans.append(Env.Binding(node.name, ty))
         elif isinstance(node, Env.Namespace):
-            ans.append(Env.Namespace(node.namespace, _optionalize_types(node.bindings)))
+            ans.append(Env.Namespace(node.namespace,
+                                     _optionalize_types(node.bindings)))
         else:
             assert False
     return ans
+
 
 TVScatter = TypeVar("TVScatter", bound="Scatter")
 TVConditional = TypeVar("TVConditional", bound="Conditional")
 
 # typecheck the workflow elements and return a type environment with the
 # outputs of the calls within (only -- not including the input type env)
-def _typecheck_workflow_body(elements : List[Union[Decl,Call,TVScatter,TVConditional]], type_env : Env.Types, doc : TVDocument) -> Env.Types:
+
+
+def _typecheck_workflow_body(elements: List[Union[Decl, Call, TVScatter, TVConditional]], type_env: Env.Types, doc: TVDocument) -> Env.Types:
     outputs_env = []
 
     for element in elements:
@@ -265,11 +284,13 @@ def _typecheck_workflow_body(elements : List[Union[Decl,Call,TVScatter,TVConditi
             # add call outputs to type environment, under the call namespace
             try:
                 Env.resolve_namespace(type_env, [element.name])
-                raise Err.MultipleDefinitions(element, "Workflow has multiple calls named {}; give calls distinct names using `call {} as NAME ...`".format(element.name, element.callee.name))
+                raise Err.MultipleDefinitions(element, "Workflow has multiple calls named {}; give calls distinct names using `call {} as NAME ...`".format(
+                    element.name, element.callee.name))
             except KeyError:
                 pass
             type_env = Env.namespace(element.name, call_outputs_env, type_env)
-            outputs_env = Env.namespace(element.name, call_outputs_env, outputs_env)
+            outputs_env = Env.namespace(
+                element.name, call_outputs_env, outputs_env)
         elif isinstance(element, Scatter) or isinstance(element, Conditional):
             # add outputs of calls within the subscatter to the type environment.
             sub_outputs_env = element.typecheck(type_env, doc)
@@ -280,31 +301,32 @@ def _typecheck_workflow_body(elements : List[Union[Decl,Call,TVScatter,TVConditi
 
     return outputs_env
 
+
 class Scatter(SourceNode):
     """A scatter stanza within a workflow"""
-    variable : str
+    variable: str
     """
     :type: string
 
     Scatter variable name"""
-    expr : E.Base
+    expr: E.Base
     """
     :type: WDL.Expr.Base
 
     Expression for the array over which to scatter"""
-    elements : List[Union[Decl,Call,TVScatter,TVConditional]]
+    elements: List[Union[Decl, Call, TVScatter, TVConditional]]
     """
     :type: List[Union[WDL.Tree.Decl,WDL.Tree.Call,WDL.Tree.Scatter,WDL.Tree.Conditional]]
 
     Scatter body"""
 
-    def __init__(self, pos : SourcePosition, variable : str, expr : E.Base, elements : List[Union[Decl,Call,TVScatter,TVConditional]]) -> None:
+    def __init__(self, pos: SourcePosition, variable: str, expr: E.Base, elements: List[Union[Decl, Call, TVScatter, TVConditional]]) -> None:
         super().__init__(pos)
         self.variable = variable
         self.expr = expr
         self.elements = elements
 
-    def typecheck(self, type_env : Env.Types, doc : TVDocument) -> Env.Types:
+    def typecheck(self, type_env: Env.Types, doc: TVDocument) -> Env.Types:
         # typecheck the array to determine the element type
         self.expr.infer_type(type_env)
         if not isinstance(self.expr.type, T.Array):
@@ -319,56 +341,59 @@ class Scatter(SourceNode):
         # promote each output type T to Array[T]
         return _arrayize_types(outputs_env)
 
+
 class Conditional(SourceNode):
     """A conditional (if) stanza within a workflow"""
-    expr : E.Base
+    expr: E.Base
     """
     :tree: WDL.Expr.Base
 
     Boolean expression"""
-    elements : List[Union[Decl,Call,TVScatter,TVConditional]]
+    elements: List[Union[Decl, Call, TVScatter, TVConditional]]
     """
     :type: List[Union[WDL.Tree.Decl,WDL.Tree.Call,WDL.Tree.Scatter,WDL.Tree.Conditional]]
 
     Conditional body"""
 
-    def __init__(self, pos : SourcePosition, expr : E.Base, elements : List[Union[Decl,Call,TVScatter,TVConditional]]) -> None:
+    def __init__(self, pos: SourcePosition, expr: E.Base, elements: List[Union[Decl, Call, TVScatter, TVConditional]]) -> None:
         super().__init__(pos)
         self.expr = expr
         self.elements = elements
 
-    def typecheck(self, type_env : Env.Types, doc : TVDocument) -> Env.Types:
+    def typecheck(self, type_env: Env.Types, doc: TVDocument) -> Env.Types:
         # check expr : Boolean
         self.expr.infer_type(type_env)
         if not self.expr.type.coerces(T.Boolean()):
-            raise Err.StaticTypeMismatch(self.expr, T.Boolean(), self.expr.type)
+            raise Err.StaticTypeMismatch(
+                self.expr, T.Boolean(), self.expr.type)
 
         outputs_env = _typecheck_workflow_body(self.elements, type_env, doc)
 
         # promote each output type T to T?
         return _optionalize_types(outputs_env)
 
+
 class Workflow(SourceNode):
-    name : str
+    name: str
     ":type: str"
-    elements: List[Union[Decl,Call,Scatter,Conditional]]
+    elements: List[Union[Decl, Call, Scatter, Conditional]]
     ":type: List[Union[WDL.Tree.Decl,WDL.Tree.Call,WDL.Tree.Scatter,WDL.Tree.Conditional]]"
     outputs: Optional[List[Decl]]
     """:type: Optional[List[Decl]]
 
     Workflow outputs, if the ``output{}`` stanza is present"""
-    parameter_meta : Dict[str,Any]
+    parameter_meta: Dict[str, Any]
     """
     :type: Dict[str,Any]
 
     ``parameter_meta{}`` section as a JSON-like dict"""
-    meta : Dict[str,Any]
+    meta: Dict[str, Any]
     """
     :type: Dict[str,Any]
 
     ``meta{}`` section as a JSON-like dict"""
 
-    def __init__(self, pos : SourcePosition, name : str, elements : List[Union[Decl,Call,Scatter]], outputs : Optional[List[Decl]], parameter_meta : Dict[str,Any], meta : Dict[str,Any]) -> None:
+    def __init__(self, pos: SourcePosition, name: str, elements: List[Union[Decl, Call, Scatter]], outputs: Optional[List[Decl]], parameter_meta: Dict[str, Any], meta: Dict[str, Any]) -> None:
         super().__init__(pos)
         self.name = name
         self.elements = elements
@@ -376,7 +401,7 @@ class Workflow(SourceNode):
         self.parameter_meta = parameter_meta
         self.meta = meta
 
-    def typecheck(self, doc : TVDocument) -> None:
+    def typecheck(self, doc: TVDocument) -> None:
         type_env = _typecheck_workflow_body(self.elements, [], doc)
 
         # typecheck the output declarations
@@ -391,33 +416,33 @@ class Workflow(SourceNode):
 
 class Document(SourceNode):
     """Top-level document, with imports, tasks, and a workflow. Typically returned by :func:`~WDL.load` with imported sub-documents loaded, and everything typechecked. Alternatively, :func:`~WDL.parse_document` constructs the AST but doesn't process imports nor perform typechecking."""
-    imports : List[Tuple[str,str,Optional[TVDocument]]]
+    imports: List[Tuple[str, str, Optional[TVDocument]]]
     """
     :type: List[Tuple[str,str,Optional[WDL.Tree.Document]]]
 
     Imports in the document (filename/URI, namespace, and later the sub-document)"""
-    tasks : List[Task]
+    tasks: List[Task]
     """:type: List[WDL.Tree.Task]"""
-    workflow : Optional[Workflow]
+    workflow: Optional[Workflow]
     """:type: Optional[WDL.Tree.Workflow]"""
 
-    imported : bool
+    imported: bool
     """
     :type: bool
 
     True iff this document has been loaded as an import from another document"""
 
-    def __init__(self, pos : SourcePosition, imports : List[Tuple[str,str]],
-                 tasks : List[Task], workflow : Optional[Workflow], imported : bool) -> None:
+    def __init__(self, pos: SourcePosition, imports: List[Tuple[str, str]],
+                 tasks: List[Task], workflow: Optional[Workflow], imported: bool) -> None:
         super().__init__(pos)
         self.imports = []
-        for (uri,namespace) in imports:
+        for (uri, namespace) in imports:
             # TODO: complain of namespace collisions
 
             # The sub-document is initially None. The WDL.load() function
             # populates it, after construction of this object but before
             # typechecking the contents.
-            self.imports.append((uri,namespace,None))
+            self.imports.append((uri, namespace, None))
         self.tasks = tasks
         self.workflow = workflow
         self.imported = imported
@@ -427,24 +452,28 @@ class Document(SourceNode):
     def typecheck(self) -> None:
         """Typecheck each task in the document, then the workflow, if any. Documents returned by :func:`~WDL.load` have already been typechecked."""
         names = set()
-        for (uri,namespace,subdoc) in self.imports:
+        for (uri, namespace, subdoc) in self.imports:
             if namespace in names:
-                raise Err.MultipleDefinitions(self, "Multiple imports with namespace " + namespace)
+                raise Err.MultipleDefinitions(
+                    self, "Multiple imports with namespace " + namespace)
             names.add(namespace)
         names = set()
         # typecheck each task
         for task in self.tasks:
             if task.name in names:
-                raise Err.MultipleDefinitions(task, "Multiple tasks named " + task.name)
+                raise Err.MultipleDefinitions(
+                    task, "Multiple tasks named " + task.name)
             names.add(task.name)
             task.typecheck()
         # typecheck the workflow
         if self.workflow:
             if self.workflow.name in names:
-                raise Err.MultipleDefinitions(task, "Workflow name collides with a task also named " + self.workflow.name)
+                raise Err.MultipleDefinitions(
+                    task, "Workflow name collides with a task also named " + self.workflow.name)
             self.workflow.typecheck(self)
 
-def load(uri : str, path : List[str] = [], imported : Optional[bool] = False) -> Document:
+
+def load(uri: str, path: List[str] = [], imported: Optional[bool] = False) -> Document:
     for fn in ([uri] + [os.path.join(dn, uri) for dn in reversed(path)]):
         if os.path.exists(fn):
             with open(fn, 'r') as infile:
@@ -456,10 +485,12 @@ def load(uri : str, path : List[str] = [], imported : Optional[bool] = False) ->
                 # TODO: limit recursion; prevent mutual recursion
                 for i in range(len(doc.imports)):
                     try:
-                        subdoc = load(doc.imports[i][0], [os.path.dirname(fn)]+path, True)
+                        subdoc = load(doc.imports[i][0], [
+                                      os.path.dirname(fn)]+path, True)
                     except Exception as exn:
                         raise Err.ImportError(uri, doc.imports[i][0]) from exn
-                    doc.imports[i] = (doc.imports[i][0], doc.imports[i][1], subdoc)
+                    doc.imports[i] = (doc.imports[i][0],
+                                      doc.imports[i][1], subdoc)
                 doc.typecheck()
                 return doc
     raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), uri)

--- a/WDL/Type.py
+++ b/WDL/Type.py
@@ -2,7 +2,7 @@
 """
 WDL data types
 
-WDL has both atomic types such as ``Int``, ``Boolean``, and ``String``; and 
+WDL has both atomic types such as ``Int``, ``Boolean``, and ``String``; and
 parametric types like ``Array[String]`` and
 ``Map[String,Array[Array[Float]]]``. Here, each type is represented by an
 immutable instance of a Python class inheriting from ``WDL.Type.Base``. Such
@@ -55,9 +55,11 @@ class Base(ABC):
         """
         True if this is the same type as, or can be coerced to, ``rhs``.
         """
-        if isinstance(rhs, Array) and rhs.item_type == self:  # coerce T to Array[T]
+        if isinstance(
+                rhs, Array) and rhs.item_type == self:  # coerce T to Array[T]
             return True
-        return (type(self).__name__ == type(rhs).__name__) and (not self.optional or rhs.optional)
+        return (type(self).__name__ == type(rhs).__name__) and (
+            not self.optional or rhs.optional)
 
     @property
     def optional(self) -> bool:
@@ -154,7 +156,11 @@ class Array(Base):
     """
     _nonempty: bool
 
-    def __init__(self, item_type: Optional[Base], optional: bool = False, nonempty: bool = False) -> None:
+    def __init__(
+            self,
+            item_type: Optional[Base],
+            optional: bool = False,
+            nonempty: bool = False) -> None:
         self.item_type = item_type
         assert isinstance(nonempty, bool)
         self._optional = optional
@@ -181,12 +187,14 @@ class Array(Base):
             if self.item_type is None or rhs.item_type is None:
                 return True
             else:
-                return self.item_type.coerces(rhs.item_type) and (not rhs.nonempty or self.nonempty)
+                return self.item_type.coerces(rhs.item_type) and (
+                    not rhs.nonempty or self.nonempty)
         if isinstance(rhs, String):
             return self.item_type is None or self.item_type.coerces(String())
         return False
 
-    def copy(self, optional: Optional[bool] = None, nonempty: Optional[bool] = None) -> Base:
+    def copy(self, optional: Optional[bool] = None,
+             nonempty: Optional[bool] = None) -> Base:
         ans: Array = super().copy(optional)
         if nonempty is not None:
             ans._nonempty = nonempty
@@ -208,13 +216,15 @@ class Map(Base):
     to any map type (but may fail at runtime).
     """
 
-    def __init__(self, item_type: Optional[Tuple[Base, Base]], optional: bool = False) -> None:
+    def __init__(
+            self, item_type: Optional[Tuple[Base, Base]], optional: bool = False) -> None:
         self._optional = optional
         self.item_type = item_type
 
     def __str__(self) -> str:
         # pyre-fixme
-        return "Map[" + (str(self.item_type[0]) + "," + str(self.item_type[1]) if self.item_type is not None else "") + "]" + ('?' if self.optional else '')
+        return "Map[" + (str(self.item_type[0]) + "," + str(self.item_type[1])
+                         if self.item_type is not None else "") + "]" + ('?' if self.optional else '')
 
     def coerces(self, rhs: Base) -> bool:
         ""
@@ -223,7 +233,9 @@ class Map(Base):
                 return True
             else:
                 # pyre-fixme
-                return self.item_type[0].coerces(rhs.item_type[0]) and self.item_type[1].coerces(rhs.item_type[1])
+                return self.item_type[0].coerces(
+                    rhs.item_type[0]) and self.item_type[1].coerces(
+                    rhs.item_type[1])
         return super().coerces(rhs)
 
 
@@ -240,10 +252,12 @@ class Pair(Base):
     :type: WDL.Type.Base
     """
 
-    def __init__(self, left_type: Base, right_type: Base, optional: bool = False) -> None:
+    def __init__(self, left_type: Base, right_type: Base,
+                 optional: bool = False) -> None:
         self._optional = optional
         self.left_type = left_type
         self.right_type = right_type
 
     def __str__(self) -> str:
-        return "Pair[" + (str(self.left_type) + "," + str(self.right_type)) + "]" + ('?' if self.optional else '')
+        return "Pair[" + (str(self.left_type) + "," + \
+                          str(self.right_type)) + "]" + ('?' if self.optional else '')

--- a/WDL/Type.py
+++ b/WDL/Type.py
@@ -36,6 +36,8 @@ from typing import Optional, TypeVar, Tuple
 import copy
 
 TVBase = TypeVar("TVBase", bound="Base")
+
+
 class Base(ABC):
     """The abstract base class for WDL types
 
@@ -47,13 +49,13 @@ class Base(ABC):
     All instances are immutable.
     """
 
-    _optional : bool # immutable!!!
+    _optional: bool  # immutable!!!
 
-    def coerces(self, rhs : TVBase) -> bool:
+    def coerces(self, rhs: TVBase) -> bool:
         """
         True if this is the same type as, or can be coerced to, ``rhs``.
         """
-        if isinstance(rhs, Array) and rhs.item_type == self: # coerce T to Array[T]
+        if isinstance(rhs, Array) and rhs.item_type == self:  # coerce T to Array[T]
             return True
         return (type(self).__name__ == type(rhs).__name__) and (not self.optional or rhs.optional)
 
@@ -65,71 +67,83 @@ class Base(ABC):
         True when the type has the optional quantifier, ``T?``"""
         return self._optional
 
-    def copy(self, optional : Optional[bool] = None) -> TVBase:
+    def copy(self, optional: Optional[bool] = None) -> TVBase:
         """
         copy(self, optional : Optional[bool] = None) -> WDL.Type.Base
-        
+
         Create a copy of the type, possibly with a different setting of the ``optional`` quantifier."""
-        ans : Base = copy.copy(self)
+        ans: Base = copy.copy(self)
         if optional is not None:
             ans._optional = optional
         return ans
 
     def __str__(self) -> str:
         return type(self).__name__ + ('?' if self.optional else '')
+
     def __eq__(self, rhs) -> bool:
-        return isinstance(rhs,Base) and str(self) == str(rhs)
+        return isinstance(rhs, Base) and str(self) == str(rhs)
+
 
 class Boolean(Base):
-    def __init__(self, optional : bool = False) -> None:
+    def __init__(self, optional: bool = False) -> None:
         self._optional = optional
-    def coerces(self, rhs : Base) -> bool:
+
+    def coerces(self, rhs: Base) -> bool:
         ""
         if isinstance(rhs, String):
             return True
         return super().coerces(rhs)
+
 
 class Float(Base):
-    def __init__(self, optional : bool = False) -> None:
+    def __init__(self, optional: bool = False) -> None:
         self._optional = optional
-    def coerces(self, rhs : Base) -> bool:
+
+    def coerces(self, rhs: Base) -> bool:
         ""
         if isinstance(rhs, String):
             return True
         return super().coerces(rhs)
 
+
 class Int(Base):
-    def __init__(self, optional : bool = False) -> None:
+    def __init__(self, optional: bool = False) -> None:
         self._optional = optional
-    def coerces(self, rhs : Base) -> bool:
+
+    def coerces(self, rhs: Base) -> bool:
         ""
         if isinstance(rhs, Float) or isinstance(rhs, String):
             return True
         return super().coerces(rhs)
 
+
 class File(Base):
-    def __init__(self, optional : bool = False) -> None:
+    def __init__(self, optional: bool = False) -> None:
         self._optional = optional
-    def coerces(self, rhs : Base) -> bool:
+
+    def coerces(self, rhs: Base) -> bool:
         ""
         if isinstance(rhs, String):
             return True
         return super().coerces(rhs)
 
+
 class String(Base):
-    def __init__(self, optional : bool = False) -> None:
+    def __init__(self, optional: bool = False) -> None:
         self._optional = optional
-    def coerces(self, rhs : Base) -> bool:
+
+    def coerces(self, rhs: Base) -> bool:
         ""
         if isinstance(rhs, File):
             return True
         return super().coerces(rhs)
 
+
 class Array(Base):
     """
     Array type, parameterized by the type of the constituent items.
     """
-    item_type : Optional[Base] # TODO: make immutable property
+    item_type: Optional[Base]  # TODO: make immutable property
     """
     :type: Optional[WDL.Type.Base]
 
@@ -138,18 +152,20 @@ class Array(Base):
     of the ``read_array()`` standard library function. This is statically
     coercible to any array type (but may fail at runtime).
     """
-    _nonempty : bool
+    _nonempty: bool
 
-    def __init__(self, item_type : Optional[Base], optional : bool = False, nonempty : bool = False) -> None:
+    def __init__(self, item_type: Optional[Base], optional: bool = False, nonempty: bool = False) -> None:
         self.item_type = item_type
         assert isinstance(nonempty, bool)
         self._optional = optional
         self._nonempty = nonempty
+
     def __str__(self) -> str:
         ans = "Array[" + (str(self.item_type) if self.item_type is not None else "") + "]" \
-                + ('+' if self.nonempty else '') \
-                + ('?' if self.optional else '')
+            + ('+' if self.nonempty else '') \
+            + ('?' if self.optional else '')
         return ans
+
     @property
     def nonempty(self) -> bool:
         """
@@ -158,7 +174,8 @@ class Array(Base):
         True when the type has the nonempty quantifier, ``Array[T]+``
         """
         return self._nonempty
-    def coerces(self, rhs : Base) -> bool:
+
+    def coerces(self, rhs: Base) -> bool:
         ""
         if isinstance(rhs, Array):
             if self.item_type is None or rhs.item_type is None:
@@ -168,18 +185,20 @@ class Array(Base):
         if isinstance(rhs, String):
             return self.item_type is None or self.item_type.coerces(String())
         return False
-    def copy(self, optional : Optional[bool] = None, nonempty : Optional[bool] = None) -> Base:
-        ans : Array = super().copy(optional)
+
+    def copy(self, optional: Optional[bool] = None, nonempty: Optional[bool] = None) -> Base:
+        ans: Array = super().copy(optional)
         if nonempty is not None:
             ans._nonempty = nonempty
         return ans
+
 
 class Map(Base):
     """
     Map type, parameterized by the (key,value) item type.
     """
 
-    item_type : Optional[Tuple[Base,Base]]
+    item_type: Optional[Tuple[Base, Base]]
     """
     :type: Optional[Tuple[WDL.Type.Base,WDL.Type.Base]]
 
@@ -189,36 +208,42 @@ class Map(Base):
     to any map type (but may fail at runtime).
     """
 
-    def __init__(self, item_type : Optional[Tuple[Base,Base]], optional : bool = False) -> None:
+    def __init__(self, item_type: Optional[Tuple[Base, Base]], optional: bool = False) -> None:
         self._optional = optional
         self.item_type = item_type
+
     def __str__(self) -> str:
-        return "Map[" + (str(self.item_type[0]) + "," + str(self.item_type[1]) if self.item_type is not None else "") + "]" + ('?' if self.optional else '') # pyre-fixme
-    def coerces(self, rhs : Base) -> bool:
+        # pyre-fixme
+        return "Map[" + (str(self.item_type[0]) + "," + str(self.item_type[1]) if self.item_type is not None else "") + "]" + ('?' if self.optional else '')
+
+    def coerces(self, rhs: Base) -> bool:
         ""
         if isinstance(rhs, Map):
             if self.item_type is None or rhs.item_type is None:
                 return True
             else:
-                return self.item_type[0].coerces(rhs.item_type[0]) and self.item_type[1].coerces(rhs.item_type[1]) # pyre-fixme
+                # pyre-fixme
+                return self.item_type[0].coerces(rhs.item_type[0]) and self.item_type[1].coerces(rhs.item_type[1])
         return super().coerces(rhs)
+
 
 class Pair(Base):
     """
     Pair type, parameterized by the left and right item types.
     """
-    left_type : Base
+    left_type: Base
     """
     :type: WDL.Type.Base
     """
-    right_type : Base
+    right_type: Base
     """
     :type: WDL.Type.Base
     """
 
-    def __init__(self, left_type : Base, right_type : Base, optional : bool = False) -> None:
+    def __init__(self, left_type: Base, right_type: Base, optional: bool = False) -> None:
         self._optional = optional
         self.left_type = left_type
         self.right_type = right_type
+
     def __str__(self) -> str:
         return "Pair[" + (str(self.left_type) + "," + str(self.right_type)) + "]" + ('?' if self.optional else '')

--- a/WDL/Value.py
+++ b/WDL/Value.py
@@ -11,13 +11,15 @@ import json
 import WDL.Type as T
 
 BaseT = TypeVar('BaseT', bound='Base')
+
+
 class Base(ABC):
     """The abstract base class for WDL values"""
 
     type: T.Base
     ":type: WDL.Type.Base"
 
-    value: Any # pyre-ignore
+    value: Any  # pyre-ignore
     """The "raw" Python value"""
 
     def __init__(self, type: T.Base, value: Any) -> None:
@@ -44,74 +46,100 @@ class Base(ABC):
             return String(str(self.value))
         # TODO: coerce T to Array[T] (x to [x])
         return self
+
     def expect(self, desired_type: Optional[T.Base] = None) -> BaseT:
         """Alias for coerce"""
         return self.coerce(desired_type)
 
+
 class Boolean(Base):
     """``value`` has Python type ``bool``"""
+
     def __init__(self, value: bool) -> None:
         super().__init__(T.Boolean(), value)
+
     def __str__(self) -> str:
         return str(self.value).lower()
 
+
 class Float(Base):
     """``value`` has Python type ``float``"""
+
     def __init__(self, value: float) -> None:
         super().__init__(T.Float(), value)
 
+
 class Int(Base):
     """``value`` has Python type ``int``"""
+
     def __init__(self, value: int) -> None:
         super().__init__(T.Int(), value)
+
     def coerce(self, desired_type: Optional[T.Base] = None) -> Base:
         ""
         if desired_type is not None and isinstance(desired_type, T.Float):
-            return Float(float(self.value)) # pyre-ignore
+            return Float(float(self.value))  # pyre-ignore
         return super().coerce(desired_type)
+
 
 class String(Base):
     """``value`` has Python type ``str``"""
+
     def __init__(self, value: str) -> None:
         super().__init__(T.String(), value)
+
     def __str__(self) -> str:
         return json.dumps(self.value)
+
 
 class Array(Base):
     """``value`` is a Python ``list`` of other ``WDL.Value.Base`` instances"""
     value: List[Base] = []
+
     def __init__(self, type: T.Array, value: List[Base]) -> None:
         super().__init__(type, value)
+
     def __str__(self) -> str:
         return "[" + ", ".join([str(item) for item in self.value]) + "]"
 
+
 class Map(Base):
     value: List[Tuple[Base, Base]] = []
+
     def __init__(self, type: T.Map, value: List[Tuple[Base, Base]]) -> None:
         super().__init__(type, value)
+
     def __str__(self) -> str:
-        raise NotImplementedError() # TODO
+        raise NotImplementedError()  # TODO
+
 
 class Pair(Base):
     value: Optional[Tuple[Base, Base]] = None
+
     def __init__(self, type: T.Pair, value: Tuple[Base, Base]) -> None:
         super().__init__(type, value)
+
     def __str__(self) -> str:
         assert isinstance(self.value, tuple)
-        return "(" + str(self.value[0]) + "," + str(self.value[1]) + ")" # pyre-fixme
+        # pyre-fixme
+        return "(" + str(self.value[0]) + "," + str(self.value[1]) + ")"
+
 
 class Null(Base):
     """Represents the missing value which optional inputs may take.
     ``type`` and ``value`` are both None."""
-    type: Optional[Any] # pyre-ignore
-    value: Optional[Any] # pyre-ignore
+    type: Optional[Any]  # pyre-ignore
+    value: Optional[Any]  # pyre-ignore
+
     def __init__(self) -> None:
         # pylint: disable=super-init-not-called
         self.type = None
         self.value = None
+
     def __str__(self) -> str:
         assert False
         return ''
+
     def coerce(self, desired_type: Optional[T.Base] = None) -> Base:
         ""
         if desired_type is None or not desired_type.optional:

--- a/WDL/Walker.py
+++ b/WDL/Walker.py
@@ -30,25 +30,24 @@ class Base():
     def __call__(self, obj: WDL.Error.SourceNode) -> Any:
         if isinstance(obj, WDL.Tree.Document):
             return self.document(obj)
-        elif isinstance(obj, WDL.Tree.Workflow):
+        if isinstance(obj, WDL.Tree.Workflow):
             return self.workflow(obj)
-        elif isinstance(obj, WDL.Tree.Call):
+        if isinstance(obj, WDL.Tree.Call):
             return self.call(obj)
-        elif isinstance(obj, WDL.Tree.Scatter):
+        if isinstance(obj, WDL.Tree.Scatter):
             return self.scatter(obj)
-        elif isinstance(obj, WDL.Tree.Conditional):
+        if isinstance(obj, WDL.Tree.Conditional):
             return self.conditional(obj)
-        elif isinstance(obj, WDL.Tree.Decl):
+        if isinstance(obj, WDL.Tree.Decl):
             return self.decl(obj)
-        elif isinstance(obj, WDL.Tree.Task):
+        if isinstance(obj, WDL.Tree.Task):
             return self.task(obj)
-        elif isinstance(obj, WDL.Expr.Base):
+        if isinstance(obj, WDL.Expr.Base):
             return self.expr(obj)
-        else:
-            assert False
+        assert False
 
     def document(self, obj: WDL.Tree.Document) -> Any:
-        for namespace, uri, subdoc in obj.imports:
+        for _, _, subdoc in obj.imports:
             assert isinstance(subdoc, WDL.Tree.Document)
             self(subdoc)
         for task in obj.tasks:
@@ -61,7 +60,7 @@ class Base():
             self(elt)
 
     def call(self, obj: WDL.Tree.Call) -> Any:
-        for nm, expr in obj.inputs.items():
+        for _, expr in obj.inputs.items():
             self(expr)
 
     def scatter(self, obj: WDL.Tree.Scatter) -> Any:
@@ -131,7 +130,7 @@ class SetParents(Base):
     def document(self, obj: WDL.Tree.Document) -> None:
         super().document(obj)
         obj.parent = None
-        for namespace, uri, subdoc in obj.imports:
+        for _, _, subdoc in obj.imports:
             subdoc.parent = obj
         for task in obj.tasks:
             task.parent = obj

--- a/WDL/__init__.py
+++ b/WDL/__init__.py
@@ -1,5 +1,6 @@
 """Toolkit for static analysis of Workflow Description Language (WDL)"""
-import os, errno
+import os
+import errno
 import lark
 import inspect
 from WDL import _parser, Error, Type, Value, Env, Expr, Tree, Walker, StdLib
@@ -9,7 +10,8 @@ from typing import List
 SourcePosition = Error.SourcePosition
 SourceNode = Error.SourceNode
 
-def load(uri : str, path : List[str] = []) -> Document:
+
+def load(uri: str, path: List[str] = []) -> Document:
     """
     Parse a WDL document given filename/URI, recursively descend into imported documents, then typecheck the tasks and workflow.
 
@@ -17,7 +19,8 @@ def load(uri : str, path : List[str] = []) -> Document:
     """
     return Tree.load(uri, path)
 
-def parse_document(txt : str, uri : str = '') -> Document:
+
+def parse_document(txt: str, uri: str = '') -> Document:
     """
     Parse WDL document text into an abstract syntax tree. Doesn't descend into
     imported documents nor typecheck the AST.
@@ -26,11 +29,13 @@ def parse_document(txt : str, uri : str = '') -> Document:
     """
     return _parser.parse_document(txt, uri)
 
-def parse_expr(txt : str) -> Expr.Base:
+
+def parse_expr(txt: str) -> Expr.Base:
     """
     Parse an isolated WDL expression text into an abstract syntax tree
     """
     return _parser.parse_expr(txt)
 
-def parse_tasks(txt : str) -> List[Task]:
+
+def parse_tasks(txt: str) -> List[Task]:
     return _parser.parse_tasks(txt)

--- a/WDL/__init__.py
+++ b/WDL/__init__.py
@@ -1,11 +1,10 @@
 """Toolkit for static analysis of Workflow Description Language (WDL)"""
 import os
 import errno
-import lark
 import inspect
+from typing import List
 from WDL import _parser, Error, Type, Value, Env, Expr, Tree, Walker, StdLib
 from WDL.Tree import Decl, Task, Call, Scatter, Conditional, Workflow, Document
-from typing import List
 
 SourcePosition = Error.SourcePosition
 SourceNode = Error.SourceNode
@@ -13,9 +12,11 @@ SourceNode = Error.SourceNode
 
 def load(uri: str, path: List[str] = []) -> Document:
     """
-    Parse a WDL document given filename/URI, recursively descend into imported documents, then typecheck the tasks and workflow.
+    Parse a WDL document given filename/URI, recursively descend into imported
+    documents, then typecheck the tasks and workflow.
 
-    :param path: local filesystem directories to search for imports, in addition to the current working directory
+    :param path: local filesystem directories to search for imports, in
+    addition to the current working directory
     """
     return Tree.load(uri, path)
 

--- a/WDL/_parser.py
+++ b/WDL/_parser.py
@@ -210,8 +210,12 @@ def parse(txt: str, start: str) -> lark.Tree:
 
 
 def sp(filename, meta) -> SourcePosition:
-    return SourcePosition(filename=filename, line=meta.line, column=meta.column,
-                          end_line=meta.end_line, end_column=meta.end_column)
+    return SourcePosition(
+        filename=filename,
+        line=meta.line,
+        column=meta.column,
+        end_line=meta.end_line,
+        end_column=meta.end_column)
 
 
 def to_int(x):
@@ -307,7 +311,7 @@ for op in ["land", "lor", "add", "sub", "mul", "div", "rem",
            "eqeq", "neq", "lt", "lte", "gt", "gte"]:
     def fn(self, items, meta, op=op):
         assert len(items) == 2
-        return E.Apply(sp(self.filename, meta), "_"+op, items)
+        return E.Apply(sp(self.filename, meta), "_" + op, items)
     setattr(_ExprTransformer, op, lark.v_args(  # pyre-fixme
         meta=True)(classmethod(fn)))
 
@@ -385,7 +389,11 @@ class _DocTransformer(_ExprTransformer, _TypeTransformer):
         self.imported = imported
 
     def decl(self, items, meta):
-        return D.Decl(sp(self.filename, meta), items[0], items[1].value, (items[2] if len(items) > 2 else None))
+        return D.Decl(sp(self.filename,
+                         meta),
+                      items[0],
+                      items[1].value,
+                      (items[2] if len(items) > 2 else None))
 
     def input_decls(self, items, meta):
         return {"inputs": items}
@@ -468,10 +476,15 @@ class _DocTransformer(_ExprTransformer, _TypeTransformer):
                 assert isinstance(item, str)
                 assert "name" not in d
                 d["name"] = item.value
-        return D.Task(sp(self.filename, meta), d["name"], d.get("inputs", []), d.get("decls", []), d["command"],
-                      d.get("outputs", []), d.get(
-                          "parameter_meta", {}), d.get("runtime", {}),
-                      d.get("meta", {}))
+        return D.Task(
+            sp(
+                self.filename, meta), d["name"], d.get(
+                "inputs", []), d.get(
+                "decls", []), d["command"], d.get(
+                    "outputs", []), d.get(
+                        "parameter_meta", {}), d.get(
+                            "runtime", {}), d.get(
+                                "meta", {}))
 
     def tasks(self, items, meta):
         return items
@@ -489,13 +502,19 @@ class _DocTransformer(_ExprTransformer, _TypeTransformer):
         return d
 
     def call(self, items, meta):
-        return D.Call(sp(self.filename, meta), items[0], None, items[1] if len(items) > 1 else dict())
+        return D.Call(sp(self.filename, meta),
+                      items[0], None, items[1] if len(items) > 1 else dict())
 
     def call_as(self, items, meta):
-        return D.Call(sp(self.filename, meta), items[0], items[1].value, items[2] if len(items) > 2 else dict())
+        return D.Call(sp(self.filename,
+                         meta),
+                      items[0],
+                      items[1].value,
+                      items[2] if len(items) > 2 else dict())
 
     def scatter(self, items, meta):
-        return D.Scatter(sp(self.filename, meta), items[0].value, items[1], items[2:])
+        return D.Scatter(sp(self.filename, meta),
+                         items[0].value, items[1], items[2:])
 
     def conditional(self, items, meta):
         return D.Conditional(sp(self.filename, meta), items[0], items[1:])
@@ -528,8 +547,13 @@ class _DocTransformer(_ExprTransformer, _TypeTransformer):
                 elements.append(item)
             else:
                 assert False
-        return D.Workflow(sp(self.filename, meta), items[0].value, elements, outputs,
-                          parameter_meta or dict(), meta_section or dict())
+        return D.Workflow(sp(self.filename,
+                             meta),
+                          items[0].value,
+                          elements,
+                          outputs,
+                          parameter_meta or dict(),
+                          meta_section or dict())
 
     def import_doc(self, items, meta):
         uri = items[0]
@@ -538,7 +562,7 @@ class _DocTransformer(_ExprTransformer, _TypeTransformer):
         else:
             namespace = uri
             try:
-                namespace = namespace[namespace.rindex('/')+1:]
+                namespace = namespace[namespace.rindex('/') + 1:]
             except ValueError:
                 pass
             if namespace.endswith(".wdl"):
@@ -564,7 +588,8 @@ class _DocTransformer(_ExprTransformer, _TypeTransformer):
                 imports.append(item["import"])
             else:
                 assert False
-        return D.Document(sp(self.filename, meta), imports, tasks, workflow, self.imported)
+        return D.Document(sp(self.filename, meta), imports,
+                          tasks, workflow, self.imported)
 
 
 # have lark pass the 'meta' with line/column numbers to each transformer method
@@ -586,9 +611,20 @@ def parse_tasks(txt: str) -> List[D.Task]:
     return _DocTransformer('', False).transform(parse(txt, "tasks"))
 
 
-def parse_document(txt: str, uri: str = '', imported: bool = False) -> D.Document:
+def parse_document(txt: str, uri: str = '',
+                   imported: bool = False) -> D.Document:
     if len(txt.strip()) == 0:
-        return D.Document(SourcePosition(filename=uri, line=0, column=0, end_line=0, end_column=0), [], [], None, imported)
+        return D.Document(
+            SourcePosition(
+                filename=uri,
+                line=0,
+                column=0,
+                end_line=0,
+                end_column=0),
+            [],
+            [],
+            None,
+            imported)
     try:
         return _DocTransformer(uri, imported).transform(parse(txt, "document"))
     except lark.exceptions.UnexpectedCharacters as exn:

--- a/WDL/_parser.py
+++ b/WDL/_parser.py
@@ -1,3 +1,14 @@
+import errno
+import os
+from WDL import Env
+from WDL.Error import SourcePosition
+from WDL import Error as Err
+from WDL import Tree as D
+from WDL import Type as T
+from WDL import Expr as E
+from typing import List, Optional
+import inspect
+import lark
 grammar = r"""
 // WDL expressions
 // start with rules handling infix operator precedence
@@ -187,48 +198,50 @@ COMMENT: "#" /[^\r\n]*/ NEWLINE
 %ignore COMMENT
 """
 
-import os, errno
-import lark
-import inspect
-from typing import List, Optional
-from WDL import Expr as E
-from WDL import Type as T
-from WDL import Tree as D
-from WDL import Error as Err
-from WDL.Error import SourcePosition
-from WDL import Env
 
-larks_by_start = {} # memoize Lark parsers constructed for various start symbols
-def parse(txt : str, start : str) -> lark.Tree:
+larks_by_start = {}  # memoize Lark parsers constructed for various start symbols
+
+
+def parse(txt: str, start: str) -> lark.Tree:
     if start not in larks_by_start:
-        larks_by_start[start] = lark.Lark(grammar, start=start, parser="lalr", propagate_positions=True)
+        larks_by_start[start] = lark.Lark(
+            grammar, start=start, parser="lalr", propagate_positions=True)
     return larks_by_start[start].parse(txt)
 
-def sp(filename,meta) -> SourcePosition:
+
+def sp(filename, meta) -> SourcePosition:
     return SourcePosition(filename=filename, line=meta.line, column=meta.column,
                           end_line=meta.end_line, end_column=meta.end_column)
 
+
 def to_int(x):
     return int(x)
+
 
 def to_float(x):
     return float(x)
 
 # Transformer from lark.Tree to WDL.Expr
+
+
 class _ExprTransformer(lark.Transformer):
-    def __init__(self, file : str) -> None:
+    def __init__(self, file: str) -> None:
         self.filename = file
 
     def boolean_true(self, items, meta) -> E.Base:
         return E.Boolean(sp(self.filename, meta), True)
+
     def boolean_false(self, items, meta) -> E.Base:
         return E.Boolean(sp(self.filename, meta), False)
+
     def int(self, items, meta) -> E.Base:
         assert len(items) == 1
         return E.Int(sp(self.filename, meta), to_int(items[0]))
+
     def float(self, items, meta) -> E.Base:
         assert len(items) == 1
         return E.Float(sp(self.filename, meta), to_float(items[0]))
+
     def string(self, items, meta) -> E.Base:
         parts = []
         for item in items:
@@ -245,35 +258,42 @@ class _ExprTransformer(lark.Transformer):
         # closing quote didn't
         assert len(parts) >= 2
         assert parts[0] in ['"', "'"]
-        assert parts[-1][-1] in ['"', "'"] # pyre-fixme
+        assert parts[-1][-1] in ['"', "'"]  # pyre-fixme
         if len(parts[-1]) > 1:
-            parts.append(parts[-1][-1]) # pyre-fixme
-            parts[-2] = parts[-2][:-1] # pyre-fixme
+            parts.append(parts[-1][-1])  # pyre-fixme
+            parts[-2] = parts[-2][:-1]  # pyre-fixme
         return E.String(sp(self.filename, meta), parts)
+
     def array(self, items, meta) -> E.Base:
         return E.Array(sp(self.filename, meta), items)
 
     def apply(self, items, meta) -> E.Base:
         assert len(items) >= 1
         return E.Apply(sp(self.filename, meta), items[0], items[1:])
+
     def negate(self, items, meta) -> E.Base:
         return E.Apply(sp(self.filename, meta), "_negate", items)
+
     def get(self, items, meta) -> E.Base:
         return E.Apply(sp(self.filename, meta), "_get", items)
 
     def pair(self, items, meta) -> E.Base:
         assert len(items) == 2
         return E.Pair(sp(self.filename, meta), items[0], items[1])
+
     def get_left(self, items, meta) -> E.Base:
         return E.Apply(sp(self.filename, meta), "_get_left", items)
+
     def get_right(self, items, meta) -> E.Base:
         return E.Apply(sp(self.filename, meta), "_get_right", items)
 
     def map_kv(self, items, meta) -> E.Base:
         assert len(items) == 2
         return (items[0], items[1])
+
     def map(self, items, meta) -> E.Base:
         return E.Map(sp(self.filename, meta), items)
+
     def ifthenelse(self, items, meta) -> E.Base:
         assert len(items) == 3
         return E.IfThenElse(sp(self.filename, meta), *items)
@@ -281,16 +301,19 @@ class _ExprTransformer(lark.Transformer):
     def ident(self, items, meta) -> E.Base:
         return E.Ident(sp(self.filename, meta), [item.value for item in items])
 
+
 # _ExprTransformer infix operators
 for op in ["land", "lor", "add", "sub", "mul", "div", "rem",
            "eqeq", "neq", "lt", "lte", "gt", "gte"]:
     def fn(self, items, meta, op=op):
         assert len(items) == 2
         return E.Apply(sp(self.filename, meta), "_"+op, items)
-    setattr(_ExprTransformer, op, lark.v_args(meta=True)(classmethod(fn))) # pyre-fixme
+    setattr(_ExprTransformer, op, lark.v_args(  # pyre-fixme
+        meta=True)(classmethod(fn)))
+
 
 class _TypeTransformer(lark.Transformer):
-    def __init__(self, file : str) -> None:
+    def __init__(self, file: str) -> None:
         self.filename = file
 
     def int_type(self, items, meta):
@@ -298,26 +321,31 @@ class _TypeTransformer(lark.Transformer):
         if len(items) > 0 and items[0].value == "?":
             optional = True
         return T.Int(optional)
+
     def float_type(self, items, meta):
         optional = False
         if len(items) > 0 and items[0].value == "?":
             optional = True
         return T.Float(optional)
+
     def boolean_type(self, items, meta):
         optional = False
         if len(items) > 0 and items[0].value == "?":
             optional = True
         return T.Boolean(optional)
+
     def string_type(self, items, meta):
         optional = False
         if len(items) > 0 and items[0].value == "?":
             optional = True
         return T.String(optional)
+
     def file_type(self, items, meta):
         optional = False
         if len(items) > 0 and items[0].value == "?":
             optional = True
         return T.File(optional)
+
     def array_type(self, items, meta):
         assert len(items) >= 1
         assert isinstance(items[0], T.Base)
@@ -329,6 +357,7 @@ class _TypeTransformer(lark.Transformer):
             if items[1].value == "+":
                 nonempty = True
         return T.Array(items[0], optional, nonempty)
+
     def map_type(self, items, meta):
         assert len(items) >= 2
         assert isinstance(items[0], T.Base)
@@ -338,6 +367,7 @@ class _TypeTransformer(lark.Transformer):
             if items[2].value == "?":
                 optional = True
         return T.Map((items[0], items[1]), optional)
+
     def pair_type(self, items, meta):
         assert len(items) >= 2
         assert isinstance(items[0], T.Base)
@@ -348,28 +378,36 @@ class _TypeTransformer(lark.Transformer):
                 optional = True
         return T.Pair(items[0], items[1], optional)
 
+
 class _DocTransformer(_ExprTransformer, _TypeTransformer):
-    def __init__(self, file : str, imported : bool) -> None:
+    def __init__(self, file: str, imported: bool) -> None:
         self.filename = file
         self.imported = imported
 
     def decl(self, items, meta):
         return D.Decl(sp(self.filename, meta), items[0], items[1].value, (items[2] if len(items) > 2 else None))
+
     def input_decls(self, items, meta):
         return {"inputs": items}
+
     def noninput_decls(self, items, meta):
         return {"decls": items}
+
     def string_literal(self, items, meta):
         assert len(items) == 1
         return items[0].value[1:-1]
+
     def placeholder_option(self, items, meta):
         assert len(items) == 2
         return (items[0].value, items[1])
+
     def placeholder(self, items, meta):
         options = dict(items[:-1])
         if len(options.items()) < len(items) - 1:
-            raise Err.MultipleDefinitions(sp(self.filename, meta), "duplicate options in expression placeholder")
+            raise Err.MultipleDefinitions(
+                sp(self.filename, meta), "duplicate options in expression placeholder")
         return E.Placeholder(sp(self.filename, meta), options, items[-1])
+
     def command(self, items, meta):
         parts = []
         for item in items:
@@ -380,68 +418,88 @@ class _DocTransformer(_ExprTransformer, _TypeTransformer):
             else:
                 parts.append(item.value)
         return {"command": E.String(sp(self.filename, meta), parts)}
+
     def output_decls(self, items, meta):
         return {"outputs": items}
+
     def meta_kv(self, items, meta):
         return (items[0].value, items[1])
+
     def meta_object(self, items, meta):
         d = dict()
         for k, v in items:
             if k in d:
-                raise Err.MultipleDefinitions(sp(self.filename, meta), "duplicate keys in meta object")
+                raise Err.MultipleDefinitions(
+                    sp(self.filename, meta), "duplicate keys in meta object")
             d[k] = v
         return d
+
     def meta_array(self, items, meta):
         return items
+
     def meta_section(self, items, meta):
         kind = items[0].value
         d = dict()
         d[kind] = items[1]
         return d
+
     def runtime_kv(self, items, meta):
         return (items[0].value, items[1])
+
     def runtime_section(self, items, meta):
         d = dict()
-        for k,v in items:
+        for k, v in items:
             # TODO: restore duplicate check, cf. https://github.com/gatk-workflows/five-dollar-genome-analysis-pipeline/blob/89f11befc13abae97ab8fb1b457731f390c8728d/tasks_pipelines/qc.wdl#L288
-            #if k in d:
+            # if k in d:
             #    raise Err.MultipleDefinitions(sp(self.filename, meta), "duplicate keys in runtime section")
             d[k] = v
         return {"runtime": d}
+
     def task(self, items, meta):
         d = {}
         for item in items:
             if isinstance(item, dict):
-                for k,v in item.items():
+                for k, v in item.items():
                     if k in d:
-                        raise Err.MultipleDefinitions(sp(self.filename, meta), "redundant sections in task")
+                        raise Err.MultipleDefinitions(
+                            sp(self.filename, meta), "redundant sections in task")
                     d[k] = v
             else:
                 assert isinstance(item, str)
                 assert "name" not in d
                 d["name"] = item.value
         return D.Task(sp(self.filename, meta), d["name"], d.get("inputs", []), d.get("decls", []), d["command"],
-                      d.get("outputs", []), d.get("parameter_meta", {}), d.get("runtime", {}),
+                      d.get("outputs", []), d.get(
+                          "parameter_meta", {}), d.get("runtime", {}),
                       d.get("meta", {}))
+
     def tasks(self, items, meta):
         return items
+
     def call_input(self, items, meta):
         return (items[0].value, items[1])
+
     def call_inputs(self, items, meta):
         d = dict()
         for k, v in items:
             if k in d:
-                raise Err.MultipleDefinitions(sp(self.filename, meta), "duplicate keys in call inputs")
+                raise Err.MultipleDefinitions(
+                    sp(self.filename, meta), "duplicate keys in call inputs")
             d[k] = v
         return d
+
     def call(self, items, meta):
-        return D.Call(sp(self.filename, meta), items[0], None, items[1] if len(items)>1 else dict())
+        return D.Call(sp(self.filename, meta), items[0], None, items[1] if len(items) > 1 else dict())
+
     def call_as(self, items, meta):
-        return D.Call(sp(self.filename, meta), items[0], items[1].value, items[2] if len(items)>2 else dict())
+        return D.Call(sp(self.filename, meta), items[0], items[1].value, items[2] if len(items) > 2 else dict())
+
     def scatter(self, items, meta):
         return D.Scatter(sp(self.filename, meta), items[0].value, items[1], items[2:])
+
     def conditional(self, items, meta):
         return D.Conditional(sp(self.filename, meta), items[0], items[1:])
+
     def workflow(self, items, meta):
         elements = []
         outputs = None
@@ -451,15 +509,18 @@ class _DocTransformer(_ExprTransformer, _TypeTransformer):
             if isinstance(item, dict):
                 if "outputs" in item:
                     if outputs is not None:
-                        raise Err.MultipleDefinitions(sp(self.filename, meta), "redundant sections in workflow")
+                        raise Err.MultipleDefinitions(
+                            sp(self.filename, meta), "redundant sections in workflow")
                     outputs = item["outputs"]
                 elif "meta" in item:
                     if meta_section is not None:
-                        raise Err.MultipleDefinitions(sp(self.filename, meta), "redundant sections in workflow")
+                        raise Err.MultipleDefinitions(
+                            sp(self.filename, meta), "redundant sections in workflow")
                     meta_section = item["meta"]
                 elif "parameter_meta" in item:
                     if parameter_meta is not None:
-                        raise Err.MultipleDefinitions(sp(self.filename, meta), "redundant sections in workflow")
+                        raise Err.MultipleDefinitions(
+                            sp(self.filename, meta), "redundant sections in workflow")
                     parameter_meta = item["parameter_meta"]
                 else:
                     assert False
@@ -469,6 +530,7 @@ class _DocTransformer(_ExprTransformer, _TypeTransformer):
                 assert False
         return D.Workflow(sp(self.filename, meta), items[0].value, elements, outputs,
                           parameter_meta or dict(), meta_section or dict())
+
     def import_doc(self, items, meta):
         uri = items[0]
         if len(items) > 1:
@@ -482,7 +544,8 @@ class _DocTransformer(_ExprTransformer, _TypeTransformer):
             if namespace.endswith(".wdl"):
                 namespace = namespace[:-4]
         # TODO: validate namespace
-        return {"import": (uri,namespace)}
+        return {"import": (uri, namespace)}
+
     def document(self, items, meta):
         imports = []
         tasks = []
@@ -492,7 +555,8 @@ class _DocTransformer(_ExprTransformer, _TypeTransformer):
                 tasks.append(item)
             elif isinstance(item, D.Workflow):
                 if workflow is not None:
-                    raise Err.MultipleDefinitions(sp(self.filename, meta), "Document has multiple workflows")
+                    raise Err.MultipleDefinitions(
+                        sp(self.filename, meta), "Document has multiple workflows")
                 workflow = item
             elif isinstance(item, lark.Tree) and item.data == "version":
                 pass
@@ -502,22 +566,27 @@ class _DocTransformer(_ExprTransformer, _TypeTransformer):
                 assert False
         return D.Document(sp(self.filename, meta), imports, tasks, workflow, self.imported)
 
+
 # have lark pass the 'meta' with line/column numbers to each transformer method
 for _klass in [_ExprTransformer, _TypeTransformer, _DocTransformer]:
     for name, method in inspect.getmembers(_klass, inspect.isfunction):
         if not name.startswith('_'):
-            setattr(_klass, name, lark.v_args(meta=True)(method)) # pyre-fixme
+            setattr(_klass, name, lark.v_args(meta=True)(method))  # pyre-fixme
 
-def parse_expr(txt : str) -> E.Base:
+
+def parse_expr(txt: str) -> E.Base:
     try:
         return _ExprTransformer(txt).transform(parse(txt, "expr"))
     except lark.exceptions.UnexpectedToken as exn:
         raise Err.ParserError(txt) from exn
 
-def parse_tasks(txt : str) -> List[D.Task]:
-    return _DocTransformer('', False).transform(parse(txt, "tasks")) # pyre-fixme
 
-def parse_document(txt : str, uri : str = '', imported : bool = False) -> D.Document:
+def parse_tasks(txt: str) -> List[D.Task]:
+    # pyre-fixme
+    return _DocTransformer('', False).transform(parse(txt, "tasks"))
+
+
+def parse_document(txt: str, uri: str = '', imported: bool = False) -> D.Document:
     if len(txt.strip()) == 0:
         return D.Document(SourcePosition(filename=uri, line=0, column=0, end_line=0, end_column=0), [], [], None, imported)
     try:

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,6 +1,7 @@
 # Packages needed for miniwdl development, in addition to those in
 # requirements.txt which are needed for miniwdl to run in common use.
 pyre-check==0.0.16
+pylint
 sphinx
 sphinx-autobuild
 sphinx_rtd_theme

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -2,6 +2,7 @@
 # requirements.txt which are needed for miniwdl to run in common use.
 pyre-check==0.0.16
 pylint
+autopep8
 sphinx
 sphinx-autobuild
 sphinx_rtd_theme

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,8 +1,8 @@
 # Packages needed for miniwdl development, in addition to those in
 # requirements.txt which are needed for miniwdl to run in common use.
 pyre-check==0.0.16
+autopep8==1.4.3
 pylint
-autopep8
 sphinx
 sphinx-autobuild
 sphinx_rtd_theme


### PR DESCRIPTION
YUGE diff introducing autopep8 and pylint to our CI, and cleaning up fuzz discovered in the process. Current pylint score 9.37/10

- `make` / `make test` includes pylint in "errors only" mode
- `make pretty` reformats code with autopep8, and displays pylint report
- Travis build fails if source code isn't at a fixed point for autopep8 (revision pinned in `requirements.dev.txt`)
