### PR TITLE
Refine StringCoercion and FileCoercion linters

### DIFF
--- a/test_corpi/contrived/contrived.wdl
+++ b/test_corpi/contrived/contrived.wdl
@@ -35,7 +35,7 @@ task popular {
     }
     String? x = popular + opt   # rhs expr is non-optional although opt is...
     Array[String] args = prefix("-f", y)
-    Pair[String,Float] contents = (read_string(popular), size([popular]))
+    Pair[String,String] contents = (read_string(popular), size([popular]))
 
     command {
         echo "~{popular} ~{contents.left}"

--- a/tests/test_4corpi.py
+++ b/tests/test_4corpi.py
@@ -56,7 +56,7 @@ class HCAskylab_task(unittest.TestCase):
 @test_corpus(
     ["test_corpi/HumanCellAtlas/skylab/pipelines/**"],
     path=[["test_corpi/HumanCellAtlas/skylab/library/tasks"]],
-    expected_lint={'UnusedDeclaration': 15, 'NameCollision': 1, 'StringCoercion': 3, 'FileCoercion': 1}
+    expected_lint={'UnusedDeclaration': 15, 'NameCollision': 1, 'StringCoercion': 4, 'FileCoercion': 1}
 )
 class HCAskylab_workflow(unittest.TestCase):
     pass
@@ -134,7 +134,7 @@ class ViralNGS(unittest.TestCase):
 
 @test_corpus(
     ["test_corpi/ENCODE-DCC/chip-seq-pipeline2/**"],
-    expected_lint={'StringCoercion': 224,  'FileCoercion': 91, 'NameCollision': 16, 'QuantityCoercion': 64},
+    expected_lint={'StringCoercion': 224,  'FileCoercion': 154, 'NameCollision': 16, 'QuantityCoercion': 64},
     check_quant=False,
 )
 class ENCODE_ChIPseq(unittest.TestCase):
@@ -142,7 +142,7 @@ class ENCODE_ChIPseq(unittest.TestCase):
 
 @test_corpus(
     ["test_corpi/ENCODE-DCC/atac-seq-pipeline/**"],
-    expected_lint={'StringCoercion': 182, 'FileCoercion': 182, 'QuantityCoercion': 26, 'UnusedCall': 13},
+    expected_lint={'StringCoercion': 182, 'FileCoercion': 204, 'QuantityCoercion': 26, 'UnusedCall': 13},
     check_quant=False,
 )
 class ENCODE_ATACseq(unittest.TestCase):
@@ -182,7 +182,7 @@ class dxWDL(unittest.TestCase):
 
 @test_corpus(
     ["test_corpi/contrived/**"],
-    expected_lint={'UnusedImport': 2, 'NameCollision': 13, 'ArrayCoercion': 3, 'StringCoercion': 2, 'FileCoercion': 2, 'QuantityCoercion': 3, 'UnnecessaryQuantifier': 2, 'UnusedDeclaration': 2, "IncompleteCall": 2},
+    expected_lint={'UnusedImport': 2, 'NameCollision': 13, 'ArrayCoercion': 3, 'StringCoercion': 3, 'FileCoercion': 2, 'QuantityCoercion': 3, 'UnnecessaryQuantifier': 2, 'UnusedDeclaration': 2, "IncompleteCall": 2},
     blacklist=["check_quant", "incomplete_call"],
 )
 class Contrived(unittest.TestCase):
@@ -190,7 +190,7 @@ class Contrived(unittest.TestCase):
 
 @test_corpus(
     ["test_corpi/contrived/**"],
-    expected_lint={'UnusedImport': 4, 'NameCollision': 28, 'ArrayCoercion': 6, 'StringCoercion': 4, 'FileCoercion': 4, 'QuantityCoercion': 9, 'UnnecessaryQuantifier': 4, 'UnusedDeclaration': 8, 'IncompleteCall': 3, "UnusedCall": 1},
+    expected_lint={'UnusedImport': 4, 'NameCollision': 28, 'ArrayCoercion': 6, 'StringCoercion': 7, 'FileCoercion': 4, 'QuantityCoercion': 9, 'UnnecessaryQuantifier': 4, 'UnusedDeclaration': 8, 'IncompleteCall': 3, "UnusedCall": 1},
     check_quant=False,
     blacklist=["incomplete_call"],
 )

--- a/tests/test_4corpi.py
+++ b/tests/test_4corpi.py
@@ -74,7 +74,7 @@ class GATK_five_dollar(unittest.TestCase):
 
 @test_corpus(
     ["test_corpi/gatk-workflows/gatk4-germline-snps-indels/**"],
-    expected_lint={'UnusedDeclaration': 3, 'StringCoercion': 15, 'FileCoercion': 1}
+    expected_lint={'UnusedDeclaration': 3, 'StringCoercion': 20, 'FileCoercion': 1}
 )
 class gatk4_germline_snps_indels(unittest.TestCase):
     pass
@@ -89,7 +89,7 @@ class gatk4_somatic_snvs_indels(unittest.TestCase):
 
 @test_corpus(
     ["test_corpi/gatk-workflows/gatk4-cnn-variant-filter/**"],
-    expected_lint={'UnusedDeclaration': 21, 'QuantityCoercion': 23, 'StringCoercion': 3, 'FileCoercion': 2, 'UnusedCall': 1},
+    expected_lint={'UnusedDeclaration': 21, 'QuantityCoercion': 23, 'StringCoercion': 4, 'FileCoercion': 2, 'UnusedCall': 1},
     check_quant=False,
 )
 class gatk4_cnn_variant_filter(unittest.TestCase):
@@ -99,7 +99,7 @@ class gatk4_cnn_variant_filter(unittest.TestCase):
 @test_corpus(
     ["test_corpi/gatk-workflows/broad-prod-wgs-germline-snps-indels/**"],
     blacklist=['JointGenotypingWf'],
-    expected_lint={'StringCoercion': 48, 'UnusedDeclaration': 10, 'ArrayCoercion': 4, 'UnusedCall': 2}
+    expected_lint={'StringCoercion': 50, 'UnusedDeclaration': 10, 'ArrayCoercion': 4, 'UnusedCall': 2}
 )
 class broad_prod_wgs(unittest.TestCase):
     pass
@@ -118,7 +118,7 @@ class GTEx(unittest.TestCase):
     # need URI import
     blacklist=['CRAM_md5sum_checker_wrapper', 'checker-workflow-wrapping-alignment-workflow',
                 'topmed_freeze3_calling', 'topmed_freeze3_calling_checker', 'u_of_michigan_aligner_checker'],
-    expected_lint={'StringCoercion': 26, 'UnusedDeclaration': 74, 'QuantityCoercion': 1},
+    expected_lint={'StringCoercion': 27, 'UnusedDeclaration': 74, 'QuantityCoercion': 1},
     check_quant=False,
 )
 class TOPMed(unittest.TestCase):
@@ -142,7 +142,7 @@ class ENCODE_ChIPseq(unittest.TestCase):
 
 @test_corpus(
     ["test_corpi/ENCODE-DCC/atac-seq-pipeline/**"],
-    expected_lint={'StringCoercion': 182, 'FileCoercion': 204, 'QuantityCoercion': 26, 'UnusedCall': 13},
+    expected_lint={'StringCoercion': 195, 'FileCoercion': 204, 'QuantityCoercion': 26, 'UnusedCall': 13},
     check_quant=False,
 )
 class ENCODE_ATACseq(unittest.TestCase):
@@ -174,7 +174,7 @@ class ENCODE_WGBS(unittest.TestCase):
         # double quantifier
         "conditionals_base"
     ],
-    expected_lint={'UnusedDeclaration': 22, 'UnusedCall': 15, 'NameCollision': 2, 'QuantityCoercion': 1, 'FileCoercion': 2},
+    expected_lint={'UnusedDeclaration': 22, 'UnusedCall': 15, 'NameCollision': 2, 'QuantityCoercion': 1, 'StringCoercion': 2, 'FileCoercion': 2},
     check_quant=False,
 )
 class dxWDL(unittest.TestCase):


### PR DESCRIPTION
* detect coercions implied within compound types
* flag most File-to-String coercions at the workflow (but not task) level