### PR TITLE
Walker/Linter refactoring

### DIFF
--- a/WDL/Error.py
+++ b/WDL/Error.py
@@ -1,5 +1,5 @@
 # pyre-strict
-from typing import List, Optional, NamedTuple, Union, Iterable
+from typing import List, Optional, NamedTuple, Union, Iterable, TypeVar
 from functools import total_ordering
 import WDL.Type as T
 
@@ -22,6 +22,8 @@ SourcePosition = NamedTuple(
     [("filename", str), ("line", int), ("column", int), ("end_line", int), ("end_column", int)],
 )
 """Source file, line, and column, attached to each AST node"""
+
+TVSourceNode = TypeVar("TVSourceNode", bound="SourceNode")
 
 
 @total_ordering
@@ -53,6 +55,15 @@ class SourceNode:
 
     def __eq__(self, rhs) -> bool:
         return self.pos == rhs.pos
+
+    @property
+    def children(self: TVSourceNode) -> Iterable[TVSourceNode]:
+        """
+        :type: Iterable[SourceNode]
+
+        Yield all child nodes
+        """
+        return []
 
 
 class Base(Exception):

--- a/WDL/Walker.py
+++ b/WDL/Walker.py
@@ -46,75 +46,33 @@ class Base:
             return self.expr(obj)
         assert False
 
+    def _descend(self, obj: WDL.Error.SourceNode) -> Any:
+        for ch in obj.children:
+            self(ch)
+
     def document(self, obj: WDL.Tree.Document) -> Any:
-        for _, _, subdoc in obj.imports:
-            assert isinstance(subdoc, WDL.Tree.Document)
-            self(subdoc)
-        for task in obj.tasks:
-            self(task)
-        if obj.workflow:
-            self(obj.workflow)
+        self._descend(obj)
 
     def workflow(self, obj: WDL.Tree.Workflow) -> Any:
-        for elt in obj.elements:
-            self(elt)
-        if obj.outputs:
-            for decl in obj.outputs or []:
-                self(decl)
+        self._descend(obj)
 
     def call(self, obj: WDL.Tree.Call) -> Any:
-        for _, expr in obj.inputs.items():
-            self(expr)
+        self._descend(obj)
 
     def scatter(self, obj: WDL.Tree.Scatter) -> Any:
-        self(obj.expr)
-        for elt in obj.elements:
-            self(elt)
+        self._descend(obj)
 
     def conditional(self, obj: WDL.Tree.Conditional) -> Any:
-        self(obj.expr)
-        for elt in obj.elements:
-            self(elt)
+        self._descend(obj)
 
     def decl(self, obj: WDL.Tree.Decl) -> Any:
-        if obj.expr:
-            self(obj.expr)
+        self._descend(obj)
 
     def task(self, obj: WDL.Tree.Task) -> Any:
-        for elt in obj.inputs + obj.postinputs:
-            self(elt)
-        self(obj.command)
-        for _, runtime_expr in obj.runtime.items():
-            self(runtime_expr)
-        for elt in obj.outputs:
-            self(elt)
+        self._descend(obj)
 
     def expr(self, obj: WDL.Expr.Base) -> Any:
-        if isinstance(obj, WDL.Expr.Placeholder):
-            self(obj.expr)
-        elif isinstance(obj, WDL.Expr.String):
-            for p in obj.parts:
-                if isinstance(p, WDL.Expr.Base):
-                    self(p)
-        elif isinstance(obj, WDL.Expr.Array):
-            for elt in obj.items:
-                self(elt)
-        elif isinstance(obj, WDL.Expr.IfThenElse):
-            self(obj.condition)
-            self(obj.consequent)
-            self(obj.alternative)
-        elif isinstance(obj, WDL.Expr.Apply):
-            for elt in obj.arguments:
-                self(elt)
-        elif isinstance(obj, WDL.Expr.Pair):
-            self(obj.left)
-            self(obj.right)
-        elif isinstance(obj, WDL.Expr.Map):
-            for k, v in obj.items.items():
-                self(k)
-                self(v)
-        else:
-            pass
+        self._descend(obj)
 
 
 class SetParents(Base):

--- a/tests/test_3corpi.py
+++ b/tests/test_3corpi.py
@@ -135,7 +135,7 @@ class ENCODE_ChIPseq(unittest.TestCase):
 
 @test_corpus(
      ["test_corpi/ENCODE-DCC/atac-seq-pipeline/**"],
-     expected_lint={'StringCoercion': 182, 'ArrayCoercion': 41, 'OptionalCoercion': 26, 'UnusedCall': 1}
+     expected_lint={'StringCoercion': 182, 'ArrayCoercion': 41, 'OptionalCoercion': 26, 'UnusedCall': 13}
 )
 class ENCODE_ATACseq(unittest.TestCase):
     pass

--- a/tests/test_3corpi.py
+++ b/tests/test_3corpi.py
@@ -128,21 +128,21 @@ class ViralNGS(unittest.TestCase):
 
 @test_corpus(
      ["test_corpi/ENCODE-DCC/chip-seq-pipeline2/**"],
-     expected_lint={'StringCoercion': 192, 'NameCollision': 16, 'ArrayCoercion': 64, 'OptionalCoercion': 64},
+     expected_lint={'StringCoercion': 224, 'NameCollision': 16, 'ArrayCoercion': 64, 'OptionalCoercion': 64},
 )
 class ENCODE_ChIPseq(unittest.TestCase):
     pass
 
 @test_corpus(
      ["test_corpi/ENCODE-DCC/atac-seq-pipeline/**"],
-     expected_lint={'StringCoercion': 156, 'ArrayCoercion': 41, 'OptionalCoercion': 26, 'UnusedCall': 1}
+     expected_lint={'StringCoercion': 182, 'ArrayCoercion': 41, 'OptionalCoercion': 26, 'UnusedCall': 1}
 )
 class ENCODE_ATACseq(unittest.TestCase):
     pass
 
 @test_corpus(
     ["test_corpi/ENCODE-DCC/rna-seq-pipeline/**"],
-    expected_lint={'StringCoercion': 2, 'UnusedDeclaration': 3, 'IncompleteCall': 3}
+    expected_lint={'StringCoercion': 6, 'UnusedDeclaration': 3, 'IncompleteCall': 3}
 )
 class ENCODE_RNAseq(unittest.TestCase):
     pass


### PR DESCRIPTION
* add `children` property to all AST nodes, which will be useful for several reasons
* streamline & speed up Walker/Linter, using `children` to simplify code and reduce duplicate traversals
* simplify & correct UnusedCall linter