### PR TITLE
recognize deprecated workflow outputs syntax with identifiers and wildcards

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,3 +37,6 @@
 [submodule "test_corpi/gatk-workflows/gatk4-somatic-snvs-indels"]
 	path = test_corpi/gatk-workflows/gatk4-somatic-snvs-indels
 	url = https://github.com/gatk-workflows/gatk4-somatic-snvs-indels.git
+[submodule "test_corpi/gatk-workflows/gatk4-cnn-variant-filter"]
+	path = test_corpi/gatk-workflows/gatk4-cnn-variant-filter
+	url = https://github.com/gatk-workflows/gatk4-cnn-variant-filter.git

--- a/WDL/Lint.py
+++ b/WDL/Lint.py
@@ -119,11 +119,13 @@ class StringCoercion(Linter):
                     if isinstance(arg.type, WDL.Type.String):
                         any_string = True
                     elif not isinstance(arg.type, WDL.Type.File):
-                        all_string = False
-                if any_string and not all_string and not isinstance(pt, WDL.Task):
+                        all_string = arg.type
+                if any_string and all_string is not True and not isinstance(pt, WDL.Task):
                     # exception when parent is Task (i.e. we're in the task
                     # command) because the coercion is probably intentional
-                    self.add(pt, "string concatenation (+) has non-String argument", obj)
+                    self.add(
+                        pt, "string concatenation (+) has {} argument".format(str(all_string)), obj
+                    )
             else:
                 F = WDL.Expr._stdlib[obj.function_name]
                 if isinstance(F, WDL.StdLib._StaticFunction):

--- a/WDL/StdLib.py
+++ b/WDL/StdLib.py
@@ -198,6 +198,7 @@ _static_functions: List[Tuple[str, List[T.Base], T.Base, Any]] = [
     # note: size() can take an empty value and probably returns 0 in that case.
     #       e.g. https://github.com/DataBiosphere/topmed-workflows/blob/31ba8a714b36ada929044f2ba3d130936e6c740e/CRAM-no-header-md5sum/md5sum/CRAM_md5sum.wdl#L39
     ("size", [T.File(optional=True), T.String(optional=True)], T.Float(), _notimpl),
+    ("floor", [T.Float()], T.Int(), _notimpl),
     ("ceil", [T.Float()], T.Int(), _notimpl),
     ("round", [T.Float()], T.Int(), _notimpl),
     ("glob", [T.String()], T.Array(T.File()), _notimpl),

--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -432,14 +432,8 @@ class Workflow(SourceNode):
     outputs: Optional[List[Decl]]
     """:type: Optional[List[Decl]]
 
-    Workflow outputs, if the ``output{}`` stanza is present"""
-    output_idents: Optional[List[E.Ident]]
-    """:type: Optional[List[WDL.Expr.Ident]]
-
-    Workflow outputs specified in an old style predating WDL 1.0 (specifying
-    just identifiers instead of complete ``Decl``s. During typechecking,
-    ``outputs`` is populated with synthetic ``Decl``s including these
-    identifiers; thus, it's usually not necessary to use this property."""
+    Workflow outputs, if the ``output{}`` section is present"""
+    _output_idents: Optional[List[E.Ident]]
     parameter_meta: Dict[str, Any]
     """
     :type: Dict[str,Any]
@@ -474,7 +468,7 @@ class Workflow(SourceNode):
         self.name = name
         self.elements = elements
         self.outputs = outputs
-        self.output_idents = output_idents
+        self._output_idents = output_idents
         self.parameter_meta = parameter_meta
         self.meta = meta
 
@@ -521,12 +515,12 @@ class Workflow(SourceNode):
                 output_names.add(output.name)
 
     def _rewrite_output_idents(self) -> None:
-        if self.output_idents:
+        if self._output_idents:
             assert self.outputs is not None
 
             # for each listed identifier, formulate a synthetic declaration
             output_ident_decls = []
-            for output_idents in self.output_idents:
+            for output_idents in self._output_idents:
                 output_idents = [output_idents]
 
                 if output_idents[0].name == "*":
@@ -560,7 +554,7 @@ class Workflow(SourceNode):
 
             # put the synthetic declarations into self.outputs
             self.outputs = output_ident_decls + self.outputs  # pyre-fixme
-            self.output_idents = None
+            self._output_idents = None
 
 
 class Document(SourceNode):

--- a/WDL/_parser.py
+++ b/WDL/_parser.py
@@ -201,8 +201,8 @@ command2: "command" "<<<" [(COMMAND2_FRAGMENT placeholder "}")*] COMMAND2_END ->
 
 ?workflow_outputs: "output" "{" workflow_output_decls "}"
 workflow_output_decls: [workflow_output_decl*]
-?workflow_output_decl: bound_decl
-                     | ident
+?workflow_output_decl: bound_decl | ident | workflow_wildcard_output
+workflow_wildcard_output: ident "." "*" | ident ".*"
 """
 
 # 1.0+ productions:
@@ -582,6 +582,10 @@ class _DocTransformer(_ExprTransformer, _TypeTransformer):
 
     def conditional(self, items, meta):
         return D.Conditional(sp(self.filename, meta), items[0], items[1:])
+
+    def workflow_wildcard_output(self, items, meta):
+        assert isinstance(items[0], E.Ident)
+        return E.Ident(items[0].pos, items[0].namespace + [items[0].name, "*"])
 
     def workflow_output_decls(self, items, meta):
         decls = [elt for elt in items if isinstance(elt, D.Decl)]

--- a/tests/test_1doc.py
+++ b/tests/test_1doc.py
@@ -832,6 +832,16 @@ class TestDoc(unittest.TestCase):
             doc.typecheck()
 
         doc = WDL.parse_document("""
+            workflow bogus {
+                output {
+                    nonex.*
+                }
+            }
+        """)
+        with self.assertRaises(WDL.Error.UnknownIdentifier):
+            doc.typecheck()
+
+        doc = WDL.parse_document("""
             task sum {
                 Int x
                 Int y

--- a/tests/test_1doc.py
+++ b/tests/test_1doc.py
@@ -954,7 +954,8 @@ class TestDoc(unittest.TestCase):
             }
         """)
         doc.typecheck()
-        self.assertEqual(len(set(decl.name for decl in doc.workflow.outputs)), 4)
+        self.assertEqual(set(decl.name for decl in doc.workflow.outputs),
+                         set(["adder.w", "adder.z", "sum.w", "sum.z"]))
 
         doc = WDL.parse_document("""
             task sum {

--- a/tests/test_3corpi.py
+++ b/tests/test_3corpi.py
@@ -20,7 +20,7 @@ def test_corpus(dir, path=[], blacklist=[], expected_lint={}, check_quant=True):
             if name not in blacklist:
                 name = "test_" + prefix + "_" + name.replace('.', '_')
                 def t(self, fn=fn):
-                    # run the 'miniwd check' command-line tool
+                    # run the 'miniwdl check' command-line tool
                     cmd = ['check']
                     for dn in gpath:
                         cmd.append('--path')
@@ -85,6 +85,15 @@ class gatk4_germline_snps_indels(unittest.TestCase):
 )
 class gatk4_somatic_snvs_indels(unittest.TestCase):
     pass
+
+@test_corpus(
+    ["test_corpi/gatk-workflows/gatk4-cnn-variant-filter/**"],
+    expected_lint={'UnusedDeclaration': 21, 'OptionalCoercion': 23, 'StringCoercion': 3, 'UnusedCall': 1},
+    check_quant=False,
+)
+class gatk4_cnn_variant_filter(unittest.TestCase):
+    pass
+
 
 @test_corpus(
     ["test_corpi/gatk-workflows/broad-prod-wgs-germline-snps-indels/**"],

--- a/tests/test_3corpi.py
+++ b/tests/test_3corpi.py
@@ -65,7 +65,7 @@ class HCAskylab_workflow(unittest.TestCase):
     # path is needed expressly here as a wdl imports from "./tasks_pipelines/import.wdl"
     # when it itself is in ./tasks_pipelines
     path=[["test_corpi/gatk-workflows/five-dollar-genome-analysis-pipeline"]],
-    blacklist=['fc_germline_single_sample_workflow'],
+    blacklist=['fc_germline_single_sample_workflow'], # uses URI import
     expected_lint={'StringCoercion': 11, 'UnusedDeclaration': 4, 'NameCollision': 2, 'ArrayCoercion': 4, 'UnusedCall': 1}
 )
 class GATK_five_dollar(unittest.TestCase):
@@ -73,11 +73,7 @@ class GATK_five_dollar(unittest.TestCase):
 
 @test_corpus(
     ["test_corpi/gatk-workflows/gatk4-germline-snps-indels/**"],
-    # TODO: support pre-1.0 style of workflow outputs (identifiers and wildcards)
-    # https://github.com/gatk-workflows/gatk4-germline-snps-indels/blob/b9bbbdcfca7ece0d011ac1225ce6818b33720f48/joint-discovery-gatk4-local.wdl#L345
-    # also needed for the CNN variant filter repo.
-    blacklist=['joint-discovery-gatk4-local', 'joint-discovery-gatk4'],
-    expected_lint={'UnusedDeclaration': 1, 'StringCoercion': 2},
+    expected_lint={'UnusedDeclaration': 3, 'StringCoercion': 15}
 )
 class gatk4_germline_snps_indels(unittest.TestCase):
     pass
@@ -161,12 +157,12 @@ class ENCODE_WGBS(unittest.TestCase):
         "cast","complex","decl_mid_wf","dict","library_math","math","math2","optionals","toplevel_calls","trivial","trivial2",
         # use dnanexus extensions
         "call_native", "call_native_app",
-        # pre-1.0 style outputs
-        "movie", "foo_toplevel", "foo_if_flag", "foo",
+        # circular imports
+        "foo_toplevel", "foo_if_flag",
         # double quantifier
         "conditionals_base"
     ],
-    expected_lint={'UnusedDeclaration': 20, 'UnusedCall': 15, 'NameCollision': 2, 'OptionalCoercion': 1},
+    expected_lint={'UnusedDeclaration': 22, 'UnusedCall': 15, 'NameCollision': 2, 'OptionalCoercion': 1},
     check_quant=False,
 )
 class dxWDL(unittest.TestCase):


### PR DESCRIPTION
Handle the deprecated, pre-1.0 style of specifying workflow outputs with just a namespaced identifier (referring to a call output) instead of a full declaration, or with a wildcard denoting all outputs from a call. We handle these with an AST rewrite into modern-style declarations during typechecking. The new productions exist only in the pre-1.0 version of the grammar.

Accepts a few previously blacklisted workflows and gatk4-cnn-variant-filter in the test corpi

Checks for duplicate output names