### PR TITLE
typecheck quantifiers in composite types

### DIFF
--- a/WDL/Expr.py
+++ b/WDL/Expr.py
@@ -78,14 +78,8 @@ class Base(SourceNode, ABC):
         :raise WDL.Error.StaticTypeMismatch:
         :return: `self`
         """
-        expected2 = expected
-        if not self._check_quant:
-            if isinstance(expected, T.Array):
-                expected2 = expected.copy(nonempty=False, optional=True)
-            else:
-                expected2 = expected.copy(optional=True)
-        if not self.type.coerces(expected2):
-            raise Error.StaticTypeMismatch(self, expected2, self.type)
+        if not self.type.coerces(expected, self._check_quant):
+            raise Error.StaticTypeMismatch(self, expected, self.type)
         return self
 
     @abstractmethod

--- a/test_corpi/contrived/check_quant.wdl
+++ b/test_corpi/contrived/check_quant.wdl
@@ -3,5 +3,7 @@ import "contrived.wdl"
 workflow bs {
     Int? x
     Int y = x
+    Array[Int] a = [x]
+    Array[String]+ a2 = [x]
     call contrived.contrived
 }

--- a/test_corpi/contrived/contrived.wdl
+++ b/test_corpi/contrived/contrived.wdl
@@ -14,7 +14,7 @@ workflow contrived {
     call popular { input:
         popular = popular,
         i = contrived,
-        y = contrived
+        y = select_first([contrived,23])
     }
     call popular as contrived { input:
         popular = 123

--- a/tests/test_2calls.py
+++ b/tests/test_2calls.py
@@ -100,6 +100,33 @@ class TestCalls(unittest.TestCase):
         doc = WDL.parse_document(txt)
         doc.typecheck(check_quant=False)
 
+        txt = tsk + r"""
+        workflow contrived {
+            Int? x = 0
+            String? s = "foo"
+            Pair[Int,String] p = (x,s)
+        }
+        """
+        doc = WDL.parse_document(txt)
+        with self.assertRaises(WDL.Error.StaticTypeMismatch):
+            doc.typecheck()
+        doc = WDL.parse_document(txt)
+        doc.typecheck(check_quant=False)
+
+        txt = tsk + r"""
+        workflow contrived {
+            Int? x = 0
+            Array[Int] y = [x]
+        }
+        """
+        doc = WDL.parse_document(txt)
+        with self.assertRaises(WDL.Error.StaticTypeMismatch):
+            doc.typecheck()
+        doc = WDL.parse_document(txt)
+        doc.typecheck(check_quant=False)
+
+        # TODO: test quant checking in Map & other composite types
+
     def test_nonempty(self):
         txt = r"""
         task p {

--- a/tests/test_3corpi.py
+++ b/tests/test_3corpi.py
@@ -80,7 +80,7 @@ class gatk4_germline_snps_indels(unittest.TestCase):
 
 @test_corpus(
     ["test_corpi/gatk-workflows/gatk4-somatic-snvs-indels/**"],
-    expected_lint={'OptionalCoercion': 50, 'UnusedDeclaration': 29, 'ForwardReference': 6, 'NonemptyArrayCoercion': 4, 'StringCoercion': 20},
+    expected_lint={'QuantityCoercion': 54, 'UnusedDeclaration': 29, 'ForwardReference': 6, 'StringCoercion': 20},
     check_quant=False,
 )
 class gatk4_somatic_snvs_indels(unittest.TestCase):
@@ -88,7 +88,7 @@ class gatk4_somatic_snvs_indels(unittest.TestCase):
 
 @test_corpus(
     ["test_corpi/gatk-workflows/gatk4-cnn-variant-filter/**"],
-    expected_lint={'UnusedDeclaration': 21, 'OptionalCoercion': 23, 'StringCoercion': 3, 'UnusedCall': 1},
+    expected_lint={'UnusedDeclaration': 21, 'QuantityCoercion': 23, 'StringCoercion': 3, 'UnusedCall': 1},
     check_quant=False,
 )
 class gatk4_cnn_variant_filter(unittest.TestCase):
@@ -117,7 +117,7 @@ class GTEx(unittest.TestCase):
     # need URI import
     blacklist=['CRAM_md5sum_checker_wrapper', 'checker-workflow-wrapping-alignment-workflow',
                 'topmed_freeze3_calling', 'topmed_freeze3_calling_checker', 'u_of_michigan_aligner_checker'],
-    expected_lint={'StringCoercion': 26, 'UnusedDeclaration': 74, 'OptionalCoercion': 1},
+    expected_lint={'StringCoercion': 26, 'UnusedDeclaration': 74, 'QuantityCoercion': 1},
     check_quant=False,
 )
 class TOPMed(unittest.TestCase):
@@ -132,15 +132,17 @@ class ViralNGS(unittest.TestCase):
     pass
 
 @test_corpus(
-     ["test_corpi/ENCODE-DCC/chip-seq-pipeline2/**"],
-     expected_lint={'StringCoercion': 224, 'NameCollision': 16, 'ArrayCoercion': 64, 'OptionalCoercion': 64},
+    ["test_corpi/ENCODE-DCC/chip-seq-pipeline2/**"],
+    expected_lint={'StringCoercion': 224, 'NameCollision': 16, 'ArrayCoercion': 64, 'QuantityCoercion': 64},
+    check_quant=False,
 )
 class ENCODE_ChIPseq(unittest.TestCase):
     pass
 
 @test_corpus(
-     ["test_corpi/ENCODE-DCC/atac-seq-pipeline/**"],
-     expected_lint={'StringCoercion': 182, 'ArrayCoercion': 41, 'OptionalCoercion': 26, 'UnusedCall': 13}
+    ["test_corpi/ENCODE-DCC/atac-seq-pipeline/**"],
+    expected_lint={'StringCoercion': 182, 'ArrayCoercion': 41, 'QuantityCoercion': 26, 'UnusedCall': 13},
+    check_quant=False,
 )
 class ENCODE_ATACseq(unittest.TestCase):
     pass
@@ -171,7 +173,7 @@ class ENCODE_WGBS(unittest.TestCase):
         # double quantifier
         "conditionals_base"
     ],
-    expected_lint={'UnusedDeclaration': 22, 'UnusedCall': 15, 'NameCollision': 2, 'OptionalCoercion': 1},
+    expected_lint={'UnusedDeclaration': 22, 'UnusedCall': 15, 'NameCollision': 2, 'QuantityCoercion': 1},
     check_quant=False,
 )
 class dxWDL(unittest.TestCase):
@@ -179,7 +181,7 @@ class dxWDL(unittest.TestCase):
 
 @test_corpus(
     ["test_corpi/contrived/**"],
-    expected_lint={'UnusedImport': 2, 'NameCollision': 13, 'ArrayCoercion': 2, 'NonemptyArrayCoercion': 1, 'StringCoercion': 2, 'OptionalCoercion': 3, 'UnnecessaryQuantifier': 2, 'UnusedDeclaration': 2},
+    expected_lint={'UnusedImport': 2, 'NameCollision': 13, 'ArrayCoercion': 2, 'StringCoercion': 2, 'QuantityCoercion': 3, 'UnnecessaryQuantifier': 2, 'UnusedDeclaration': 2},
     blacklist=["check_quant"],
 )
 class Contrived(unittest.TestCase):
@@ -187,7 +189,7 @@ class Contrived(unittest.TestCase):
 
 @test_corpus(
     ["test_corpi/contrived/**"],
-    expected_lint={'UnusedImport': 4, 'NameCollision': 27, 'ArrayCoercion': 4, 'NonemptyArrayCoercion': 2, 'StringCoercion': 4, 'OptionalCoercion': 7, 'UnnecessaryQuantifier': 4, 'UnusedDeclaration': 5, 'IncompleteCall': 1},
+    expected_lint={'UnusedImport': 4, 'NameCollision': 27, 'ArrayCoercion': 4, 'StringCoercion': 4, 'QuantityCoercion': 8, 'UnnecessaryQuantifier': 4, 'UnusedDeclaration': 7, 'IncompleteCall': 1},
     check_quant=False,
 )
 class Contrived2(unittest.TestCase):


### PR DESCRIPTION
e.g. Array[Array[Int]] = [[:Int?:]]

Entailed pushing check_quant logic from Expr down into Type, and consolidating OptionalCoercion and NonemptyArrayCoercion linters into QuantityCoercion.