### PR TITLE
ForwardReference linter

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -5,5 +5,6 @@
   ],
   "search_path": [
     "."
-  ]
+  ],
+  "workers": 4
 }

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ qtest:
 	python3 -m unittest -v -f
 
 check:
-	pylint --errors-only WDL
+	pylint -j `nproc` --errors-only WDL
 	pyre \
 		--search-path $(HOME)/.local/lib/python3.6/site-packages/lark \
 		--typeshed $(HOME)/.local/lib/pyre_check/typeshed \

--- a/WDL/Env.py
+++ b/WDL/Env.py
@@ -105,7 +105,7 @@ def resolve(tree: "Tree[R]", namespace: List[str], name: str) -> R:
     return ans
 
 
-def resolve_ctx(tree: "Tree[R]", namespace: List[str], name: str) -> Any: # pyre-ignore
+def resolve_ctx(tree: "Tree[R]", namespace: List[str], name: str) -> Any:  # pyre-ignore
     """Resolve a name to its secondary context value"""
     ans: Any = resolve_binding(tree, namespace, name).ctx
     return ans

--- a/WDL/Env.py
+++ b/WDL/Env.py
@@ -34,7 +34,7 @@ class Binding(Generic[R]):
     """:type: Union[WDL.Type.Base,WDL.Value.Base]"""
 
     ctx: Any
-    "Arbitrary context value"
+    "Arbitrary, secondary context also associated with name"
 
     def __init__(self, name: str, rhs: R, ctx: Any = None) -> None:
         self.name = name
@@ -87,22 +87,28 @@ def resolve_namespace(tree: "Tree[R]", namespace: List[str]) -> R:
     raise KeyError()
 
 
+def resolve_binding(tree: "Tree[R]", namespace: List[str], name: str) -> Binding[R]:
+    """
+    Resolve a name within an environment to the corresponding Binding object
+    """
+    ns = resolve_namespace(tree, namespace)
+    for node in ns:
+        if isinstance(node, Binding) and node.name == name:
+            ans: Binding[R] = node
+            return ans
+    raise KeyError()
+
+
 def resolve(tree: "Tree[R]", namespace: List[str], name: str) -> R:
     """Resolve a name within an environment"""
-    ns = resolve_namespace(tree, namespace)
-    for node in ns:
-        if isinstance(node, Binding) and node.name == name:
-            return node.rhs
-    raise KeyError()
+    ans: R = resolve_binding(tree, namespace, name).rhs
+    return ans
 
 
-def resolve_ctx(tree: "Tree[R]", namespace: List[str], name: str) -> Any:
+def resolve_ctx(tree: "Tree[R]", namespace: List[str], name: str) -> Any: # pyre-ignore
     """Resolve a name to its secondary context value"""
-    ns = resolve_namespace(tree, namespace)
-    for node in ns:
-        if isinstance(node, Binding) and node.name == name:
-            return node.ctx
-    raise KeyError()
+    ans: Any = resolve_binding(tree, namespace, name).ctx
+    return ans
 
 
 # print(arrayize([Binding('x',T.Int())])[0].rhs)

--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -61,7 +61,7 @@ class Decl(SourceNode):
         ty = self.type
         if isinstance(self.expr, (E.Int, E.Float, E.String, E.Array, E.Pair, E.Map)):
             ty = ty.copy(optional=False)
-        ans: Env.Types = Env.bind(self.name, ty, type_env)
+        ans: Env.Types = Env.bind(self.name, ty, type_env, ctx=self)
         return ans
 
     def typecheck(self, type_env: Env.Types) -> None:
@@ -255,7 +255,7 @@ class Call(SourceNode):
             pass
         outputs_env = []
         for outp in self.callee.outputs:
-            outputs_env = Env.bind(outp.name, outp.type, outputs_env)
+            outputs_env = Env.bind(outp.name, outp.type, outputs_env, ctx=self)
         return Env.namespace(self.name, outputs_env, type_env)
 
     def typecheck_input(self, type_env: Env.Types, doc: TVDocument) -> None:
@@ -625,7 +625,7 @@ def _build_workflow_type_env(
             )
         except KeyError:
             pass
-        type_env = Env.bind(self.variable, self.expr.type.item_type, type_env)
+        type_env = Env.bind(self.variable, self.expr.type.item_type, type_env, ctx=self)
     elif isinstance(self, Conditional):
         # typecheck the condition
         self.expr.infer_type(type_env)

--- a/WDL/Walker.py
+++ b/WDL/Walker.py
@@ -9,7 +9,7 @@ class Base:
     scatter, conditional, decl, task). The base implementations of these
     methods recurse into the node's "children." Overriding subclasses can thus
     invoke their super at the appropriate point for preorder or postorder
-    traversal.
+    traversal (or omit super to prevent further descent).
 
     ``
     class PrintUnconditionalCallNames(Walker.Base):

--- a/tests/test_3corpi.py
+++ b/tests/test_3corpi.py
@@ -82,7 +82,7 @@ class gatk4_germline_snps_indels(unittest.TestCase):
 
 @test_corpus(
     ["test_corpi/gatk-workflows/gatk4-somatic-snvs-indels/**"],
-    expected_lint={'StringCoercion': 20},
+    expected_lint= {'ForwardReference': 3, 'StringCoercion': 20},
 )
 class gatk4_somatic_snvs_indels(unittest.TestCase):
     pass


### PR DESCRIPTION
Links each Expr.Ident to the Decl or Call it references, which is added during document typechecking by threading it through the type environment (as 'context').

This link makes it easy to ask whether the Expr.Ident lexically precedes the Decl/Call. It will also facilitate detection of cyclic dependencies and unused declarations.