### PR TITLE
refactoring errors

### DIFF
--- a/WDL/Error.py
+++ b/WDL/Error.py
@@ -109,6 +109,10 @@ class InvalidType(ValidationError):
     pass
 
 
+class IndeterminateType(ValidationError):
+    pass
+
+
 class NoSuchTask(ValidationError):
     def __init__(self, node: Union[SourceNode, SourcePosition], name: str) -> None:
         super().__init__(node, "No such task/workflow: " + name)
@@ -152,16 +156,6 @@ class StaticTypeMismatch(ValidationError):
 class IncompatibleOperand(ValidationError):
     def __init__(self, node: SourceNode, message: str) -> None:
         super().__init__(node, message)
-
-
-class OutOfBounds(ValidationError):
-    def __init__(self, node: SourceNode) -> None:
-        super().__init__(node, "Array index out of bounds")
-
-
-class EmptyArray(ValidationError):
-    def __init__(self, node: SourceNode) -> None:
-        super().__init__(node, "Empty array for Array+ input/declaration")
 
 
 class UnknownIdentifier(ValidationError):
@@ -296,6 +290,16 @@ class EvalError(RuntimeError):
         else:
             self.pos = node
         super().__init__(message)
+
+
+class OutOfBounds(EvalError):
+    def __init__(self, node: SourceNode) -> None:
+        super().__init__(node, "Array index out of bounds")
+
+
+class EmptyArray(EvalError):
+    def __init__(self, node: SourceNode) -> None:
+        super().__init__(node, "Empty array for Array+ input/declaration")
 
 
 class NullValue(EvalError):

--- a/WDL/Expr.py
+++ b/WDL/Expr.py
@@ -93,13 +93,23 @@ class Base(SourceNode, ABC):
         return self
 
     @abstractmethod
+    def _eval(self, env: Env.Values, stdlib: "Optional[WDL.StdLib.Base]" = None) -> V.Base:
+        # to be overridden by subclasses. eval() calls this and deals with any
+        # exceptions raised
+        pass
+
     def eval(self, env: Env.Values, stdlib: "Optional[WDL.StdLib.Base]" = None) -> V.Base:
         """
         Evaluate the expression in the given environment
         
         :param stdlib: a context-specific standard function library implementation
         """
-        pass
+        try:
+            return self._eval(env, stdlib)
+        except Error.EvalError:
+            raise
+        except Exception as exn:
+            raise Error.EvalError(self, str(exn)) from exn
 
 
 class Boolean(Base):
@@ -121,7 +131,7 @@ class Boolean(Base):
     def _infer_type(self, type_env: Env.Types) -> T.Base:
         return T.Boolean()
 
-    def eval(self, env: Env.Values, stdlib: "Optional[WDL.StdLib.Base]" = None) -> V.Boolean:
+    def _eval(self, env: Env.Values, stdlib: "Optional[WDL.StdLib.Base]" = None) -> V.Boolean:
         ""
         return V.Boolean(self.value)
 
@@ -145,7 +155,7 @@ class Int(Base):
     def _infer_type(self, type_env: Env.Types) -> T.Base:
         return T.Int()
 
-    def eval(self, env: Env.Values, stdlib: "Optional[WDL.StdLib.Base]" = None) -> V.Int:
+    def _eval(self, env: Env.Values, stdlib: "Optional[WDL.StdLib.Base]" = None) -> V.Int:
         ""
         return V.Int(self.value)
 
@@ -172,7 +182,7 @@ class Float(Base):
     def _infer_type(self, type_env: Env.Types) -> T.Base:
         return T.Float()
 
-    def eval(self, env: Env.Values, stdlib: "Optional[WDL.StdLib.Base]" = None) -> V.Float:
+    def _eval(self, env: Env.Values, stdlib: "Optional[WDL.StdLib.Base]" = None) -> V.Float:
         ""
         return V.Float(self.value)
 
@@ -237,7 +247,7 @@ class Placeholder(Base):
                 )
         return T.String()
 
-    def eval(self, env: Env.Values, stdlib: "Optional[WDL.StdLib.Base]" = None) -> V.String:
+    def _eval(self, env: Env.Values, stdlib: "Optional[WDL.StdLib.Base]" = None) -> V.String:
         ""
         v = self.expr.eval(env, stdlib)
         if isinstance(v, V.Null):
@@ -285,7 +295,7 @@ class String(Base):
         ""
         return super().typecheck(expected)  # pyre-ignore
 
-    def eval(self, env: Env.Values, stdlib: "Optional[WDL.StdLib.Base]" = None) -> V.String:
+    def _eval(self, env: Env.Values, stdlib: "Optional[WDL.StdLib.Base]" = None) -> V.String:
         ""
         ans = []
         for part in self.parts:
@@ -371,7 +381,7 @@ class Array(Base):
             return self
         return super().typecheck(expected)  # pyre-ignore
 
-    def eval(self, env: Env.Values, stdlib: "Optional[WDL.StdLib.Base]" = None) -> V.Array:
+    def _eval(self, env: Env.Values, stdlib: "Optional[WDL.StdLib.Base]" = None) -> V.Array:
         ""
         assert isinstance(self.type, T.Array)
         return V.Array(
@@ -410,7 +420,7 @@ class Pair(Base):
     def _infer_type(self, type_env: Env.Types) -> T.Base:
         return T.Pair(self.left.type, self.right.type)
 
-    def eval(self, env: Env.Values, stdlib: "Optional[WDL.StdLib.Base]" = None) -> V.Base:
+    def _eval(self, env: Env.Values, stdlib: "Optional[WDL.StdLib.Base]" = None) -> V.Base:
         ""
         assert isinstance(self.type, T.Pair)
         lv = self.left.eval(env, stdlib)
@@ -457,7 +467,7 @@ class Map(Base):
         assert vty is not None
         return T.Map((kty, vty))
 
-    def eval(self, env: Env.Values, stdlib: "Optional[WDL.StdLib.Base]" = None) -> V.Base:
+    def _eval(self, env: Env.Values, stdlib: "Optional[WDL.StdLib.Base]" = None) -> V.Base:
         ""
         assert isinstance(self.type, T.Map)
         eitems = []
@@ -498,7 +508,7 @@ class Struct(Base):
             member_types[k] = v.type
         return T.Object(member_types)
 
-    def eval(self, env: Env.Values, stdlib: "Optional[WDL.StdLib.Base]" = None) -> V.Base:
+    def _eval(self, env: Env.Values, stdlib: "Optional[WDL.StdLib.Base]" = None) -> V.Base:
         ans = {}
         for k, v in self.members.items():
             ans[k] = v.eval(env, stdlib)
@@ -583,7 +593,7 @@ class IfThenElse(Base):
             ) from None
         return self_type
 
-    def eval(self, env: Env.Values, stdlib: "Optional[WDL.StdLib.Base]" = None) -> V.Base:
+    def _eval(self, env: Env.Values, stdlib: "Optional[WDL.StdLib.Base]" = None) -> V.Base:
         ""
         try:
             if self.condition.eval(env, stdlib).expect(T.Boolean()).value:
@@ -640,7 +650,7 @@ class Ident(Base):
         self.ctx = Env.resolve_ctx(type_env, self.namespace, self.name)
         return ans
 
-    def eval(self, env: Env.Values, stdlib: "Optional[WDL.StdLib.Base]" = None) -> V.Base:
+    def _eval(self, env: Env.Values, stdlib: "Optional[WDL.StdLib.Base]" = None) -> V.Base:
         ""
         ans: V.Base = Env.resolve(env, self.namespace, self.name)
         return ans
@@ -669,7 +679,7 @@ class _LeftName(Base):
     def _infer_type(self, type_env: Env.Types) -> T.Base:
         raise NotImplementedError()
 
-    def eval(self, env: Env.Values, stdlib: "Optional[WDL.StdLib.Base]" = None) -> V.Base:
+    def _eval(self, env: Env.Values, stdlib: "Optional[WDL.StdLib.Base]" = None) -> V.Base:
         raise NotImplementedError()
 
     @property
@@ -787,7 +797,7 @@ class Get(Base):
                 pass
         raise Error.NoSuchMember(self, self.member)
 
-    def eval(self, env: Env.Values, stdlib: "Optional[WDL.StdLib.Base]" = None) -> V.Base:
+    def _eval(self, env: Env.Values, stdlib: "Optional[WDL.StdLib.Base]" = None) -> V.Base:
         innard_value = self.expr.eval(env, stdlib)
         if not self.member:
             return innard_value
@@ -844,7 +854,7 @@ class Apply(Base):
         assert isinstance(f, StdLibFunction)
         return f.infer_type(self)
 
-    def eval(self, env: Env.Values, stdlib: "Optional[WDL.StdLib.Base]" = None) -> V.Base:
+    def _eval(self, env: Env.Values, stdlib: "Optional[WDL.StdLib.Base]" = None) -> V.Base:
         ""
         from WDL.StdLib import Base as StdLibBase, Function as StdLibFunction
 

--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -1144,8 +1144,8 @@ def _build_workflow_type_env(
         self.expr.infer_type(type_env, check_quant=check_quant)
         if not isinstance(self.expr.type, T.Array):
             raise Err.NotAnArray(self.expr)
-        if self.expr.type.item_type is None:
-            raise Err.EmptyArray(self.expr)
+        if isinstance(self.expr.type.item_type, T.Any):
+            raise Err.IndeterminateType(self.expr, "can't infer item type of empty array")
         # bind the scatter variable to the array item type within the body
         try:
             Env.resolve(type_env, [], self.variable)

--- a/test_corpi/contrived/scatter_collisions.wdl
+++ b/test_corpi/contrived/scatter_collisions.wdl
@@ -11,9 +11,9 @@ struct popular {
 }
 
 workflow contrived {
-    scatter (popular in []) {
+    scatter (popular in [1]) {
     }
-    scatter (contrived in []) {
+    scatter (contrived in [2]) {
     }
 }
 

--- a/tests/test_0eval.py
+++ b/tests/test_0eval.py
@@ -284,9 +284,9 @@ class TestEval(unittest.TestCase):
 
     def test_short_circuit(self):
         self._test_tuples(
-            ("true && 1/0 == 1", "", WDL.Error.IncompatibleOperand),
+            ("true && 1/0 == 1", "", WDL.Error.EvalError),
             ("false && 1/0 == 1", "false"),
-            ("false || 1/0 == 1", "", WDL.Error.IncompatibleOperand),
+            ("false || 1/0 == 1", "", WDL.Error.EvalError),
             ("true || 1/0 == 1", "true"),
         )
 


### PR DESCRIPTION
- OutOfBounds and EmptyArray inherit EvalError instead of ValidationError
- Expr.eval() reraises any error as EvalError
- introduce IntdeterminateType : ValidationError