### PR TITLE
Rudimentary URI import

### DIFF
--- a/WDL/Error.py
+++ b/WDL/Error.py
@@ -1,4 +1,5 @@
 # pyre-strict
+import os
 from typing import List, Optional, NamedTuple, Union, Iterable, TypeVar, Generator, Callable, Any
 from functools import total_ordering
 from contextlib import contextmanager
@@ -94,7 +95,7 @@ class ValidationError(Exception):
         else:
             self.pos = node
         message = "({} Ln {}, Col {}) {}".format(
-            self.pos.filename, self.pos.line, self.pos.column, message
+            os.path.basename(self.pos.filename), self.pos.line, self.pos.column, message
         )
         super().__init__(message)
 
@@ -161,10 +162,13 @@ class NoSuchInput(ValidationError):
         super().__init__(node, "No such input " + name)
 
 
-class MissingInput(ValidationError):
-    def __init__(self, node: SourceNode, name: str, inputs: Iterable[str]) -> None:
+class UncallableWorkflow(ValidationError):
+    def __init__(self, node: SourceNode, name: str) -> None:
         super().__init__(
-            node, "Call {} missing required input(s) {}".format(name, ", ".join(inputs))
+            node,
+            "Cannot call workflow {} because its calls don't supply all required inputs".format(
+                name
+            ),
         )
 
 

--- a/WDL/__init__.py
+++ b/WDL/__init__.py
@@ -2,7 +2,7 @@
 import os
 import errno
 import inspect
-from typing import List, Optional
+from typing import List, Optional, Callable
 from WDL import _parser, Error, Type, Value, Env, Expr, Tree, Walker, StdLib
 from WDL.Tree import Decl, Task, Call, Scatter, Conditional, Workflow, Document
 
@@ -10,7 +10,12 @@ SourcePosition = Error.SourcePosition
 SourceNode = Error.SourceNode
 
 
-def load(uri: str, path: List[str] = [], check_quant: bool = True) -> Document:
+def load(
+    uri: str,
+    path: List[str] = [],
+    check_quant: bool = True,
+    import_uri: Optional[Callable[[str], str]] = None,
+) -> Document:
     """
     Parse a WDL document given filename/URI, recursively descend into imported documents, then typecheck the tasks and workflow.
 
@@ -18,12 +23,14 @@ def load(uri: str, path: List[str] = [], check_quant: bool = True) -> Document:
 
     :param check_quant: set to ``False`` to relax static typechecking of the optional (?) and nonempty (+) type quantifiers. This is discouraged, but may be useful for older WDL workflows which assume less-rigorous static validation of these annotations.
 
+    :param import_uri: to support non-file URI import, supply a function that takes the URI and returns a local file path
+
     :raises WDL.Error.SyntaxError: when the document is syntactically invalid under the WDL grammar
     :raises WDL.Error.ValidationError: when the document is syntactically OK, but fails typechecking or other static validity checks
     :raises WDL.Error.MultipleValidationErrors: when multiple validation errors are detected in one pass, listed in the ``exceptions`` attribute
     :raises WDL.Error.ImportError: when an imported sub-document can't be loaded; the ``__cause__`` attribute has the specific error
     """
-    return Tree.load(uri, path, check_quant)
+    return Tree.load(uri, path=path, check_quant=check_quant, import_uri=import_uri)
 
 
 def parse_document(txt: str, version: Optional[str] = None, uri: str = "") -> Document:

--- a/test_corpi/contrived/incomplete.wdl
+++ b/test_corpi/contrived/incomplete.wdl
@@ -1,0 +1,16 @@
+version 1.0
+
+workflow has_incomplete_call {
+    call sum
+}
+
+task sum {
+    Int x
+    Int y
+    command <<<
+        echo $(( ~{x} + ~{y} ))
+    >>>
+    output {
+        Int z = read_int(stdout())
+    }
+}

--- a/test_corpi/contrived/incomplete_call.wdl
+++ b/test_corpi/contrived/incomplete_call.wdl
@@ -1,0 +1,5 @@
+import "incomplete.wdl"
+
+workflow xx {
+    call incomplete.has_incomplete_call
+}

--- a/test_corpi/contrived/incomplete_import.wdl
+++ b/test_corpi/contrived/incomplete_import.wdl
@@ -1,0 +1,8 @@
+import "incomplete.wdl"
+
+workflow xx {
+    call incomplete.sum { input:
+        x = 1,
+        y = 1
+    }
+}

--- a/tests/cli.t
+++ b/tests/cli.t
@@ -11,7 +11,7 @@ source tests/bash-tap/bash-tap-bootstrap
 export PYTHONPATH="$SOURCE_DIR:$PYTHONPATH"
 miniwdl="python3 -m WDL"
 
-plan tests 36
+plan tests 37
 
 DN=$(mktemp -d --tmpdir miniwdl_tests_XXXXXX)
 cd $DN
@@ -109,5 +109,8 @@ $miniwdl check --no-quant-check import_multi_error.wdl > import_multi_error.no_q
 is "$?" "0" "import_multi_error.wdl --no-quant-check"
 is "$(grep QuantityCoercion import_multi_error.no_quant_check.out | wc -l)" "2" "import_multi_error.wdl --no-quant-check QuantityCoercion"
 is "$(grep UnusedDeclaration import_multi_error.no_quant_check.out | wc -l)" "2" "import_multi_error.wdl --no-quant-check UnusedDeclaration"
+
+$miniwdl check $SOURCE_DIR/test_corpi/DataBiosphere/topmed-workflows/CRAM-no-header-md5sum/CRAM_md5sum_checker_wrapper.wdl > import_uri.out 2> import_uri.err
+is "$?" "0" "URI import"
 
 rm -rf $DN

--- a/tests/test_2calls.py
+++ b/tests/test_2calls.py
@@ -1,4 +1,4 @@
-import unittest, inspect
+import unittest, inspect, os
 from typing import Optional
 from .context import WDL
 
@@ -384,3 +384,9 @@ class TestCalls(unittest.TestCase):
         assert(doc.workflow.elements[0].type.nonempty and doc.workflow.elements[0].type.optional)
 
         # TODO: test cycle detection
+
+    def test_uncallable_workflow(self):
+        # should not be able to call a workflow containing an incomplete call
+        WDL.load(os.path.join(os.path.dirname(__file__), "../test_corpi/contrived/incomplete_import.wdl"))
+        with self.assertRaises(WDL.Error.UncallableWorkflow):
+            WDL.load(os.path.join(os.path.dirname(__file__), "../test_corpi/contrived/incomplete_call.wdl"))

--- a/tests/test_2calls.py
+++ b/tests/test_2calls.py
@@ -25,10 +25,7 @@ class TestCalls(unittest.TestCase):
         """
         doc = WDL.parse_document(txt)
         doc.typecheck()
-
-        doc = WDL._parser.parse_document(txt, imported=True)
-        with self.assertRaises(WDL.Error.MissingInput):
-            doc.typecheck()
+        self.assertFalse(doc.workflow.complete_calls)
 
         txt = tsk + r"""
         workflow contrived {
@@ -40,11 +37,7 @@ class TestCalls(unittest.TestCase):
         """
         doc = WDL.parse_document(txt)
         doc.typecheck()
-
-        doc = WDL._parser.parse_document(txt, imported=True)
-        with self.assertRaises(WDL.Error.MissingInput):
-            doc.typecheck()
-
+        self.assertFalse(doc.workflow.complete_calls)
 
         txt = tsk + r"""
         workflow contrived {
@@ -58,9 +51,7 @@ class TestCalls(unittest.TestCase):
         """
         doc = WDL.parse_document(txt)
         doc.typecheck()
-
-        doc = WDL._parser.parse_document(txt, imported=True)
-        doc.typecheck()
+        self.assertTrue(doc.workflow.complete_calls)
 
     def test_duplicate_input(self):
         txt = tsk + r"""

--- a/tests/test_2calls.py
+++ b/tests/test_2calls.py
@@ -387,6 +387,6 @@ class TestCalls(unittest.TestCase):
 
     def test_uncallable_workflow(self):
         # should not be able to call a workflow containing an incomplete call
-        WDL.load(os.path.join(os.path.dirname(__file__), "../test_corpi/contrived/incomplete_import.wdl"))
+        WDL.load("file://" + os.path.join(os.path.dirname(__file__), "../test_corpi/contrived/incomplete_import.wdl"))
         with self.assertRaises(WDL.Error.UncallableWorkflow):
             WDL.load(os.path.join(os.path.dirname(__file__), "../test_corpi/contrived/incomplete_call.wdl"))

--- a/tests/test_3corpi.py
+++ b/tests/test_3corpi.py
@@ -179,16 +179,17 @@ class dxWDL(unittest.TestCase):
 
 @test_corpus(
     ["test_corpi/contrived/**"],
-    expected_lint={'UnusedImport': 2, 'NameCollision': 13, 'ArrayCoercion': 2, 'StringCoercion': 2, 'QuantityCoercion': 3, 'UnnecessaryQuantifier': 2, 'UnusedDeclaration': 2},
-    blacklist=["check_quant"],
+    expected_lint={'UnusedImport': 2, 'NameCollision': 13, 'ArrayCoercion': 2, 'StringCoercion': 2, 'QuantityCoercion': 3, 'UnnecessaryQuantifier': 2, 'UnusedDeclaration': 2, "IncompleteCall": 2},
+    blacklist=["check_quant", "incomplete_call"],
 )
 class Contrived(unittest.TestCase):
     pass
 
 @test_corpus(
     ["test_corpi/contrived/**"],
-    expected_lint={'UnusedImport': 4, 'NameCollision': 27, 'ArrayCoercion': 4, 'StringCoercion': 4, 'QuantityCoercion': 8, 'UnnecessaryQuantifier': 4, 'UnusedDeclaration': 7, 'IncompleteCall': 1},
+    expected_lint={'UnusedImport': 4, 'NameCollision': 27, 'ArrayCoercion': 4, 'StringCoercion': 4, 'QuantityCoercion': 8, 'UnnecessaryQuantifier': 4, 'UnusedDeclaration': 7, 'IncompleteCall': 3},
     check_quant=False,
+    blacklist=["incomplete_call"],
 )
 class Contrived2(unittest.TestCase):
     pass


### PR DESCRIPTION
Also, documents containing workflows with incomplete calls can be imported, so long as their workflow is not actually called.