### PR TITLE
Add WDL.values_from_json, WDL.values_to_json

### DIFF
--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -997,11 +997,12 @@ class Document(SourceNode):
 
 def load(
     uri: str,
-    path: List[str] = [],
+    path: Optional[List[str]] = None,
     check_quant: bool = True,
     import_uri: Optional[Callable[[str], str]] = None,
     import_max_depth=10,
 ) -> Document:
+    path = path or []
     if uri.startswith("file://"):
         uri = uri[7:]
     elif uri.find("://") > 0 and import_uri:

--- a/WDL/__init__.py
+++ b/WDL/__init__.py
@@ -2,10 +2,10 @@
 import os
 import errno
 import inspect
-from typing import List, Optional, Callable
-from WDL import _util, _parser, Error, Type, Value, Env, Expr, Tree, Walker, StdLib
-from WDL.Tree import Decl, StructTypeDef, Task, Call, Scatter, Conditional, Workflow, Document
-import WDL.runtime
+from typing import List, Optional, Callable, Dict, Any
+from . import _util, _parser, Error, Type, Value, Env, Expr, Tree, Walker, StdLib
+from .Tree import Decl, StructTypeDef, Task, Call, Scatter, Conditional, Workflow, Document
+from . import runtime
 
 SourcePosition = Error.SourcePosition
 SourceNode = Error.SourceNode
@@ -13,7 +13,7 @@ SourceNode = Error.SourceNode
 
 def load(
     uri: str,
-    path: List[str] = [],
+    path: Optional[List[str]] = None,
     check_quant: bool = True,
     import_uri: Optional[Callable[[str], str]] = None,
     import_max_depth=10,
@@ -64,3 +64,64 @@ def parse_expr(txt: str, version: Optional[str] = None) -> Expr.Base:
 
 def parse_tasks(txt: str, version: Optional[str] = None) -> List[Task]:
     return _parser.parse_tasks(txt, version)
+
+
+def values_from_json(
+    values_json: Dict[str, Any], available: Env.Decls, required: Optional[Env.Decls] = None
+) -> Env.Values:
+    """
+    Given a dict parsed from Cromwell-style JSON and the available input/output
+    declarations of a task or workflow, create a ``WDL.Env.Values`` for the
+    inputs/outputs.
+
+    :param required: raise an error if any of these required inputs/outputs
+                     are not present
+    """
+    ans = []
+    for key in values_json:
+        fqn = key.split(".")
+        if [name for name in fqn if not name]:
+            raise Error.InputError("invalid key in JSON: " + key)
+        try:
+            ty = Env.resolve(available, fqn[:-1], fqn[-1]).type
+        except KeyError:
+            raise Error.InputError("unknown input/output: " + key)
+        v = Value.from_json(ty, values_json[key])
+        ans = Env.bind(ans, fqn[:-1], fqn[-1], v)
+    if required:
+        missing = Env.subtract(required, ans)
+        if missing:
+            raise Error.InputError(
+                "missing required inputs/outputs: {}", ", ".join(values_to_json(missing))
+            )
+    return ans
+
+
+def values_to_json(values_env: Env.Values, namespace: Optional[List[str]] = None) -> Dict[str, Any]:
+    """
+    Convert a ``WDL.Env.Values`` to a dict which ``json.dumps`` to
+    Cromwell-style JSON.
+    """
+    # also can be used on Env.Decls or Env.Types, then the right-hand side of
+    # each entry will be the type string.
+    namespace = namespace or []
+    ans = {}
+    for item in reversed(values_env):
+        if isinstance(item, Env.Binding):
+            v = item.rhs
+            if isinstance(v, Value.Base):
+                j = v.json
+            elif isinstance(item.rhs, Tree.Decl):
+                j = str(item.rhs.type)
+            else:
+                assert isinstance(item.rhs, Type.Base)
+                j = str(item.rhs)
+            ans[".".join(namespace + [item.name])] = j
+        elif isinstance(item, Env.Namespace):
+            for k, v in values_to_json(
+                item.bindings, namespace=(namespace + [item.namespace])
+            ).items():
+                ans[k] = v
+        else:
+            assert False
+    return ans

--- a/WDL/__init__.py
+++ b/WDL/__init__.py
@@ -85,7 +85,7 @@ def values_from_json(
         try:
             ty = Env.resolve(available, fqn[:-1], fqn[-1]).type
         except KeyError:
-            raise Error.InputError("unknown input/output: " + key)
+            raise Error.InputError("unknown input/output: " + key) from None
         v = Value.from_json(ty, values_json[key])
         ans = Env.bind(ans, fqn[:-1], fqn[-1], v)
     if required:

--- a/WDL/_parser.py
+++ b/WDL/_parser.py
@@ -328,7 +328,7 @@ class _ExprTransformer(lark.Transformer):
 
     def apply(self, items, meta) -> E.Base:
         assert len(items) >= 1
-        assert not items[0].startswith("_") # TODO enforce in grammar
+        assert not items[0].startswith("_")  # TODO enforce in grammar
         return E.Apply(sp(self.filename, meta), items[0], items[1:])
 
     def negate(self, items, meta) -> E.Base:

--- a/WDL/_parser.py
+++ b/WDL/_parser.py
@@ -328,6 +328,7 @@ class _ExprTransformer(lark.Transformer):
 
     def apply(self, items, meta) -> E.Base:
         assert len(items) >= 1
+        assert not items[0].startswith("_") # TODO enforce in grammar
         return E.Apply(sp(self.filename, meta), items[0], items[1:])
 
     def negate(self, items, meta) -> E.Base:

--- a/tests/test_0eval.py
+++ b/tests/test_0eval.py
@@ -450,6 +450,10 @@ class TestValue(unittest.TestCase):
         rt(doc.workflow, {"s.who": "Alyssa", "s.age": 24})
         with self.assertRaises(WDL.Error.InputError):
             rt(doc.workflow, {})
+        with self.assertRaises(WDL.Error.InputError):
+            rt(doc.workflow, {".who": "a"})
+        with self.assertRaises(WDL.Error.InputError):
+            rt(doc.workflow, {"s..who": "b"})
 
         # misc functionality
         self.assertEqual(WDL.values_to_json(doc.workflow.required_inputs, ["w"]), {"w.s.who": "String"})


### PR DESCRIPTION
These provide conversion between WDL.Env.Values and Cromwell-style JSON for inputs & outputs.
Subsumes simpler version used for miniwdl cromwell CLI.
Simplifies task runtime test cases