### PR TITLE
UnusedDeclaration and UnusedCall linters

### DIFF
--- a/WDL/CLI.py
+++ b/WDL/CLI.py
@@ -102,10 +102,18 @@ def outline(obj, level, file=sys.stdout):
             descend(decl)
     # call
     elif isinstance(obj, WDL.Call):
-        print(
-            "{}call {}".format(s, ".".join(obj.callee_id.namespace + [obj.callee_id.name])),
-            file=file,
-        )
+        if obj.name != obj.callee_id.name:
+            print(
+                "{}call {} as {}".format(
+                    s, ".".join(obj.callee_id.namespace + [obj.callee_id.name]), obj.name
+                ),
+                file=file,
+            )
+        else:
+            print(
+                "{}call {}".format(s, ".".join(obj.callee_id.namespace + [obj.callee_id.name])),
+                file=file,
+            )
     # scatter
     elif isinstance(obj, WDL.Scatter):
         print("{}scatter {}".format(s, obj.variable), file=file)

--- a/WDL/CLI.py
+++ b/WDL/CLI.py
@@ -60,16 +60,16 @@ def outline(obj, level, file=sys.stdout):
     def descend(dobj=None, first_descent=first_descent):
         # show lint for the node just prior to first descent beneath it
         if not first_descent and hasattr(obj, "lint"):
-            for (node, klass, msg) in sorted(obj.lint, key=lambda t: t[0]):
+            for (node, klass, msg) in sorted(obj.lint, key=lambda t: t[0].pos):
                 print(
-                    "{}  (Ln {}, Col {}) {}: {}".format(
+                    "{}    (Ln {}, Col {}) {}: {}".format(
                         s, node.pos.line, node.pos.column, klass, msg
                     ),
                     file=file,
                 )
         first_descent.append(False)
         if dobj:
-            outline(dobj, level + 1, file=file)
+            outline(dobj, level + (1 if not isinstance(dobj, WDL.Decl) else 0), file=file)
 
     # document
     if isinstance(obj, WDL.Document):

--- a/WDL/Expr.py
+++ b/WDL/Expr.py
@@ -439,7 +439,7 @@ def _retype(type_env: Env.Types, namespace: List[str], name: str, new_type: T.Ba
     for node in type_env:
         if isinstance(node, Env.Binding):
             if not namespace and name == node.name:
-                ans.append(Env.Binding(node.name, new_type))
+                ans.append(Env.Binding(node.name, new_type, node.ctx))
             else:
                 ans.append(node)
         elif isinstance(node, Env.Namespace):
@@ -562,6 +562,7 @@ class Ident(Base):
             except KeyError:
                 pass
             if isinstance(ans, T.Pair):
+                self.ctx = Env.resolve_ctx(type_env, pair_namespace, pair_name)
                 return ans.left_type if self.name == "left" else ans.right_type
         try:
             ans: T.Base = Env.resolve(type_env, self.namespace, self.name)

--- a/WDL/Lint.py
+++ b/WDL/Lint.py
@@ -316,9 +316,7 @@ class ForwardReference(Linter):
             if isinstance(obj.ctx, WDL.Decl):
                 msg = "reference to {} precedes its declaration".format(obj.name)
             elif isinstance(obj.ctx, WDL.Call):
-                msg = "reference to output of {} precedes the call".format(
-                    ".".join(obj.namespace)
-                )
+                msg = "reference to output of {} precedes the call".format(".".join(obj.namespace))
             else:
                 assert False
             self.add(getattr(obj, "parent"), msg, obj)

--- a/WDL/Lint.py
+++ b/WDL/Lint.py
@@ -331,7 +331,7 @@ class UnusedDeclaration(Linter):
         if not is_output and not uncalled and not getattr(obj, "referrers", []):
             self.add(obj, "nothing refers to " + obj.name)
 
-
+"""
 @a_linter
 class UnusedCall(Linter):
     _workflow_with_outputs: bool = False
@@ -349,3 +349,4 @@ class UnusedCall(Linter):
                 + obj.name
                 + " aren't output from the workflow nor otherwise used",
             )
+"""

--- a/WDL/Lint.py
+++ b/WDL/Lint.py
@@ -313,9 +313,14 @@ class ForwardReference(Linter):
                 or (obj.ctx.pos.line == obj.pos.line and obj.ctx.pos.column > obj.pos.column)
             )
         ):
-            msg = "identifier lexically precedes the referenced declaration"
-            if isinstance(obj.ctx, WDL.Call):
-                msg = "reference to call output lexically precedes the call"
+            if isinstance(obj.ctx, WDL.Decl):
+                msg = "reference to {} precedes its declaration".format(obj.name)
+            elif isinstance(obj.ctx, WDL.Call):
+                msg = "reference to output of {} precedes the call".format(
+                    ".".join(obj.namespace)
+                )
+            else:
+                assert False
             self.add(getattr(obj, "parent"), msg, obj)
         super().expr(obj)
 

--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -165,7 +165,6 @@ class Task(SourceNode):
             decl.typecheck(type_env)
         # TODO: detect circularities in output declarations
 
-
     @property
     def required_inputs(self) -> List[Decl]:
         return [
@@ -536,16 +535,18 @@ class Document(SourceNode):
                 )
             self.workflow.typecheck(self)
 
-def _detect_version(fn):
+
+def _detect_version(fn) -> str:
     # if the first line of the file is "version <number>", assume for now the
     # version is 1.0; otherwise draft-2
     with open(fn, "r") as infile:
         for line in infile:
-            if line.strip() and line[0] != '#':
+            if line.strip() and line[0] != "#":
                 if line.startswith("version ") and line[8].isdigit():
                     return "1.0"
                 return "draft-2"
     return "draft-2"
+
 
 def load(uri: str, path: List[str] = [], imported: Optional[bool] = False) -> Document:
     for fn in [uri] + [os.path.join(dn, uri) for dn in reversed(path)]:
@@ -669,7 +670,7 @@ def _arrayize_types(type_env: Env.Types) -> Env.Types:
     ans = []
     for node in type_env:
         if isinstance(node, Env.Binding):
-            ans.append(Env.Binding(node.name, T.Array(node.rhs)))
+            ans.append(Env.Binding(node.name, T.Array(node.rhs), node.ctx))
         elif isinstance(node, Env.Namespace):
             ans.append(Env.Namespace(node.namespace, _arrayize_types(node.bindings)))
         else:
@@ -684,7 +685,7 @@ def _optionalize_types(type_env: Env.Types) -> Env.Types:
     for node in type_env:
         if isinstance(node, Env.Binding):
             ty = node.rhs.copy(optional=True)
-            ans.append(Env.Binding(node.name, ty))
+            ans.append(Env.Binding(node.name, ty, node.ctx))
         elif isinstance(node, Env.Namespace):
             ans.append(Env.Namespace(node.namespace, _optionalize_types(node.bindings)))
         else:

--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -154,6 +154,9 @@ class Task(SourceNode):
         # TODO: detect circular dependencies among input & postinput decls
         # Typecheck the command (string)
         self.command.infer_type(type_env).typecheck(T.String())
+        # Typecheck runtime expressions
+        for _, runtime_expr in self.runtime.items():
+            runtime_expr.infer_type(type_env).typecheck(T.String())
         # Add output declarations to type environment
         for decl in self.outputs:
             type_env = decl.add_to_type_env(type_env)
@@ -161,7 +164,7 @@ class Task(SourceNode):
         for decl in self.outputs:
             decl.typecheck(type_env)
         # TODO: detect circularities in output declarations
-        # TODO: check runtime section
+
 
     @property
     def required_inputs(self) -> List[Decl]:

--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -541,7 +541,7 @@ def load(uri: str, path: List[str] = [], imported: Optional[bool] = False) -> Do
         if os.path.exists(fn):
             with open(fn, "r") as infile:
                 # read and parse the document
-                doc = WDL._parser.parse_document(infile.read(), uri, imported)
+                doc = WDL._parser.parse_document(infile.read(), uri=uri, imported=imported)
                 assert isinstance(doc, Document)
                 # recursively descend into document's imports, and store the imported
                 # documents into doc.imports

--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -536,25 +536,12 @@ class Document(SourceNode):
             self.workflow.typecheck(self)
 
 
-def _detect_version(fn) -> str:
-    # if the first line of the file is "version <number>", assume for now the
-    # version is 1.0; otherwise draft-2
-    with open(fn, "r") as infile:
-        for line in infile:
-            if line.strip() and line[0] != "#":
-                if line.startswith("version ") and line[8].isdigit():
-                    return "1.0"
-                return "draft-2"
-    return "draft-2"
-
-
 def load(uri: str, path: List[str] = [], imported: Optional[bool] = False) -> Document:
     for fn in [uri] + [os.path.join(dn, uri) for dn in reversed(path)]:
         if os.path.exists(fn):
-            version = _detect_version(fn)
             with open(fn, "r") as infile:
                 # read and parse the document
-                doc = WDL._parser.parse_document(infile.read(), version, uri, imported)
+                doc = WDL._parser.parse_document(infile.read(), uri, imported)
                 assert isinstance(doc, Document)
                 # recursively descend into document's imports, and store the imported
                 # documents into doc.imports

--- a/WDL/Walker.py
+++ b/WDL/Walker.py
@@ -81,12 +81,15 @@ class Base:
         for elt in obj.inputs + obj.postinputs:
             self(elt)
         self(obj.command)
+        for _, runtime_expr in obj.runtime.items():
+            self(runtime_expr)
         for elt in obj.outputs:
             self(elt)
-        # TODO: traverse runtime section
 
     def expr(self, obj: WDL.Expr.Base) -> Any:
         if isinstance(obj, WDL.Expr.Placeholder):
+#            if hasattr(obj.expr, 'name'):
+#                print(">>> " + obj.expr.name)
             self(obj.expr)
         elif isinstance(obj, WDL.Expr.String):
             for p in obj.parts:

--- a/WDL/Walker.py
+++ b/WDL/Walker.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, List
 import WDL
 
 
@@ -129,8 +129,9 @@ class SetParents(Base):
     On each Expr, the containing Decl, Call, Scatter, Conditional, or Task.
     """
 
+    _parent_stack: List[WDL.Error.SourceNode] = []
+
     def document(self, obj: WDL.Tree.Document) -> None:
-        self._parent_stack = []
         super().document(obj)
         obj.parent = None
         for _, _, subdoc in obj.imports:

--- a/WDL/Walker.py
+++ b/WDL/Walker.py
@@ -58,6 +58,9 @@ class Base:
     def workflow(self, obj: WDL.Tree.Workflow) -> Any:
         for elt in obj.elements:
             self(elt)
+        if obj.outputs:
+            for decl in obj.outputs or []:
+                self(decl)
 
     def call(self, obj: WDL.Tree.Call) -> Any:
         for _, expr in obj.inputs.items():
@@ -88,8 +91,6 @@ class Base:
 
     def expr(self, obj: WDL.Expr.Base) -> Any:
         if isinstance(obj, WDL.Expr.Placeholder):
-#            if hasattr(obj.expr, 'name'):
-#                print(">>> " + obj.expr.name)
             self(obj.expr)
         elif isinstance(obj, WDL.Expr.String):
             for p in obj.parts:
@@ -149,6 +150,8 @@ class SetParents(Base):
         obj.parent = None
         for elt in obj.elements:
             elt.parent = obj
+        for decl in obj.outputs or []:
+            decl.parent = obj
 
     def call(self, obj: WDL.Tree.Call) -> None:
         self._parent_stack.append(obj)

--- a/WDL/Walker.py
+++ b/WDL/Walker.py
@@ -197,6 +197,8 @@ class MarkCalled(Base):
     Mark each Task and Workflow with ``called : bool`` according to whether
     there exists a Call to it in the top-level workflow (or a subworkflow it
     calls). Requires SetParents to have been applied previously.
+
+    The top-level workflow is considered called.
     """
 
     marking: bool = False  # True while recursing from the top-level workflow
@@ -205,6 +207,7 @@ class MarkCalled(Base):
         obj.called = False
         if obj.parent.parent is None:  # pyre-ignore
             assert not self.marking
+            obj.called = True
             self.marking = True
             super().workflow(obj)
             self.marking = False

--- a/WDL/Walker.py
+++ b/WDL/Walker.py
@@ -199,3 +199,18 @@ class MarkCalled(Base):
 
     def task(self, obj: WDL.Tree.Task) -> None:
         obj.called = False
+
+
+class SetReferrers(Base):
+    """
+    Add ``referrers`` to each Decl and Call in all tasks and workflows.
+
+    It lists each Expr.Ident which uses the value (of a Decl) or any output of
+    the Call. The Expr.Ident instances may be in declarations, call inputs,
+    task commands, outputs, scatter arrays, if conditions.
+    """
+
+    def expr(self, obj: WDL.Expr.Base) -> None:
+        if isinstance(obj, WDL.Expr.Ident) and isinstance(obj.ctx, (WDL.Tree.Decl, WDL.Tree.Call)):
+            setattr(obj.ctx, "referrers", getattr(obj.ctx, "referrers", []) + [obj])
+        return super().expr(obj)

--- a/WDL/__init__.py
+++ b/WDL/__init__.py
@@ -28,7 +28,7 @@ def parse_document(txt: str, version: Optional[str] = None, uri: str = "") -> Do
 
     :param version: Override the WDL language version, such as "1.0" or
     "draft-2". (By default, detects from the "version" string at the beginning
-    of the document)
+    of the document, per the WDL spec.)
     :param uri: filename/URI for error reporting (not otherwise used)
     """
     return _parser.parse_document(txt, version, uri)

--- a/WDL/__init__.py
+++ b/WDL/__init__.py
@@ -2,7 +2,7 @@
 import os
 import errno
 import inspect
-from typing import List
+from typing import List, Optional
 from WDL import _parser, Error, Type, Value, Env, Expr, Tree, Walker, StdLib
 from WDL.Tree import Decl, Task, Call, Scatter, Conditional, Workflow, Document
 
@@ -21,22 +21,25 @@ def load(uri: str, path: List[str] = []) -> Document:
     return Tree.load(uri, path)
 
 
-def parse_document(txt: str, uri: str = "") -> Document:
+def parse_document(txt: str, version: Optional[str] = None, uri: str = "") -> Document:
     """
     Parse WDL document text into an abstract syntax tree. Doesn't descend into
     imported documents nor typecheck the AST.
 
+    :param version: Override the WDL language version, such as "1.0" or
+    "draft-2". (By default, detects from the "version" string at the beginning
+    of the document)
     :param uri: filename/URI for error reporting (not otherwise used)
     """
-    return _parser.parse_document(txt, uri)
+    return _parser.parse_document(txt, version, uri)
 
 
-def parse_expr(txt: str) -> Expr.Base:
+def parse_expr(txt: str, version: Optional[str] = None) -> Expr.Base:
     """
     Parse an isolated WDL expression text into an abstract syntax tree
     """
-    return _parser.parse_expr(txt)
+    return _parser.parse_expr(txt, version)
 
 
-def parse_tasks(txt: str) -> List[Task]:
-    return _parser.parse_tasks(txt)
+def parse_tasks(txt: str, version: Optional[str] = None) -> List[Task]:
+    return _parser.parse_tasks(txt, version)

--- a/WDL/_parser.py
+++ b/WDL/_parser.py
@@ -673,14 +673,6 @@ def parse_tasks(txt: str, version: Optional[str] = None) -> List[D.Task]:
 def parse_document(
     txt: str, version: Optional[str] = None, uri: str = "", imported: bool = False
 ) -> D.Document:
-    if not txt.strip():
-        return D.Document(
-            SourcePosition(filename=uri, line=0, column=0, end_line=0, end_column=0),
-            [],
-            [],
-            None,
-            imported,
-        )
     if version is None:
         # for now assume the version is 1.0 if the first line is "version <number>"
         # otherwise draft-2
@@ -691,6 +683,14 @@ def parse_document(
                 if line.startswith("version ") and line[8].isdigit():
                     version = "1.0"
                 break
+    if not txt.strip():
+        return D.Document(
+            SourcePosition(filename=uri, line=0, column=0, end_line=0, end_column=0),
+            [],
+            [],
+            None,
+            imported,
+        )
     try:
         return _DocTransformer(uri, imported).transform(parse(txt, "document", version))
     except lark.exceptions.UnexpectedCharacters as exn:

--- a/WDL/_parser.py
+++ b/WDL/_parser.py
@@ -214,6 +214,7 @@ COMMAND2_FRAGMENT: COMMAND2_CHAR* "~{"
 command2: "command" "<<<" [(COMMAND2_FRAGMENT placeholder "}")*] COMMAND2_END -> command
 """
 
+
 def _effective_version(version: Optional[str]) -> str:
     if version:
         version = version.strip()
@@ -226,12 +227,13 @@ def _effective_version(version: Optional[str]) -> str:
     # down here.
     return "1.0"
 
+
 def _grammar_for_version(version: str) -> str:
     if version == "draft-2":
         return common_grammar + commands_pre_1_0
-    if version == "1.0":
-        return common_grammar + commands_1_0
-    assert False
+    assert version == "1.0"
+    return common_grammar + commands_1_0
+
 
 # memoize Lark parsers constructed for version & start symbol
 _lark_cache = {}
@@ -683,7 +685,9 @@ def parse_tasks(txt: str, version: Optional[str] = None) -> List[D.Task]:
     return _DocTransformer("", False).transform(parse(txt, "tasks", version))
 
 
-def parse_document(txt: str, version: Optional[str] = None, uri: str = "", imported: bool = False) -> D.Document:
+def parse_document(
+    txt: str, version: Optional[str] = None, uri: str = "", imported: bool = False
+) -> D.Document:
     if not txt.strip():
         return D.Document(
             SourcePosition(filename=uri, line=0, column=0, end_line=0, end_column=0),

--- a/tests/test_1doc.py
+++ b/tests/test_1doc.py
@@ -768,5 +768,6 @@ class TestDoc(unittest.TestCase):
         """
         doc = WDL.parse_document(doc)
         doc.typecheck()
+        self.assertEqual(len(doc.tasks[0].command.parts), 5)
 
         # TODO: test circular reference

--- a/tests/test_1doc.py
+++ b/tests/test_1doc.py
@@ -276,6 +276,105 @@ class TestTasks(unittest.TestCase):
         self.assertIsInstance(task.meta['description'], WDL.Expr.String)
         self.assertEqual(task.meta['description'].parts, ["'", "it\\'s a task", "'"])
 
+    def test_compare_md5sums(self):
+        txt = """
+task compare_md5sum {
+	Array[String] labels
+	Array[File] files
+	Array[File] ref_files
+
+	command <<<
+		python <<CODE	
+		from collections import OrderedDict
+		import os
+		import json
+		import hashlib
+
+		def md5sum(filename, blocksize=65536):
+		    hash = hashlib.md5()
+		    with open(filename, 'rb') as f:
+		        for block in iter(lambda: f.read(blocksize), b""):
+		            hash.update(block)
+		    return hash.hexdigest()
+
+		with open('${write_lines(labels)}','r') as fp:
+			labels = fp.read().splitlines()
+		with open('${write_lines(files)}','r') as fp:
+			files = fp.read().splitlines()
+		with open('${write_lines(ref_files)}','r') as fp:
+			ref_files = fp.read().splitlines()
+
+		result = OrderedDict()
+		match = OrderedDict()
+		match_overall = True
+
+		result['tasks'] = []
+		result['failed_task_labels'] = []
+		result['succeeded_task_labels'] = []
+		for i, label in enumerate(labels):
+			f = files[i]
+			ref_f = ref_files[i]
+			md5 = md5sum(f)
+			ref_md5 = md5sum(ref_f)
+			# if text file, read in contents
+			if f.endswith('.qc') or f.endswith('.txt') or \
+				f.endswith('.log') or f.endswith('.out'):
+				with open(f,'r') as fp:
+					contents = fp.read()
+				with open(ref_f,'r') as fp:
+					ref_contents = fp.read()
+			else:
+				contents = ''
+				ref_contents = ''
+			matched = md5==ref_md5
+			result['tasks'].append(OrderedDict([
+				('label', label),
+				('match', matched),
+				('md5sum', md5),
+				('ref_md5sum', ref_md5),
+				('basename', os.path.basename(f)),
+				('ref_basename', os.path.basename(ref_f)),
+				('contents', contents),
+				('ref_contents', ref_contents),
+				]))
+			match[label] = matched
+			match_overall &= matched
+			if matched:
+				result['succeeded_task_labels'].append(label)
+			else:
+				result['failed_task_labels'].append(label)		
+		result['match_overall'] = match_overall
+
+		with open('result.json','w') as fp:
+			fp.write(json.dumps(result, indent=4))
+		match_tmp = []
+		for key in match:
+			val = match[key]
+			match_tmp.append('{}\t{}'.format(key, val))
+		with open('match.tsv','w') as fp:
+			fp.writelines('\n'.join(match_tmp))
+		with open('match_overall.txt','w') as fp:
+			fp.write(str(match_overall))
+		CODE
+	>>>
+	output {
+		Map[String,String] match = read_map('match.tsv') # key:label, val:match
+		Boolean match_overall = read_boolean('match_overall.txt')
+		File json = glob('result.json')[0] # details (json file)
+		String json_str = read_string('result.json') # details (string)
+	}
+	runtime {
+		cpu : 1
+		memory : "4000 MB"
+		time : 1
+		disks : "local-disk 50 HDD"		
+	}
+}
+"""
+        task = WDL.parse_tasks(txt, version="draft-2")[0]
+        task.typecheck()
+        self.assertEqual(len(task.command.parts), 7)
+
 
 class TestDoc(unittest.TestCase):
     def test_count_foo(self):
@@ -340,12 +439,12 @@ class TestDoc(unittest.TestCase):
             File bam
             Int num_chrom = 22
             command <<<
-            set -ex
-            samtools index ${bam}
-            mkdir slices/
-            for i in `seq ${num_chrom}`; do
-                samtools view -b ${bam} -o slices/$i.bam $i
-            done
+                set -ex
+                samtools index ${bam}
+                mkdir slices/
+                for i in `seq ${num_chrom}`; do
+                    samtools view -b ${bam} -o slices/$i.bam $i
+                done
             >>>
             runtime {
                 docker: "quay.io/ucsc_cgl/samtools"
@@ -369,12 +468,14 @@ class TestDoc(unittest.TestCase):
             }
         }
         """
-        doc = WDL.parse_document(doc)
+        doc = WDL.parse_document(doc, version="draft-2")
         self.assertIsInstance(doc.workflow, WDL.Tree.Workflow)
         self.assertEqual(len(doc.workflow.elements), 3)
         self.assertIsInstance(doc.workflow.elements[2], WDL.Tree.Scatter)
         self.assertEqual(len(doc.workflow.elements[2].elements), 1)
         self.assertEqual(len(doc.tasks), 2)
+        self.assertEqual(doc.tasks[0].name, "slice_bam")
+        self.assertEqual(len(doc.tasks[0].command.parts), 7)
         doc.typecheck()
 
     def test_nested_scatter(self):
@@ -457,6 +558,7 @@ class TestDoc(unittest.TestCase):
 
     def test_errors(self):
         doc = r"""
+        version 1.0
         task sum {
             Int x
             Int y
@@ -478,6 +580,7 @@ class TestDoc(unittest.TestCase):
             doc.typecheck()
 
         doc = r"""
+        version 1.0
         task sum {
             Int x
             Int y
@@ -538,6 +641,7 @@ class TestDoc(unittest.TestCase):
             doc.typecheck()
 
         doc = r"""
+        version 1.0
         task sum {
             Int x
             Int y
@@ -561,6 +665,7 @@ class TestDoc(unittest.TestCase):
             doc.typecheck()
 
         doc = r"""
+        version 1.0
         task sum {
             Int x
             Int y
@@ -580,6 +685,7 @@ class TestDoc(unittest.TestCase):
             doc.typecheck()
 
         doc = r"""
+        version 1.0
         task sum {
             Int x
             Int y
@@ -599,6 +705,7 @@ class TestDoc(unittest.TestCase):
             doc.typecheck()
 
         doc = r"""
+        version 1.0
         task sum {
             Int x
             Int y
@@ -645,6 +752,7 @@ class TestDoc(unittest.TestCase):
 
     def test_task_forward_reference(self):
         doc = r"""
+        version 1.0
         task sum {
             input {
                 Int x = y

--- a/tests/test_3corpi.py
+++ b/tests/test_3corpi.py
@@ -45,7 +45,7 @@ def check_lint(cls):
 
 @test_corpus(
     ["test_corpi/HumanCellAtlas/skylab/library/tasks/**"],
-    expected_lint={'StringCoercion': 3}
+    expected_lint={'StringCoercion': 3, 'UnusedDeclaration': 1}
 )
 class HCAskylab_task(unittest.TestCase):
     pass
@@ -82,7 +82,7 @@ class gatk4_germline_snps_indels(unittest.TestCase):
 
 @test_corpus(
     ["test_corpi/gatk-workflows/gatk4-somatic-snvs-indels/**"],
-    expected_lint={'UnusedDeclaration': 30, 'ForwardReference': 6, 'StringCoercion': 20},
+    expected_lint={'UnusedDeclaration': 29, 'ForwardReference': 6, 'StringCoercion': 20},
 )
 class gatk4_somatic_snvs_indels(unittest.TestCase):
     pass
@@ -109,7 +109,7 @@ class GTEx(unittest.TestCase):
     # need URI import
     blacklist=['CRAM_md5sum_checker_wrapper', 'checker-workflow-wrapping-alignment-workflow',
                 'topmed_freeze3_calling', 'topmed_freeze3_calling_checker', 'u_of_michigan_aligner_checker'],
-    expected_lint={'StringCoercion': 26, 'UnusedDeclaration': 22}
+    expected_lint={'StringCoercion': 26, 'UnusedDeclaration': 74}
 )
 class TOPMed(unittest.TestCase):
     pass
@@ -117,7 +117,7 @@ class TOPMed(unittest.TestCase):
 @test_corpus(
     ["test_corpi/broadinstitute/viral-ngs/pipes/WDL/workflows"],
     path=[["test_corpi/broadinstitute/viral-ngs/pipes/WDL/workflows/tasks"]],
-    expected_lint={'UnusedDeclaration': 8, 'IncompleteCall': 44, 'UnusedImport': 1}
+    expected_lint={'UnusedDeclaration': 23, 'IncompleteCall': 44, 'UnusedImport': 1}
 )
 class ViralNGS(unittest.TestCase):
     pass
@@ -162,7 +162,7 @@ class ENCODE_WGBS(unittest.TestCase):
         # double quantifier
         "conditionals_base"
     ],
-    expected_lint={'UnusedDeclaration': 14, 'UnusedCall': 15}
+    expected_lint={'UnusedDeclaration': 20, 'UnusedCall': 15}
 )
 class dxWDL(unittest.TestCase):
     pass

--- a/tests/test_3corpi.py
+++ b/tests/test_3corpi.py
@@ -53,7 +53,7 @@ class HCAskylab_task(unittest.TestCase):
 @test_corpus(
     ["test_corpi/HumanCellAtlas/skylab/pipelines/**"],
     path=[["test_corpi/HumanCellAtlas/skylab/library/tasks"]],
-    expected_lint={'CallImportNameCollision': 1, 'StringCoercion': 3}
+    expected_lint={'UnusedDeclaration': 15, 'CallImportNameCollision': 1, 'StringCoercion': 3}
 )
 class HCAskylab_workflow(unittest.TestCase):
     pass
@@ -64,7 +64,7 @@ class HCAskylab_workflow(unittest.TestCase):
     # when it itself is in ./tasks_pipelines
     path=[["test_corpi/gatk-workflows/five-dollar-genome-analysis-pipeline"]],
     blacklist=['fc_germline_single_sample_workflow'],
-    expected_lint={'CallImportNameCollision': 2, 'ArrayCoercion': 4, 'StringCoercion': 5}
+    expected_lint={'StringCoercion': 11, 'UnusedDeclaration': 4, 'CallImportNameCollision': 2, 'ArrayCoercion': 4}
 )
 class GATK_five_dollar(unittest.TestCase):
     pass
@@ -75,14 +75,14 @@ class GATK_five_dollar(unittest.TestCase):
     # https://github.com/gatk-workflows/gatk4-germline-snps-indels/blob/b9bbbdcfca7ece0d011ac1225ce6818b33720f48/joint-discovery-gatk4-local.wdl#L345
     # also needed for the CNN variant filter repo.
     blacklist=['joint-discovery-gatk4-local', 'joint-discovery-gatk4'],
-    expected_lint={'StringCoercion': 2}
+    expected_lint={'UnusedDeclaration': 1, 'StringCoercion': 2},
 )
 class gatk4_germline_snps_indels(unittest.TestCase):
     pass
 
 @test_corpus(
     ["test_corpi/gatk-workflows/gatk4-somatic-snvs-indels/**"],
-    expected_lint= {'ForwardReference': 3, 'StringCoercion': 20},
+    expected_lint={'UnusedDeclaration': 30, 'ForwardReference': 6, 'StringCoercion': 20},
 )
 class gatk4_somatic_snvs_indels(unittest.TestCase):
     pass
@@ -90,7 +90,7 @@ class gatk4_somatic_snvs_indels(unittest.TestCase):
 @test_corpus(
     ["test_corpi/gatk-workflows/broad-prod-wgs-germline-snps-indels/**"],
     blacklist=['JointGenotypingWf'],
-    expected_lint={'ArrayCoercion': 4, 'StringCoercion': 6}
+    expected_lint={'StringCoercion': 48, 'UnusedDeclaration': 10, 'ArrayCoercion': 4}
 )
 class broad_prod_wgs(unittest.TestCase):
     pass
@@ -99,7 +99,7 @@ class broad_prod_wgs(unittest.TestCase):
     ["test_corpi/broadinstitute/gtex-pipeline/**"],
     # need URI import
     blacklist=["rnaseq_pipeline_bam","rnaseq_pipeline_fastq"],
-    expected_lint={'IncompleteCall': 30}
+    expected_lint={'IncompleteCall': 30, 'UnusedDeclaration': 3}
 )
 class GTEx(unittest.TestCase):
     pass
@@ -109,7 +109,7 @@ class GTEx(unittest.TestCase):
     # need URI import
     blacklist=['CRAM_md5sum_checker_wrapper', 'checker-workflow-wrapping-alignment-workflow',
                 'topmed_freeze3_calling', 'topmed_freeze3_calling_checker', 'u_of_michigan_aligner_checker'],
-    expected_lint={'StringCoercion': 2}
+    expected_lint={'StringCoercion': 26, 'UnusedDeclaration': 22}
 )
 class TOPMed(unittest.TestCase):
     pass
@@ -117,7 +117,7 @@ class TOPMed(unittest.TestCase):
 @test_corpus(
     ["test_corpi/broadinstitute/viral-ngs/pipes/WDL/workflows"],
     path=[["test_corpi/broadinstitute/viral-ngs/pipes/WDL/workflows/tasks"]],
-    expected_lint={'IncompleteCall': 44, 'UnusedImport': 1}
+    expected_lint={'UnusedDeclaration': 8, 'IncompleteCall': 44, 'UnusedImport': 1}
 )
 class ViralNGS(unittest.TestCase):
     pass
@@ -145,7 +145,7 @@ class ENCODE_RNAseq(unittest.TestCase):
 
 @test_corpus(
     ["test_corpi/ENCODE-DCC/wgbs-pipeline/**"],
-    expected_lint={'StringCoercion': 9, 'UnusedDeclaration': 4}
+    expected_lint={'StringCoercion': 9, 'UnusedDeclaration': 1}
 )
 class ENCODE_WGBS(unittest.TestCase):
     pass
@@ -161,7 +161,8 @@ class ENCODE_WGBS(unittest.TestCase):
         "movie", "foo_toplevel", "foo_if_flag", "foo",
         # double quantifier
         "conditionals_base"
-    ]
+    ],
+    expected_lint={'UnusedDeclaration': 14}
 )
 class dxWDL(unittest.TestCase):
     pass

--- a/tests/test_3corpi.py
+++ b/tests/test_3corpi.py
@@ -124,28 +124,28 @@ class ViralNGS(unittest.TestCase):
 
 @test_corpus(
      ["test_corpi/ENCODE-DCC/chip-seq-pipeline2/**"],
-     expected_lint={'StringCoercion': 48, 'ArrayCoercion': 64}
+     expected_lint={'StringCoercion': 192, 'ArrayCoercion': 64}
 )
 class ENCODE_ChIPseq(unittest.TestCase):
     pass
 
 @test_corpus(
      ["test_corpi/ENCODE-DCC/atac-seq-pipeline/**"],
-     expected_lint={'StringCoercion': 52, 'ArrayCoercion': 41}
+     expected_lint={'StringCoercion': 156, 'ArrayCoercion': 41}
 )
 class ENCODE_ATACseq(unittest.TestCase):
     pass
 
 @test_corpus(
     ["test_corpi/ENCODE-DCC/rna-seq-pipeline/**"],
-    expected_lint={'IncompleteCall': 3}
+    expected_lint={'StringCoercion': 2, 'UnusedDeclaration': 3, 'IncompleteCall': 3}
 )
 class ENCODE_RNAseq(unittest.TestCase):
     pass
 
 @test_corpus(
     ["test_corpi/ENCODE-DCC/wgbs-pipeline/**"],
-    expected_lint={'StringCoercion': 1}
+    expected_lint={'StringCoercion': 9, 'UnusedDeclaration': 4}
 )
 class ENCODE_WGBS(unittest.TestCase):
     pass

--- a/tests/test_3corpi.py
+++ b/tests/test_3corpi.py
@@ -64,7 +64,7 @@ class HCAskylab_workflow(unittest.TestCase):
     # when it itself is in ./tasks_pipelines
     path=[["test_corpi/gatk-workflows/five-dollar-genome-analysis-pipeline"]],
     blacklist=['fc_germline_single_sample_workflow'],
-    expected_lint={'StringCoercion': 11, 'UnusedDeclaration': 4, 'CallImportNameCollision': 2, 'ArrayCoercion': 4}
+    expected_lint={'StringCoercion': 11, 'UnusedDeclaration': 4, 'CallImportNameCollision': 2, 'ArrayCoercion': 4, 'UnusedCall': 1}
 )
 class GATK_five_dollar(unittest.TestCase):
     pass
@@ -90,7 +90,7 @@ class gatk4_somatic_snvs_indels(unittest.TestCase):
 @test_corpus(
     ["test_corpi/gatk-workflows/broad-prod-wgs-germline-snps-indels/**"],
     blacklist=['JointGenotypingWf'],
-    expected_lint={'StringCoercion': 48, 'UnusedDeclaration': 10, 'ArrayCoercion': 4}
+    expected_lint={'StringCoercion': 48, 'UnusedDeclaration': 10, 'ArrayCoercion': 4, 'UnusedCall': 2}
 )
 class broad_prod_wgs(unittest.TestCase):
     pass
@@ -131,7 +131,7 @@ class ENCODE_ChIPseq(unittest.TestCase):
 
 @test_corpus(
      ["test_corpi/ENCODE-DCC/atac-seq-pipeline/**"],
-     expected_lint={'StringCoercion': 156, 'ArrayCoercion': 41}
+     expected_lint={'StringCoercion': 156, 'ArrayCoercion': 41, 'UnusedCall': 1}
 )
 class ENCODE_ATACseq(unittest.TestCase):
     pass
@@ -162,7 +162,7 @@ class ENCODE_WGBS(unittest.TestCase):
         # double quantifier
         "conditionals_base"
     ],
-    expected_lint={'UnusedDeclaration': 14}
+    expected_lint={'UnusedDeclaration': 14, 'UnusedCall': 15}
 )
 class dxWDL(unittest.TestCase):
     pass


### PR DESCRIPTION
**UnusedDeclaration:** a (non-output) value is declared, but not subsequently used in the task/workflow.
**UnusedCall:** the outputs of a call within a workflow are neither outputs from the workflow, nor used by anything else in the workflow.

In the process of developing these, we realized that the task commands in many draft-2 WDLs were not being parsed as expected (specifically, `${ }` delimited placeholders were ignored within `<<< >>>` delimited commands, which are indeed not recognized as placeholders in WDL 1.0). To address this, we introduce a rudimentary way to serve different grammar versions, and detect the version from the document header, if any. The mechanism will need more polishing.

Typecheck task runtime section.

Fix several bugs and omissions in the AST, Walker, etc.