### PR TITLE
Simpler version handling

### DIFF
--- a/WDL/CLI.py
+++ b/WDL/CLI.py
@@ -2,6 +2,7 @@
 miniwdl command-line interface
 """
 import sys
+import pkg_resources
 import os
 import subprocess
 import tempfile
@@ -62,9 +63,9 @@ def main(args=None):
 class PipVersionAction(Action):
     def __call__(self, parser, namespace, values, option_string=None):
         try:
-            subprocess.check_call(["pip3", "show", "miniwdl"])
-        except subprocess.CalledProcessError:
-            print("miniwdl version unknown (not installed by pip3)")
+            print(pkg_resources.get_distribution("miniwdl"))
+        except pkg_resources.DistributionNotFound as exc:
+            print("miniwdl version unknown ({}: {})".format(type(exc).__name__, exc))
         print("Cromwell-Version: " + CROMWELL_VERSION)
         sys.exit(0)
 


### PR DESCRIPTION
@mlin - pkg_resources is (I believe) the standard way to handle versioning. This
can get a bit weird if git repo is missing, but usually if you're pip
installing with standard packaging PBR handles this just fine! Yay! :D


```
›› pipenv run pip install -e .
Obtaining file:///Users/jtratner/miniwdl
Requirement already satisfied: lark-parser==0.7.0 in /Users/jtratner/.virtualenvs/miniwdl-PSNaoBg-/lib/python3.6/site-packages (from miniwdl==0.1.7.dev2) (0.7.0)
Installing collected packages: miniwdl
  Found existing installation: miniwdl 0.1.7.dev2
    Uninstalling miniwdl-0.1.7.dev2:
      Successfully uninstalled miniwdl-0.1.7.dev2
  Running setup.py develop for miniwdl
Successfully installed miniwdl
›› pipenv run miniwdl --version
miniwdl 0.1.7.dev2
Cromwell-Version: 40
```