### PR TITLE
Add biowdl/tasks test corpus

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -43,3 +43,6 @@
 [submodule "tests/bash-tap"]
 	path = tests/bash-tap
 	url = https://github.com/illusori/bash-tap.git
+[submodule "test_corpi/biowdl/tasks"]
+	path = test_corpi/biowdl/tasks
+	url = https://github.com/biowdl/tasks.git

--- a/WDL/Lint.py
+++ b/WDL/Lint.py
@@ -654,12 +654,12 @@ class UnusedDeclaration(Linter):
             if not (
                 (
                     isinstance(obj.type, WDL.Type.File)
-                    and sum(1 for sfx in index_suffixes if obj.name.endswith(sfx))
+                    and sum(1 for sfx in index_suffixes if obj.name.lower().endswith(sfx))
                 )
                 or (
                     isinstance(obj.type, WDL.Type.Array)
                     and isinstance(obj.type.item_type, WDL.Type.File)
-                    and sum(1 for sfx in index_suffixes if obj.name.endswith(sfx))
+                    and sum(1 for sfx in index_suffixes if obj.name.lower().endswith(sfx))
                 )
                 or (
                     isinstance(pt, WDL.Tree.Task)

--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -1390,7 +1390,7 @@ def _resolve_struct_typedef(
     try:
         struct_typedef = Env.resolve(struct_typedefs, [], ty.type_name)
     except KeyError:
-        raise Err.InvalidType(pos, "Unknown type " + ty.type_name)
+        raise Err.InvalidType(pos, "Unknown type " + ty.type_name) from None
     ty.members = struct_typedef.members
 
 
@@ -1421,7 +1421,7 @@ def _initialize_struct_typedefs(struct_typedefs: Env.StructTypeDefs):
             try:
                 _resolve_struct_typedefs(b.rhs.pos, member_ty, struct_typedefs)
             except StopIteration:
-                raise Err.CircularDependencies(b.rhs)
+                raise Err.CircularDependencies(b.rhs) from None
 
 
 def _add_struct_instance_to_type_env(

--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -825,6 +825,8 @@ class Workflow(SourceNode):
             # 5. typecheck the output expressions
             if self.outputs:
                 output_names = set()
+                output_type_env = self._type_env
+                assert output_type_env
                 for output in self.outputs:
                     assert output.expr
                     if output.name in output_names:
@@ -835,10 +837,11 @@ class Workflow(SourceNode):
                         )
                     errors.try1(
                         lambda output=output: output.typecheck(
-                            self._type_env, check_quant=check_quant
+                            output_type_env, check_quant=check_quant
                         )
                     )
                     output_names.add(output.name)
+                    output_type_env = Env.bind(output_type_env, [], output.name, output.type)
         # 6. check for cyclic dependencies
         WDL._util.detect_cycles(_dependency_matrix(_decls_and_calls(self)))  # pyre-fixme
 

--- a/WDL/_parser.py
+++ b/WDL/_parser.py
@@ -262,7 +262,7 @@ def parse(txt: str, start: str, version: Optional[str] = None) -> lark.Tree:
         _lark_cache[(version, start)] = lark.Lark(
             _grammar_for_version(version), start=start, parser="lalr", propagate_positions=True
         )
-    return _lark_cache[(version, start)].parse(txt)
+    return _lark_cache[(version, start)].parse(txt + ("\n" if not txt.endswith("\n") else ""))
 
 
 def sp(filename, meta) -> SourcePosition:

--- a/tests/test_1doc.py
+++ b/tests/test_1doc.py
@@ -1187,7 +1187,9 @@ class TestDoc(unittest.TestCase):
                 y = y
             }
             output {
-                Int z = z
+                Int z = z+1
+                Int w = x+y
+                Array[Int] outs = [z,w]
             }
         }
         """

--- a/tests/test_3corpi.py
+++ b/tests/test_3corpi.py
@@ -200,3 +200,18 @@ class Contrived(unittest.TestCase):
 )
 class Contrived2(unittest.TestCase):
     pass
+
+@test_corpus(
+    ["test_corpi/biowdl/tasks/**"],
+    expected_lint={'OptionalCoercion': 3, 'NonemptyCoercion': 1, 'UnnecessaryQuantifier': 3, 'UnusedDeclaration': 6},
+    check_quant=False,
+    blacklist=[
+        # use Object
+        "common", "bamstats", "seqstat", "flash", "sampleconfig", "strelka",
+        "stringtie", "vardict", "manta", "somaticseq", "biopet",
+        # preoutput declarations (FIXME)
+        "gffcompare", "multiqc",
+    ],
+)
+class BioWDLTasks(unittest.TestCase):
+    pass

--- a/tests/test_3corpi.py
+++ b/tests/test_3corpi.py
@@ -203,14 +203,12 @@ class Contrived2(unittest.TestCase):
 
 @test_corpus(
     ["test_corpi/biowdl/tasks/**"],
-    expected_lint={'OptionalCoercion': 3, 'NonemptyCoercion': 1, 'UnnecessaryQuantifier': 3, 'UnusedDeclaration': 6},
+    expected_lint={'OptionalCoercion': 4, 'NonemptyCoercion': 1, 'UnnecessaryQuantifier': 3, 'UnusedDeclaration': 9},
     check_quant=False,
     blacklist=[
         # use Object
         "common", "bamstats", "seqstat", "flash", "sampleconfig", "strelka",
         "stringtie", "vardict", "manta", "somaticseq", "biopet",
-        # preoutput declarations (FIXME)
-        "gffcompare", "multiqc",
     ],
 )
 class BioWDLTasks(unittest.TestCase):


### PR DESCRIPTION
- typechecker: workflow output expressions can reference previous workflow outputs (#155)
- parser: task 'non-input' declarations can interleave anywhere among other sections (#156)
- parser: spike in newline at end of input (accommodates last-line comments)
- check: make UnusedDeclaration's heuristic index files exception case-insensitive