### PR TITLE
struct literals may omit optional fields

### DIFF
--- a/WDL/Type.py
+++ b/WDL/Type.py
@@ -432,10 +432,16 @@ class Object(Base):
             # are coercible to the respective member types.
             # TODO: in the event of StaticTypeMismatch errors, this may produce
             # unwieldy error messages
-            if set(self.members.keys()) != set(rhs_members.keys()):
+            self_keys = set(self.members.keys())
+            rhs_keys = set(rhs_members.keys())
+            if self_keys - rhs_keys:
                 return False
-            for k in self.members.keys():
+            for k in self_keys:
                 if not self.members[k].coerces(rhs_members[k], check_quant):
+                    return False
+            for opt_k in (rhs_keys - self_keys):
+                # object literal may omit optional struct fields
+                if not rhs_members[opt_k].optional:
                     return False
             return True
         if isinstance(rhs, Any):

--- a/WDL/Type.py
+++ b/WDL/Type.py
@@ -439,7 +439,7 @@ class Object(Base):
             for k in self_keys:
                 if not self.members[k].coerces(rhs_members[k], check_quant):
                     return False
-            for opt_k in (rhs_keys - self_keys):
+            for opt_k in rhs_keys - self_keys:
                 # object literal may omit optional struct fields
                 if not rhs_members[opt_k].optional:
                     return False

--- a/WDL/_parser.py
+++ b/WDL/_parser.py
@@ -346,7 +346,9 @@ class _ExprTransformer(lark.Transformer):
 
     def object_kv(self, items, meta):
         assert len(items) == 2
-        k = items[0].value
+        k = items[0]
+        if isinstance(k, lark.Token):
+            k = k.value
         assert isinstance(k, str), k
         assert isinstance(items[1], E.Base)
         return (k, items[1])

--- a/WDL/_parser.py
+++ b/WDL/_parser.py
@@ -346,7 +346,7 @@ class _ExprTransformer(lark.Transformer):
 
     def object_kv(self, items, meta):
         assert len(items) == 2
-        k = items[0]
+        k = items[0].value
         assert isinstance(k, str), k
         assert isinstance(items[1], E.Base)
         return (k, items[1])

--- a/tests/test_3corpi.py
+++ b/tests/test_3corpi.py
@@ -203,11 +203,10 @@ class Contrived2(unittest.TestCase):
 
 @test_corpus(
     ["test_corpi/biowdl/tasks/**"],
-    expected_lint={'UnusedImport': 7, 'OptionalCoercion': 9, 'StringCoercion': 10, 'UnusedDeclaration': 10, 'NonemptyCoercion': 1, 'UnnecessaryQuantifier': 3, 'NameCollision': 1},
+    expected_lint={'UnusedImport': 10, 'OptionalCoercion': 11, 'StringCoercion': 14, 'UnusedDeclaration': 12, 'UnnecessaryQuantifier': 41, 'NonemptyCoercion': 1, 'NameCollision': 1},
     check_quant=False,
     blacklist=[
-        # issue #167
-        "biopet", "flash", "manta"
+
     ],
 )
 class BioWDLTasks(unittest.TestCase):

--- a/tests/test_3corpi.py
+++ b/tests/test_3corpi.py
@@ -205,9 +205,6 @@ class Contrived2(unittest.TestCase):
     ["test_corpi/biowdl/tasks/**"],
     expected_lint={'UnusedImport': 10, 'OptionalCoercion': 11, 'StringCoercion': 14, 'UnusedDeclaration': 12, 'UnnecessaryQuantifier': 41, 'NonemptyCoercion': 1, 'NameCollision': 1},
     check_quant=False,
-    blacklist=[
-
-    ],
 )
 class BioWDLTasks(unittest.TestCase):
     pass

--- a/tests/test_4taskrun.py
+++ b/tests/test_4taskrun.py
@@ -361,6 +361,24 @@ class TestTaskRunner(unittest.TestCase):
             command {}
         }
         """)
+        outputs = self._test_task(R"""
+        version 1.0
+        struct Car {
+            String model
+            Int year
+            Int? mileage
+        }
+        task t {
+            command {}
+            output {
+                Car car = object {
+                    model: "Mazda",
+                    year: 2017
+                }
+            }
+        }
+        """)
+        self.assertEqual(outputs["car"], {"model": "Mazda", "year": 2017, "mileage": None})
 
     def test_errors(self):
         self._test_task(R"""


### PR DESCRIPTION
An object literal typechecks with a struct type even if it omits some fields, if the omitted fields have optional types. At runtime, when the literal is coerced to the struct instance, these fields are filled in with null values. This should be done earlier during eval of the literal, in the future when there's a new struct literal syntax making the desired struct type known at eval time.