### PR TITLE
refactor Env.bind

### DIFF
--- a/WDL/Env.py
+++ b/WDL/Env.py
@@ -20,7 +20,6 @@ to share code for both type and value environments.
 """
 
 R = TypeVar("R")
-S = TypeVar("S")
 Tree = TypeVar("Tree", bound="List[Node[R]]")
 """:type: List[Union[WDL.Env.Binding,WDL.Env.Namespace]]
 ``WDL.Env.Tree`` is the polymorphic data structure for an environment mapping
@@ -179,6 +178,9 @@ def unbind(tree: "Tree[R]", namespace: List[str], name: str) -> "Tree[R]":
     if not found:
         raise KeyError()
     return ans
+
+
+S = TypeVar("S")
 
 
 def subtract(lhs: "Tree[R]", rhs: "Tree[S]") -> "Tree[R]":

--- a/WDL/Env.py
+++ b/WDL/Env.py
@@ -3,8 +3,6 @@
 Environments, for identifier resolution during WDL typechecking and evaluation.
 """
 from typing import List, TypeVar, Generic, Any
-import WDL.Type as T
-import WDL.Value as V
 
 """
 FIXME: we haven't found exactly the right way to write the type annotations for
@@ -125,8 +123,7 @@ def resolve_ctx(tree: "Tree[R]", namespace: List[str], name: str) -> Any:  # pyr
     return ans
 
 
-def bind(
-    tree: "Tree[R]", namespace: List[str], name: str, rhs: R, ctx: Any = None) -> "Tree[R]":
+def bind(tree: "Tree[R]", namespace: List[str], name: str, rhs: R, ctx: Any = None) -> "Tree[R]":
     """
     Return a copy of ``tree`` with a new binding prepended. (Does not check for
     name collision!)
@@ -142,7 +139,9 @@ def bind(
     new_namespace = True
     for node in tree:
         if isinstance(node, Namespace) and node.namespace == namespace[0]:
-            ans.append(Namespace(node.namespace, bind(node.bindings, namespace[1:], name, rhs, ctx=ctx)))
+            ans.append(
+                Namespace(node.namespace, bind(node.bindings, namespace[1:], name, rhs, ctx=ctx))
+            )
             new_namespace = False
         else:
             ans.append(node)
@@ -204,7 +203,3 @@ def subtract(lhs: "Tree[R]", rhs: "Tree[S]") -> "Tree[R]":
         else:
             assert False
     return ans
-
-
-def namespace(namespace: str, bindings: "Tree[R]", tree: "Tree[R]") -> "Tree[R]":
-    return [Namespace(namespace, bindings)] + tree

--- a/WDL/Env.py
+++ b/WDL/Env.py
@@ -2,7 +2,7 @@
 """
 Environments, for identifier resolution during WDL typechecking and evaluation.
 """
-from typing import List, TypeVar, Generic, Any, Optional
+from typing import List, TypeVar, Generic, Any
 import WDL.Type as T
 import WDL.Value as V
 

--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -341,11 +341,10 @@ class Call(SourceNode):
             )
         except KeyError:
             pass
-        outputs_env = []
         for outp in self.callee.effective_outputs:
             assert isinstance(outp, Env.Binding)
-            outputs_env = Env.bind(outputs_env, [], outp.name, outp.rhs.type, ctx=self)
-        return Env.namespace(self.name, outputs_env, type_env)
+            type_env = Env.bind(type_env, [self.name], outp.name, outp.rhs.type, ctx=self)
+        return type_env
 
     def typecheck_input(self, type_env: Env.Types, check_quant: bool) -> bool:
         # Check the input expressions against the callee's inputs. One-time use.
@@ -389,7 +388,7 @@ class Call(SourceNode):
                 b, Env.Namespace
             ):
                 ans.append(b)
-        return Env.namespace(self.name, ans, []) if ans else []
+        return [Env.Namespace(self.name, ans)] if ans else []
 
     @property
     def required_inputs(self) -> Env.Decls:
@@ -408,7 +407,7 @@ class Call(SourceNode):
                 b, Env.Namespace
             ):
                 ans.append(b)
-        return Env.namespace(self.name, ans, []) if ans else []
+        return [Env.Namespace(self.name, ans)] if ans else []
 
     @property
     def effective_outputs(self) -> Env.Decls:
@@ -417,7 +416,7 @@ class Call(SourceNode):
         Yields the effective outputs of the callee Task or Workflow, in a
         namespace according to the call name."""
         ceo = self.callee.effective_outputs
-        return Env.namespace(self.name, ceo, []) if ceo else []
+        return [Env.Namespace(self.name, ceo)] if ceo else []
 
 
 class Scatter(SourceNode):

--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -64,7 +64,7 @@ class Decl(SourceNode):
             raise Err.MultipleDefinitions(self, "Multiple declarations of " + self.name)
         except KeyError:
             pass
-        ans: Env.Types = Env.bind(self.name, self.type, type_env, ctx=self)
+        ans: Env.Types = Env.bind(type_env, [], self.name, self.type, ctx=self)
         return ans
 
     def typecheck(self, type_env: Env.Types, check_quant: bool) -> None:
@@ -157,7 +157,7 @@ class Task(SourceNode):
         """
         ans = []
         for decl in self.inputs if self.inputs is not None else self.postinputs:
-            ans = Env.bind(decl.name, decl, ans)
+            ans = Env.bind(ans, [], decl.name, decl)
         return ans
 
     @property
@@ -185,7 +185,7 @@ class Task(SourceNode):
         """
         ans = []
         for decl in self.outputs:
-            ans = Env.bind(decl.name, decl, ans)
+            ans = Env.bind(ans, [], decl.name, decl)
         return ans
 
     @property
@@ -344,7 +344,7 @@ class Call(SourceNode):
         outputs_env = []
         for outp in self.callee.effective_outputs:
             assert isinstance(outp, Env.Binding)
-            outputs_env = Env.bind(outp.name, outp.rhs.type, outputs_env, ctx=self)
+            outputs_env = Env.bind(outputs_env, [], outp.name, outp.rhs.type, ctx=self)
         return Env.namespace(self.name, outputs_env, type_env)
 
     def typecheck_input(self, type_env: Env.Types, check_quant: bool) -> bool:
@@ -615,12 +615,12 @@ class Workflow(SourceNode):
 
         if self.inputs is not None:
             for decl in self.inputs:
-                ans = Env.bind(decl.name, decl, ans)
+                ans = Env.bind(ans, [], decl.name, decl)
 
         for elt in _decls_and_calls(self):
             if isinstance(elt, Decl):
                 if self.inputs is None:
-                    ans = Env.bind(elt.name, elt, ans)
+                    ans = Env.bind(ans, [], elt.name, elt)
             elif isinstance(elt, Call):
                 ans = elt.available_inputs + ans
             else:
@@ -639,12 +639,12 @@ class Workflow(SourceNode):
         if self.inputs is not None:
             for decl in self.inputs:
                 if decl.expr is None and decl.type.optional is False:
-                    ans = Env.bind(decl.name, decl, ans)
+                    ans = Env.bind(ans, [], decl.name, decl)
 
         for elt in _decls_and_calls(self):
             if isinstance(elt, Decl):
                 if self.inputs is None and elt.expr is None and elt.type.optional is False:
-                    ans = Env.bind(elt.name, elt, ans)
+                    ans = Env.bind(ans, [], elt.name, elt)
             elif isinstance(elt, Call):
                 ans = elt.required_inputs + ans
             else:
@@ -664,7 +664,7 @@ class Workflow(SourceNode):
 
         if self.outputs is not None:
             for decl in self.outputs:
-                ans = Env.bind(decl.name, decl, ans)
+                ans = Env.bind(ans, [], decl.name, decl)
         else:
             for call in _decls_and_calls(self):
                 if isinstance(call, Call):
@@ -962,7 +962,7 @@ def _build_workflow_type_env(
             )
         except KeyError:
             pass
-        type_env = Env.bind(self.variable, self.expr.type.item_type, type_env, ctx=self)
+        type_env = Env.bind(type_env, [], self.variable, self.expr.type.item_type, ctx=self)
     elif isinstance(self, Conditional):
         # typecheck the condition
         self.expr.infer_type(type_env, check_quant)

--- a/tests/test_0eval.py
+++ b/tests/test_0eval.py
@@ -330,6 +330,7 @@ class TestEnv(unittest.TestCase):
         self.assertEqual(WDL.Env.resolve(e, [], "foo"), "bar")
         self.assertEqual(WDL.Env.resolve(e, ["fruit"], "orange"), "a")
         self.assertEqual(WDL.Env.resolve(e, ["fruit", "apple"], "macintosh"), "d")
+        self.assertEqual(WDL.Env.resolve(e, ["fruit", "grape"], "green"), "f")
 
         e = WDL.Env.subtract(e, WDL.Env.bind([], ["fruit", "apple"], "macintosh", "d"))
         with self.assertRaises(KeyError):
@@ -338,3 +339,4 @@ class TestEnv(unittest.TestCase):
             WDL.Env.resolve_namespace(e, ["fruit", "apple"])
         self.assertEqual(WDL.Env.resolve(e, [], "foo"), "bar")
         self.assertEqual(WDL.Env.resolve(e, ["fruit"], "orange"), "a")
+        self.assertEqual(WDL.Env.resolve(e, ["fruit", "grape"], "green"), "f")

--- a/tests/test_0eval.py
+++ b/tests/test_0eval.py
@@ -316,6 +316,8 @@ class TestEnv(unittest.TestCase):
         e = WDL.Env.bind(e, ["fruit"], "pear", "b")
         e = WDL.Env.bind(e, ["fruit", "apple"], "honeycrisp", "c")
         e = WDL.Env.bind(e, ["fruit", "apple"], "macintosh", "d")
+        e = WDL.Env.bind(e, ["fruit", "grape"], "red", "e")
+        e = WDL.Env.bind(e, ["fruit", "grape"], "green", "f")
 
         rhs = WDL.Env.bind([], ["fruit"], "pear", "b")
         rhs = WDL.Env.bind(rhs, ["fruit", "apple"], "honeycrisp", "c")

--- a/tests/test_1doc.py
+++ b/tests/test_1doc.py
@@ -68,7 +68,7 @@ class TestTasks(unittest.TestCase):
 
             task.typecheck()
 
-            self.assertEqual(task.command.parts[1].eval(WDL.Env.bind('in', WDL.Value.String("hello"), [])).value, 'hello')
+            self.assertEqual(task.command.parts[1].eval(WDL.Env.bind([], [], 'in', WDL.Value.String("hello"))).value, 'hello')
 
             self.assertFalse(task.command.parts[0].strip().startswith("{"))
             self.assertFalse(task.command.parts[0].strip().startswith("<<<"))
@@ -114,9 +114,9 @@ class TestTasks(unittest.TestCase):
             }
             """)[0]
         task.typecheck()
-        self.assertEqual(task.command.parts[1].eval(WDL.Env.bind('b', WDL.Value.Boolean(True), [])).value, 'yes')
-        self.assertEqual(task.command.parts[1].eval(WDL.Env.bind('b', WDL.Value.Boolean(False), [])).value, 'no')
-        self.assertEqual(task.command.parts[1].eval(WDL.Env.bind('b', WDL.Value.Null(), [])).value, '')
+        self.assertEqual(task.command.parts[1].eval(WDL.Env.bind([], [], 'b', WDL.Value.Boolean(True))).value, 'yes')
+        self.assertEqual(task.command.parts[1].eval(WDL.Env.bind([], [], 'b', WDL.Value.Boolean(False))).value, 'no')
+        self.assertEqual(task.command.parts[1].eval(WDL.Env.bind([], [], 'b', WDL.Value.Null())).value, '')
 
         task = WDL.parse_tasks("""
             task wc {
@@ -130,10 +130,10 @@ class TestTasks(unittest.TestCase):
             }
             """)[0]
         task.typecheck()
-        self.assertEqual(task.command.parts[1].eval(WDL.Env.bind('b', WDL.Value.Boolean(True), [])).value, 'yes')
-        self.assertEqual(task.command.parts[1].eval(WDL.Env.bind('b', WDL.Value.Boolean(False), [])).value, 'no')
+        self.assertEqual(task.command.parts[1].eval(WDL.Env.bind([], [], 'b', WDL.Value.Boolean(True))).value, 'yes')
+        self.assertEqual(task.command.parts[1].eval(WDL.Env.bind([], [], 'b', WDL.Value.Boolean(False))).value, 'no')
         with self.assertRaises(WDL.Error.NullValue):
-            self.assertEqual(task.command.parts[1].eval(WDL.Env.bind('b', WDL.Value.Null(), [])).value, '')
+            self.assertEqual(task.command.parts[1].eval(WDL.Env.bind([], [], 'b', WDL.Value.Null())).value, '')
 
         with self.assertRaises(WDL.Error.StaticTypeMismatch):
             WDL.parse_tasks("""
@@ -180,9 +180,9 @@ class TestTasks(unittest.TestCase):
             """)[0]
         task.typecheck()
         foobar = WDL.Value.Array(WDL.Type.Array(WDL.Type.String()), [WDL.Value.String("foo"), WDL.Value.String("bar")])
-        self.assertEqual(task.command.parts[1].eval(WDL.Env.bind('s', foobar, [])).value, 'foo, bar')
+        self.assertEqual(task.command.parts[1].eval(WDL.Env.bind([], [], 's', foobar)).value, 'foo, bar')
         foobar = WDL.Value.Array(WDL.Type.Array(WDL.Type.String()), [])
-        self.assertEqual(task.command.parts[1].eval(WDL.Env.bind('s', foobar, [])).value, '')
+        self.assertEqual(task.command.parts[1].eval(WDL.Env.bind([], [], 's', foobar)).value, '')
         with self.assertRaises(WDL.Error.StaticTypeMismatch):
             task = WDL.parse_tasks("""
             task wc {
@@ -218,9 +218,9 @@ class TestTasks(unittest.TestCase):
             """)[0]
         task.typecheck()
         self.assertTrue(task.inputs[0].type.optional)
-        self.assertEqual(task.command.parts[1].eval(WDL.Env.bind('b', WDL.Value.Boolean(True), [])).value, 'true')
-        self.assertEqual(task.command.parts[1].eval(WDL.Env.bind('b', WDL.Value.Boolean(False), [])).value, 'false')
-        self.assertEqual(task.command.parts[1].eval(WDL.Env.bind('b', WDL.Value.Null(), [])).value, 'foo')
+        self.assertEqual(task.command.parts[1].eval(WDL.Env.bind([], [], 'b', WDL.Value.Boolean(True))).value, 'true')
+        self.assertEqual(task.command.parts[1].eval(WDL.Env.bind([], [], 'b', WDL.Value.Boolean(False))).value, 'false')
+        self.assertEqual(task.command.parts[1].eval(WDL.Env.bind([], [], 'b', WDL.Value.Null())).value, 'foo')
 
     def test_meta(self):
         task = WDL.parse_tasks("""


### PR DESCRIPTION
- bind() can insert namespaces recursively as needed (deprecates namespace())
- bind() arguments reordered for consistency
- add unbind() and subtract()
- unit tests