### PR TITLE
read_json() stub and Any type

### DIFF
--- a/WDL/CLI.py
+++ b/WDL/CLI.py
@@ -114,7 +114,7 @@ def outline(obj, level, file=sys.stdout):
             "{}workflow {}{}".format(s, obj.name, " (not called)" if not obj.called else ""),
             file=file,
         )
-        for elt in obj.elements:
+        for elt in (obj.inputs or []) + obj.elements + (obj.outputs or []):
             descend(elt)
     # task
     elif isinstance(obj, WDL.Task):

--- a/WDL/Expr.py
+++ b/WDL/Expr.py
@@ -187,14 +187,17 @@ class Placeholder(Base):
         if isinstance(self.expr.type, T.Array):
             if "sep" not in self.options:
                 raise Error.StaticTypeMismatch(
-                    self, T.Array(None), self.expr.type, "array command placeholder must have 'sep'"
+                    self,
+                    T.Array(T.Any()),
+                    self.expr.type,
+                    "array command placeholder must have 'sep'",
                 )
             # if sum(1 for t in [T.Int, T.Float, T.Boolean, T.String, T.File] if isinstance(self.expr.type.item_type, t)) == 0:
-            #    raise Error.StaticTypeMismatch(self, T.Array(None), self.expr.type, "cannot use array of complex types for command placeholder")
+            #    raise Error.StaticTypeMismatch(self, T.Array(T.Any()), self.expr.type, "cannot use array of complex types for command placeholder")
         elif "sep" in self.options:
             raise Error.StaticTypeMismatch(
                 self,
-                T.Array(None),
+                T.Array(T.Any()),
                 self.expr.type,
                 "command placeholder has 'sep' option for non-Array expression",
             )
@@ -301,7 +304,7 @@ class Array(Base):
 
     def _infer_type(self, type_env: Env.Types) -> T.Base:
         if not self.items:
-            return T.Array(None)
+            return T.Array(T.Any())
         # Start by assuming the type of the first item is the item type
         item_type: T.Base = self.items[0].type
         # Allow a mixture of Int and Float to construct Array[Float]
@@ -649,7 +652,7 @@ class Map(Base):
                 kty = k.type
             else:
                 k.typecheck(kty)
-            if vty is None or vty == T.Array(None) or vty == T.Map(None):
+            if vty is None or vty == T.Array(T.Any()) or vty == T.Map(None):
                 vty = v.type
             else:
                 v.typecheck(vty)

--- a/WDL/StdLib.py
+++ b/WDL/StdLib.py
@@ -206,9 +206,9 @@ _static_functions: List[Tuple[str, List[T.Base], T.Base, Any]] = [
     ("read_boolean", [T.String()], T.Boolean(), _notimpl),
     ("read_string", [T.String()], T.String(), _notimpl),
     ("read_float", [T.String()], T.Float(), _notimpl),
-    ("read_array", [T.String()], T.Array(None), _notimpl),
+    ("read_array", [T.String()], T.Array(T.Any()), _notimpl),
     ("read_map", [T.String()], T.Map(None), _notimpl),
-    ("read_lines", [T.String()], T.Array(None), _notimpl),
+    ("read_lines", [T.String()], T.Array(T.Any()), _notimpl),
     ("read_tsv", [T.String()], T.Array(T.Array(T.String())), _notimpl),
     ("read_json", [T.String()], T.Any(), _notimpl),
     ("write_lines", [T.Array(T.String())], T.File(), _notimpl),
@@ -397,7 +397,7 @@ class _Length(E._Function):
         if len(expr.arguments) != 1:
             raise Error.WrongArity(expr, 1)
         if not isinstance(expr.arguments[0].type, T.Array):
-            raise Error.StaticTypeMismatch(expr, T.Array(None), expr.arguments[0].type)
+            raise Error.StaticTypeMismatch(expr, T.Array(T.Any()), expr.arguments[0].type)
         return T.Int()
 
     def __call__(self, expr: E.Apply, env: Env.Values) -> V.Base:
@@ -416,7 +416,9 @@ class _SelectFirst(E._Function):
         if len(expr.arguments) != 1:
             raise Error.WrongArity(expr, 1)
         if not isinstance(expr.arguments[0].type, T.Array):
-            raise Error.StaticTypeMismatch(expr.arguments[0], T.Array(None), expr.arguments[0].type)
+            raise Error.StaticTypeMismatch(
+                expr.arguments[0], T.Array(T.Any()), expr.arguments[0].type
+            )
         if expr.arguments[0].type.item_type is None:
             # TODO: error for 'indeterminate type'
             raise Error.EmptyArray(expr.arguments[0])
@@ -436,7 +438,9 @@ class _SelectAll(E._Function):
         if len(expr.arguments) != 1:
             raise Error.WrongArity(expr, 1)
         if not isinstance(expr.arguments[0].type, T.Array):
-            raise Error.StaticTypeMismatch(expr.arguments[0], T.Array(None), expr.arguments[0].type)
+            raise Error.StaticTypeMismatch(
+                expr.arguments[0], T.Array(T.Any()), expr.arguments[0].type
+            )
         if expr.arguments[0].type.item_type is None:
             # TODO: error for 'indeterminate type'
             raise Error.EmptyArray(expr.arguments[0])
@@ -458,13 +462,13 @@ class _Zip(E._Function):
             raise Error.WrongArity(expr, 2)
         arg0ty: T.Base = expr.arguments[0].type
         if not isinstance(arg0ty, T.Array) or (expr._check_quant and arg0ty.optional):
-            raise Error.StaticTypeMismatch(expr.arguments[0], T.Array(None), arg0ty)
+            raise Error.StaticTypeMismatch(expr.arguments[0], T.Array(T.Any()), arg0ty)
         if arg0ty.item_type is None:
             # TODO: error for 'indeterminate type'
             raise Error.EmptyArray(expr.arguments[0])
         arg1ty: T.Base = expr.arguments[1].type
         if not isinstance(arg1ty, T.Array) or (expr._check_quant and arg1ty.optional):
-            raise Error.StaticTypeMismatch(expr.arguments[1], T.Array(None), arg1ty)
+            raise Error.StaticTypeMismatch(expr.arguments[1], T.Array(T.Any()), arg1ty)
         if arg1ty.item_type is None:
             # TODO: error for 'indeterminate type'
             raise Error.EmptyArray(expr.arguments[1])
@@ -483,14 +487,14 @@ class _Flatten(E._Function):
     def infer_type(self, expr: E.Apply) -> T.Base:
         if len(expr.arguments) != 1:
             raise Error.WrongArity(expr, 1)
-        expr.arguments[0].typecheck(T.Array(None))
+        expr.arguments[0].typecheck(T.Array(T.Any()))
         # TODO: won't handle implicit coercion from T to Array[T]
         assert isinstance(expr.arguments[0].type, T.Array)
         if expr.arguments[0].type.item_type is None:
-            return T.Array(None)
+            return T.Array(T.Any())
         if not isinstance(expr.arguments[0].type.item_type, T.Array):
             raise Error.StaticTypeMismatch(
-                expr.arguments[0], T.Array(T.Array(None)), expr.arguments[0].type
+                expr.arguments[0], T.Array(T.Array(T.Any())), expr.arguments[0].type
             )
         return T.Array(expr.arguments[0].type.item_type.item_type)
 
@@ -506,14 +510,14 @@ class _Transpose(E._Function):
     def infer_type(self, expr: E.Apply) -> T.Base:
         if len(expr.arguments) != 1:
             raise Error.WrongArity(expr, 1)
-        expr.arguments[0].typecheck(T.Array(None))
+        expr.arguments[0].typecheck(T.Array(T.Any()))
         # TODO: won't handle implicit coercion from T to Array[T]
         assert isinstance(expr.arguments[0].type, T.Array)
         if expr.arguments[0].type.item_type is None:
-            return T.Array(None)
+            return T.Array(T.Any())
         if not isinstance(expr.arguments[0].type.item_type, T.Array):
             raise Error.StaticTypeMismatch(
-                expr.arguments[0], T.Array(T.Array(None)), expr.arguments[0].type
+                expr.arguments[0], T.Array(T.Array(T.Any())), expr.arguments[0].type
             )
         return expr.arguments[0].type
 

--- a/WDL/StdLib.py
+++ b/WDL/StdLib.py
@@ -210,9 +210,11 @@ _static_functions: List[Tuple[str, List[T.Base], T.Base, Any]] = [
     ("read_map", [T.String()], T.Map(None), _notimpl),
     ("read_lines", [T.String()], T.Array(None), _notimpl),
     ("read_tsv", [T.String()], T.Array(T.Array(T.String())), _notimpl),
+    ("read_json", [T.String()], T.Any(), _notimpl),
     ("write_lines", [T.Array(T.String())], T.File(), _notimpl),
     ("write_tsv", [T.Array(T.Array(T.String()))], T.File(), _notimpl),
     ("write_map", [T.Map(None)], T.File(), _notimpl),
+    ("write_json", [T.Any()], T.File(), _notimpl),
     ("range", [T.Int()], T.Array(T.Int()), _notimpl),
     ("sub", [T.String(), T.String(), T.String()], T.String(), _notimpl),
 ]
@@ -536,19 +538,3 @@ class _Prefix(E._Function):
 
 
 E._stdlib["prefix"] = _Prefix()
-
-
-class _WriteJson(E._Function):
-    # t -> file
-    def infer_type(self, expr: E.Apply) -> T.Base:
-        if len(expr.arguments) != 1:
-            raise Error.WrongArity(expr, 1)
-        if expr.arguments[0].type.optional:
-            raise Error.IncompatibleOperand(expr.arguments[0], "optional operand to write_json()")
-        return T.File()
-
-    def __call__(self, expr: E.Apply, env: Env.Values) -> V.Base:
-        raise NotImplementedError()
-
-
-E._stdlib["write_json"] = _WriteJson()

--- a/test_corpi/contrived/check_quant.wdl
+++ b/test_corpi/contrived/check_quant.wdl
@@ -1,4 +1,5 @@
 import "contrived.wdl"
+import "empty.wdl"
 
 workflow bs {
     Int? x
@@ -6,4 +7,5 @@ workflow bs {
     Array[Int] a = [x]
     Array[String]+ a2 = [x]
     call contrived.contrived
+    call empty.empty
 }

--- a/test_corpi/contrived/contrived.wdl
+++ b/test_corpi/contrived/contrived.wdl
@@ -19,6 +19,11 @@ workflow contrived {
     call popular as contrived { input:
         popular = 123
     }
+
+    output {
+        Int read_int = read_json(popular.json)
+        Array[Boolean] read_array = read_json(contrived.json)
+    }
 }
 
 task popular {

--- a/test_corpi/contrived/empty.wdl
+++ b/test_corpi/contrived/empty.wdl
@@ -1,0 +1,2 @@
+workflow empty {
+}

--- a/tests/test_0eval.py
+++ b/tests/test_0eval.py
@@ -166,7 +166,7 @@ class TestEval(unittest.TestCase):
             ("[1+2, 3*4][1]", "12"),
             ("[1,2,3,]", "[1, 2, 3]"),
             ("[1,'a']", '["1", "a"]'),
-            ("[]","[]", WDL.Type.Array(None)),
+            ("[]","[]", WDL.Type.Array(WDL.Type.Any())),
             ("[] == []","true"),
             ("[1, false]", "(Ln 1, Col 1) Expected Int instead of Boolean; inconsistent types within array", WDL.Error.StaticTypeMismatch),
             ("1 + 2[3]", "(Ln 1, Col 5) Not an array", WDL.Error.NotAnArray),

--- a/tests/test_2calls.py
+++ b/tests/test_2calls.py
@@ -316,6 +316,7 @@ class TestCalls(unittest.TestCase):
             doc.typecheck()
         doc = WDL.parse_document(txt)
         doc.typecheck(check_quant=False)
+        self.assertEqual(len(list(doc.workflow.effective_outputs)), 2)
 
     def test_forward_reference(self):
         txt = tsk + r"""

--- a/tests/test_3corpi.py
+++ b/tests/test_3corpi.py
@@ -187,7 +187,7 @@ class Contrived(unittest.TestCase):
 
 @test_corpus(
     ["test_corpi/contrived/**"],
-    expected_lint={'UnusedImport': 4, 'NameCollision': 27, 'ArrayCoercion': 4, 'StringCoercion': 4, 'QuantityCoercion': 8, 'UnnecessaryQuantifier': 4, 'UnusedDeclaration': 7, 'IncompleteCall': 3},
+    expected_lint={'UnusedImport': 4, 'NameCollision': 28, 'ArrayCoercion': 4, 'StringCoercion': 4, 'QuantityCoercion': 8, 'UnnecessaryQuantifier': 4, 'UnusedDeclaration': 7, 'IncompleteCall': 3},
     check_quant=False,
     blacklist=["incomplete_call"],
 )


### PR DESCRIPTION
read_json() can return values of different types depending on what's in the JSON file at runtime. Introduce WDL.Type.Any to model this, and use it instead of None to represent the item types of empty Array/Map literals.