### PR TITLE
Fixed bug when initializing nested Struct types

### DIFF
--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -1480,6 +1480,8 @@ def _initialize_struct_typedefs(struct_typedefs: Env.StructTypeDefs):
         for member_ty in b.rhs.members.values():
             if isinstance(member_ty, T.StructInstance):
                 _resolve_struct_typedef(b.rhs.pos, member_ty, struct_typedefs)
+            else:
+                _resolve_struct_typedefs(b.rhs.pos, member_ty, struct_typedefs)
     # make a dummy allusion to each StructTypeDef.type_id, which will detect any
     # circular definitions (see Type._struct_type_id)
     for b in struct_typedefs:


### PR DESCRIPTION
Fixes #127 

This change simply ensures that `StructTypeDefs` will be recursively resolved in the case where a `member` of a `struct` is a parameterized type such as an `Array` or `Map`. The bug was being caused because nested structs were only being resolved IFF a member's type was a `Struct` and NOT a paremeterized type