### PR TITLE
Rework effective_outputs

### DIFF
--- a/WDL/Env.py
+++ b/WDL/Env.py
@@ -149,15 +149,40 @@ def bind(tree: "Tree[R]", namespace: List[str], name: str, rhs: R, ctx: Any = No
     return ans
 
 
+S = TypeVar("S")
+
+
+def map(
+    tree: "Tree[R]",
+    fn: "Callable[[List[str], Binding[R]], S]",
+    namespace: Optional[List[str]] = None,
+) -> "Tree[S]":
+    """
+    Copy ``tree`` with the ``rhs`` of each binding replaced by
+    ``fn(namespace, binding)``
+    """
+    namespace = namespace or []
+    ans = []
+    for node in tree:
+        if isinstance(node, Binding):
+            ans.append(Binding(node.name, fn(namespace, node), ctx=node.ctx))
+        else:
+            assert isinstance(node, Namespace)
+            ans.append(
+                Namespace(node.namespace, map(node.bindings, fn, namespace + [node.namespace]))
+            )
+    return ans
+
+
 def filter(
     tree: "Tree[R]",
-    keep: Callable[[List[str], Binding], bool],
+    keep: "Callable[[List[str], Binding[R]], bool]",
     namespace: Optional[List[str]] = None,
 ):
     """
-    Return a copy of ``tree`` with only those bindings satisfying the
-    predicate ``keep(namespace, binding)``. Any ``Namespace`` nodes which
-    become empty are also removed.
+    Copy ``tree`` with only those bindings satisfying the predicate
+    ``keep(namespace, binding)``. Any ``Namespace`` nodes which become empty
+    are also removed.
     """
     namespace = namespace or []
     ans = []
@@ -183,9 +208,6 @@ def unbind(tree: "Tree[R]", namespace: List[str], name: str) -> "Tree[R]":
     return filter(
         tree, lambda a_namespace, binding: a_namespace != namespace or binding.name != name
     )
-
-
-S = TypeVar("S")
 
 
 def subtract(lhs: "Tree[R]", rhs: "Tree[S]") -> "Tree[R]":

--- a/WDL/Env.py
+++ b/WDL/Env.py
@@ -178,7 +178,7 @@ def filter(
     tree: "Tree[R]",
     keep: "Callable[[List[str], Binding[R]], bool]",
     namespace: Optional[List[str]] = None,
-):
+) -> "Tree[R]":
     """
     Copy ``tree`` with only those bindings satisfying the predicate
     ``keep(namespace, binding)``. Any ``Namespace`` nodes which become empty

--- a/WDL/Expr.py
+++ b/WDL/Expr.py
@@ -567,6 +567,8 @@ class Ident(Base):
             ans: T.Base = Env.resolve(type_env, self.namespace, self.name)
         except KeyError:
             raise Error.UnknownIdentifier(self) from None
+        # the ctx for each binding in the type environment should be the
+        # originating Decl (for inputs/values) or Call (for call outputs)
         self.ctx = Env.resolve_ctx(type_env, self.namespace, self.name)
         return ans
 

--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -186,7 +186,7 @@ class Task(SourceNode):
         """
         ans = []
         for decl in self.outputs:
-            ans = Env.bind(ans, [], decl.name, decl.type)
+            ans = Env.bind(ans, [], decl.name, decl.type, ctx=decl)
         return ans
 
     @property
@@ -686,7 +686,7 @@ class Workflow(SourceNode):
 
         if self.outputs is not None:
             for decl in self.outputs:
-                ans = Env.bind(ans, [], decl.name, decl.type)
+                ans = Env.bind(ans, [], decl.name, decl.type, ctx=decl)
         else:
             for elt in self.elements:
                 if not isinstance(elt, Decl):

--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -177,15 +177,16 @@ class Task(SourceNode):
         return ans
 
     @property
-    def effective_outputs(self) -> Env.Decls:
-        """:type: WDL.Env.Decls
+    def effective_outputs(self) -> Env.Types:
+        """:type: WDL.Env.Types
 
-        Yields each output declaration, at the top level of the Env, with no
-        namespace. (Present for isomorphism with ``Workflow.effective_outputs``)
+        Yields each task output with its type, at the top level of the Env with
+        no namespace. (Present for isomorphism with
+        ``Workflow.effective_outputs``)
         """
         ans = []
         for decl in self.outputs:
-            ans = Env.bind(ans, [], decl.name, decl)
+            ans = Env.bind(ans, [], decl.name, decl.type)
         return ans
 
     @property
@@ -341,10 +342,7 @@ class Call(SourceNode):
             )
         except KeyError:
             pass
-        for outp in self.callee.effective_outputs:
-            assert isinstance(outp, Env.Binding)
-            type_env = Env.bind(type_env, [self.name], outp.name, outp.rhs.type, ctx=self)
-        return type_env
+        return self.effective_outputs + type_env
 
     def typecheck_input(self, type_env: Env.Types, check_quant: bool) -> bool:
         # Check the input expressions against the callee's inputs. One-time use.
@@ -410,13 +408,17 @@ class Call(SourceNode):
         return [Env.Namespace(self.name, ans)] if ans else []
 
     @property
-    def effective_outputs(self) -> Env.Decls:
+    def effective_outputs(self) -> Env.Types:
         """:type: WDL.Env.Decls
 
         Yields the effective outputs of the callee Task or Workflow, in a
-        namespace according to the call name."""
-        ceo = self.callee.effective_outputs
-        return [Env.Namespace(self.name, ceo)] if ceo else []
+        namespace according to the call name.
+        """
+        ans = []
+        for outp in self.callee.effective_outputs:
+            assert isinstance(outp, Env.Binding)
+            ans = Env.bind(ans, [self.name], outp.name, outp.rhs, ctx=self)
+        return ans
 
 
 class Scatter(SourceNode):
@@ -474,12 +476,22 @@ class Scatter(SourceNode):
         inner_type_env = []
         for elt in self.elements:
             inner_type_env = elt.add_to_type_env(inner_type_env)
-        nonempty = False
-        if isinstance(self.expr._type, T.Array):
-            # Subtlety: if the scatter array is statically nonempty, then so
-            # too are the arrayized values
-            nonempty = self.expr.type.nonempty
-        return _arrayize_types(inner_type_env, nonempty) + type_env
+        # Subtlety: if the scatter array is statically nonempty, then so too
+        # are the arrayized values
+        nonempty = isinstance(self.expr._type, T.Array) and self.expr.type.nonempty
+        return Env.map(inner_type_env, lambda ns, b: T.Array(b.rhs, nonempty=nonempty)) + type_env
+
+    @property
+    def effective_outputs(self) -> Env.Types:
+        # Yield the outputs of calls in this section and subsections, typed
+        # and namespaced appropriately, as they'll be propagated if the
+        # workflow lacks an explicit output{} section
+        nonempty = isinstance(self.expr._type, T.Array) and self.expr.type.nonempty
+        ans = []
+        for elt in self.elements:
+            if not isinstance(elt, Decl):
+                ans = elt.effective_outputs + ans
+        return Env.map(ans, lambda ns, b: T.Array(b.rhs, nonempty=nonempty))
 
 
 class Conditional(SourceNode):
@@ -529,7 +541,18 @@ class Conditional(SourceNode):
         inner_type_env = []
         for elt in self.elements:
             inner_type_env = elt.add_to_type_env(inner_type_env)
-        return _optionalize_types(inner_type_env) + type_env
+        return Env.map(inner_type_env, lambda ns, b: b.rhs.copy(optional=True)) + type_env
+
+    @property
+    def effective_outputs(self) -> Env.Types:
+        # Yield the outputs of calls in this section and subsections, typed
+        # and namespaced appropriately, as they'll be propagated if the
+        # workflow lacks an explicit output{} section
+        ans = []
+        for elt in self.elements:
+            if not isinstance(elt, Decl):
+                ans = elt.effective_outputs + ans
+        return Env.map(ans, lambda ns, b: b.rhs.copy(optional=True))
 
 
 class Workflow(SourceNode):
@@ -652,22 +675,22 @@ class Workflow(SourceNode):
         return ans
 
     @property
-    def effective_outputs(self) -> Env.Decls:
+    def effective_outputs(self) -> Env.Types:
         """:type: WDL.Env.Decls
 
-        If the ``output{}`` workflow section is present, yields each
-        declaration therein, at the top level of the Env. Otherwise, yield a
-        declaration for each call output, namespaced by the call name.
+        If the ``output{}`` workflow section is present, yields the names and
+        types therein, at the top level of the Env. Otherwise, yield all the
+        call outputs, namespaced and typed appropriately.
         """
         ans = []
 
         if self.outputs is not None:
             for decl in self.outputs:
-                ans = Env.bind(ans, [], decl.name, decl)
+                ans = Env.bind(ans, [], decl.name, decl.type)
         else:
-            for call in _decls_and_calls(self):
-                if isinstance(call, Call):
-                    ans = call.effective_outputs + ans
+            for elt in self.elements:
+                if not isinstance(elt, Decl):
+                    ans = elt.effective_outputs + ans
 
         return ans
 
@@ -992,35 +1015,6 @@ def _build_workflow_type_env(
     for child in self.elements:
         type_env = child.add_to_type_env(type_env)
     self._type_env = type_env
-
-
-def _arrayize_types(type_env: Env.Types, nonempty: bool = False) -> Env.Types:
-    # Given a type environment, recursively promote each binding of type T to
-    # Array[T] -- used in Scatter.add_to_type_env
-    ans = []
-    for node in type_env:
-        if isinstance(node, Env.Binding):
-            ans.append(Env.Binding(node.name, T.Array(node.rhs, nonempty=nonempty), node.ctx))
-        elif isinstance(node, Env.Namespace):
-            ans.append(Env.Namespace(node.namespace, _arrayize_types(node.bindings, nonempty)))
-        else:
-            assert False
-    return ans
-
-
-def _optionalize_types(type_env: Env.Types) -> Env.Types:
-    # Given a type environment, recursively make each binding optional -- used
-    # in Conditional.add_to_type_env
-    ans = []
-    for node in type_env:
-        if isinstance(node, Env.Binding):
-            ty = node.rhs.copy(optional=True)
-            ans.append(Env.Binding(node.name, ty, node.ctx))
-        elif isinstance(node, Env.Namespace):
-            ans.append(Env.Namespace(node.namespace, _optionalize_types(node.bindings)))
-        else:
-            assert False
-    return ans
 
 
 def _typecheck_workflow_elements(

--- a/test_corpi/contrived/tricky_outputs.wdl
+++ b/test_corpi/contrived/tricky_outputs.wdl
@@ -1,0 +1,35 @@
+version 1.0
+
+task hello {
+    input {
+        String who
+    }
+    command {
+        echo "Hello, ${who}!"
+    }
+    output {
+        String message = read_string(stdout())
+    }
+}
+
+workflow hello_wf {
+    input {
+        Array[String] names = ["Alyssa P. Hacker", "Ben Bitdiddle"]
+        Boolean extra = false
+    }
+    scatter (name in names) {
+        call hello { input:
+            who = name
+        }
+    }
+    if (extra) {
+        scatter (name in names) {
+            call hello as hello2 { input:
+                who = name
+            }
+        }
+    }
+    call hello as hello3 { input:
+        who = names[0]
+    }
+}

--- a/tests/test_2calls.py
+++ b/tests/test_2calls.py
@@ -432,3 +432,9 @@ class TestCalls(unittest.TestCase):
         WDL.Env.resolve(ns, [], "y")
         self.assertEqual(len(doc.workflow.required_inputs), 1)
         WDL.Env.resolve(doc.workflow.required_inputs, [], "required")
+
+        doc = WDL.load("file://" + os.path.join(os.path.dirname(__file__), "../test_corpi/contrived/tricky_outputs.wdl"))
+        self.assertEqual(len(doc.workflow.effective_outputs), 3)
+        self.assertEqual(str(WDL.Env.resolve(doc.workflow.effective_outputs, ["hello"], "message")), "Array[String]")
+        self.assertEqual(str(WDL.Env.resolve(doc.workflow.effective_outputs, ["hello2"], "message")), "Array[String]?")
+        self.assertEqual(str(WDL.Env.resolve(doc.workflow.effective_outputs, ["hello3"], "message")), "String")


### PR DESCRIPTION
- Make them Env.Types instead of Env.Decls
- Correctly type the outputs of calls inside scatter and conditional sections
- Clean up internals using new Env.map