### PR TITLE
clean up internal imports

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -3,7 +3,6 @@
     "WDL"
   ],
   "search_path": [
-    ".",
     "stubs"
   ],
   "workers": 4

--- a/WDL/Error.py
+++ b/WDL/Error.py
@@ -3,7 +3,7 @@ import os
 from typing import List, Optional, NamedTuple, Union, Iterable, TypeVar, Generator, Callable, Any
 from functools import total_ordering
 from contextlib import contextmanager
-import WDL.Type as T
+from . import Type
 
 
 SourcePosition = NamedTuple(
@@ -143,7 +143,11 @@ class NoSuchMember(ValidationError):
 
 class StaticTypeMismatch(ValidationError):
     def __init__(
-        self, node: SourceNode, expected: T.Base, actual: T.Base, message: Optional[str] = None
+        self,
+        node: SourceNode,
+        expected: Type.Base,
+        actual: Type.Base,
+        message: Optional[str] = None,
     ) -> None:
         self.expected = expected
         self.actual = actual

--- a/WDL/Lint.py
+++ b/WDL/Lint.py
@@ -27,10 +27,10 @@ import json
 import os
 import shutil
 from typing import Any, Optional, Union
-import WDL
+from . import Error, Type, Env, Expr, Tree, StdLib, Walker, _util
 
 
-class Linter(WDL.Walker.Base):
+class Linter(Walker.Base):
     """
     Linters are Walkers which annotate each Tree node with
         ``lint : List[Tuple[SourceNode,str,str]]``
@@ -44,12 +44,7 @@ class Linter(WDL.Walker.Base):
     def __init__(self, auto_descend: bool = True, descend_imports: bool = True):
         super().__init__(auto_descend=auto_descend, descend_imports=descend_imports)
 
-    def add(
-        self,
-        obj: WDL.Error.SourceNode,
-        message: str,
-        pos: Optional[WDL.Error.SourcePosition] = None,
-    ):
+    def add(self, obj: Error.SourceNode, message: str, pos: Optional[Error.SourcePosition] = None):
         """
         Used by subclasses to attach lint to a node.
 
@@ -57,7 +52,7 @@ class Linter(WDL.Walker.Base):
         Conditional, Document). Warnings about individual expressions should
         attach to their parent Tree node.
         """
-        assert not isinstance(obj, WDL.Expr.Base)
+        assert not isinstance(obj, Expr.Base)
         if pos is None:
             pos = obj.pos
         if not hasattr(obj, "lint"):
@@ -81,15 +76,15 @@ def lint(doc, descend_imports: bool = True):
     """
 
     # Add additional markups to the AST for use by the linters
-    WDL.Walker.SetParents()(doc)
-    WDL.Walker.MarkCalled()(doc)
-    WDL.Walker.SetReferrers()(doc)
+    Walker.SetParents()(doc)
+    Walker.MarkCalled()(doc)
+    Walker.SetReferrers()(doc)
 
     # instantiate linters
     linter_instances = [cons(descend_imports=descend_imports) for cons in _all_linters]
 
     # run auto-descend linters "concurrently"
-    WDL.Walker.Multi(
+    Walker.Multi(
         [linter for linter in linter_instances if linter.auto_descend],
         descend_imports=descend_imports,
     )(doc)
@@ -101,7 +96,7 @@ def lint(doc, descend_imports: bool = True):
     return doc
 
 
-class _Collector(WDL.Walker.Base):
+class _Collector(Walker.Base):
     def __init__(self):
         super().__init__(auto_descend=True)
         self.lint = []
@@ -122,25 +117,25 @@ def collect(doc):
     return collector.lint
 
 
-def _find_input_decl(obj: WDL.Tree.Call, name: str) -> WDL.Tree.Decl:
-    assert isinstance(obj.callee, (WDL.Tree.Task, WDL.Tree.Workflow))
-    return WDL.Env.resolve(obj.callee.available_inputs, [], name)
+def _find_input_decl(obj: Tree.Call, name: str) -> Tree.Decl:
+    assert isinstance(obj.callee, (Tree.Task, Tree.Workflow))
+    return Env.resolve(obj.callee.available_inputs, [], name)
 
 
 def _compound_coercion(to_type, from_type, base_to_type, extra_from_type=None):
     # helper for StringCoercion and FileCoercion to detect coercions implied
     # within compound types like arrays
-    if isinstance(to_type, WDL.Type.Array) and isinstance(from_type, WDL.Type.Array):
+    if isinstance(to_type, Type.Array) and isinstance(from_type, Type.Array):
         return _compound_coercion(
             to_type.item_type, from_type.item_type, base_to_type, extra_from_type
         )
-    elif isinstance(to_type, WDL.Type.Map) and isinstance(from_type, WDL.Type.Map):
+    elif isinstance(to_type, Type.Map) and isinstance(from_type, Type.Map):
         return _compound_coercion(
             to_type.item_type[0], from_type.item_type[0], base_to_type, extra_from_type
         ) or _compound_coercion(
             to_type.item_type[1], from_type.item_type[1], base_to_type, extra_from_type
         )
-    elif isinstance(to_type, WDL.Type.Pair) and isinstance(from_type, WDL.Type.Pair):
+    elif isinstance(to_type, Type.Pair) and isinstance(from_type, Type.Pair):
         return _compound_coercion(
             to_type.left_type, from_type.left_type, base_to_type, extra_from_type
         ) or _compound_coercion(
@@ -148,15 +143,13 @@ def _compound_coercion(to_type, from_type, base_to_type, extra_from_type=None):
         )
     elif isinstance(to_type, base_to_type):
         if extra_from_type:
-            return not isinstance(from_type, (base_to_type, extra_from_type, WDL.Type.Any))
-        return not isinstance(from_type, (base_to_type, WDL.Type.Any))
+            return not isinstance(from_type, (base_to_type, extra_from_type, Type.Any))
+        return not isinstance(from_type, (base_to_type, Type.Any))
     return False
 
 
-def _parent_executable(
-    obj: WDL.Error.SourceNode
-) -> Optional[Union[WDL.Tree.Task, WDL.Tree.Workflow]]:
-    if isinstance(obj, (WDL.Tree.Task, WDL.Tree.Workflow)):
+def _parent_executable(obj: Error.SourceNode) -> Optional[Union[Tree.Task, Tree.Workflow]]:
+    if isinstance(obj, (Tree.Task, Tree.Workflow)):
         return obj
     if hasattr(obj, "parent_executable"):
         return getattr(obj, "parent_executable")
@@ -172,28 +165,28 @@ class StringCoercion(Linter):
     # String declaration with non-String rhs expression
     # File-to-String coercions are normal in tasks, but flagged at the workflow level.
 
-    def decl(self, obj: WDL.Tree.Decl) -> Any:
+    def decl(self, obj: Tree.Decl) -> Any:
         if obj.expr and _compound_coercion(
             obj.type,
             obj.expr.type,
-            WDL.Type.String,
-            (WDL.Type.File if isinstance(_parent_executable(obj), WDL.Tree.Task) else None),
+            Type.String,
+            (Type.File if isinstance(_parent_executable(obj), Tree.Task) else None),
         ):
             self.add(obj, "{} {} = :{}:".format(str(obj.type), obj.name, str(obj.expr.type)))
 
-    def expr(self, obj: WDL.Expr.Base) -> Any:
+    def expr(self, obj: Expr.Base) -> Any:
         pt = getattr(obj, "parent")
-        if isinstance(obj, WDL.Expr.Apply):
+        if isinstance(obj, Expr.Apply):
             # String function operands with non-String expression
             if obj.function_name == "_add":
                 any_string = False
                 all_string = True
                 for arg in obj.arguments:
-                    if isinstance(arg.type, WDL.Type.String):
+                    if isinstance(arg.type, Type.String):
                         any_string = True
-                    elif not isinstance(arg.type, WDL.Type.File):
+                    elif not isinstance(arg.type, Type.File):
                         all_string = arg.type
-                if any_string and all_string is not True and not isinstance(pt, WDL.Tree.Task):
+                if any_string and all_string is not True and not isinstance(pt, Tree.Task):
                     # exception when parent is Task (i.e. we're in the task
                     # command) because the coercion is probably intentional
                     self.add(
@@ -202,8 +195,8 @@ class StringCoercion(Linter):
                         obj.pos,
                     )
             else:
-                F = getattr(WDL.StdLib.Base(), obj.function_name)
-                if isinstance(F, WDL.StdLib.StaticFunction) and obj.function_name != "basename":
+                F = getattr(StdLib.Base(), obj.function_name)
+                if isinstance(F, StdLib.StaticFunction) and obj.function_name != "basename":
                     # ok for basename to take either String or File
                     for i in range(min(len(F.argument_types), len(obj.arguments))):
                         F_i = F.argument_types[i]
@@ -211,27 +204,23 @@ class StringCoercion(Linter):
                         if _compound_coercion(
                             F_i,
                             arg_i.type,
-                            WDL.Type.String,
-                            (
-                                WDL.Type.File
-                                if isinstance(_parent_executable(obj), WDL.Tree.Task)
-                                else None
-                            ),
+                            Type.String,
+                            (Type.File if isinstance(_parent_executable(obj), Tree.Task) else None),
                         ):
                             msg = "{} argument of {}() = :{}:".format(
                                 str(F_i), F.name, str(arg_i.type)
                             )
                             self.add(pt, msg, arg_i.pos)
-        elif isinstance(obj, WDL.Expr.Array):
+        elif isinstance(obj, Expr.Array):
             # Array literal with mixed item types, one of which is String,
             # causing coercion of the others
             any_string = False
             all_string = True
             item_types = []
             for elt in obj.items:
-                if isinstance(elt.type, WDL.Type.String):
+                if isinstance(elt.type, Type.String):
                     any_string = True
-                elif not isinstance(elt.type, (WDL.Type.File, WDL.Type.Any)):
+                elif not isinstance(elt.type, (Type.File, Type.Any)):
                     all_string = False
                 item_types.append(str(elt.type))
             if any_string and not all_string:
@@ -240,10 +229,10 @@ class StringCoercion(Linter):
                 )
                 self.add(pt, msg, obj.pos)
 
-    def call(self, obj: WDL.Tree.Call) -> Any:
+    def call(self, obj: Tree.Call) -> Any:
         for name, inp_expr in obj.inputs.items():
             decl = _find_input_decl(obj, name)
-            if _compound_coercion(decl.type, inp_expr.type, WDL.Type.String):
+            if _compound_coercion(decl.type, inp_expr.type, Type.String):
                 msg = "input {} {} = :{}:".format(str(decl.type), decl.name, str(inp_expr.type))
                 self.add(obj, msg, inp_expr.pos)
 
@@ -256,7 +245,7 @@ class FileCoercion(Linter):
     def __init__(self, descend_imports: bool = True):
         super().__init__(auto_descend=False, descend_imports=descend_imports)
 
-    def task(self, obj: WDL.Tree.Task) -> Any:
+    def task(self, obj: Tree.Task) -> Any:
         # descend into everything but outputs
         for d in obj.inputs or []:
             self(d)
@@ -267,28 +256,28 @@ class FileCoercion(Linter):
             self(ex)
 
     # File declaration with String rhs expression
-    def decl(self, obj: WDL.Tree.Decl) -> Any:
+    def decl(self, obj: Tree.Decl) -> Any:
         super().decl(obj)
-        if obj.expr and _compound_coercion(obj.type, obj.expr.type, WDL.Type.File):
+        if obj.expr and _compound_coercion(obj.type, obj.expr.type, Type.File):
             self.add(obj, "{} {} = :{}:".format(str(obj.type), obj.name, str(obj.expr.type)))
 
-    def expr(self, obj: WDL.Expr.Base) -> Any:
+    def expr(self, obj: Expr.Base) -> Any:
         super().expr(obj)
         pt = getattr(obj, "parent")
-        if isinstance(obj, WDL.Expr.Apply):
+        if isinstance(obj, Expr.Apply):
             # File function operands with String expression
-            F = getattr(WDL.StdLib.Base(), obj.function_name)
-            if isinstance(F, WDL.StdLib.StaticFunction):
+            F = getattr(StdLib.Base(), obj.function_name)
+            if isinstance(F, StdLib.StaticFunction):
                 for i in range(min(len(F.argument_types), len(obj.arguments))):
                     F_i = F.argument_types[i]
                     arg_i = obj.arguments[i]
-                    if _compound_coercion(F_i, arg_i.type, WDL.Type.File):
+                    if _compound_coercion(F_i, arg_i.type, Type.File):
                         msg = "{} argument of {}() = :{}:".format(str(F_i), F.name, str(arg_i.type))
                         self.add(pt, msg, arg_i.pos)
             elif obj.function_name == "size":
-                if not isinstance(obj.arguments[0].type, WDL.Type.File) and not (
-                    isinstance(obj.arguments[0].type, WDL.Type.Array)
-                    and isinstance(obj.arguments[0].type.item_type, WDL.Type.File)
+                if not isinstance(obj.arguments[0].type, Type.File) and not (
+                    isinstance(obj.arguments[0].type, Type.Array)
+                    and isinstance(obj.arguments[0].type.item_type, Type.File)
                 ):
                     self.add(
                         pt,
@@ -298,43 +287,43 @@ class FileCoercion(Linter):
                         obj.arguments[0].pos,
                     )
 
-    def call(self, obj: WDL.Tree.Call) -> Any:
+    def call(self, obj: Tree.Call) -> Any:
         super().call(obj)
         for name, inp_expr in obj.inputs.items():
             decl = _find_input_decl(obj, name)
-            if _compound_coercion(decl.type, inp_expr.type, WDL.Type.File):
+            if _compound_coercion(decl.type, inp_expr.type, Type.File):
                 msg = "input {} {} = :{}:".format(str(decl.type), decl.name, str(inp_expr.type))
                 self.add(obj, msg, inp_expr.pos)
 
 
-def _array_levels(ty: WDL.Type.Base, l=0):
-    if isinstance(ty, WDL.Type.Array):
+def _array_levels(ty: Type.Base, l=0):
+    if isinstance(ty, Type.Array):
         return _array_levels(ty.item_type, l + 1)
     return l
 
 
-def _is_array_coercion(value_type: WDL.Type.Base, expr_type: WDL.Type.Base):
+def _is_array_coercion(value_type: Type.Base, expr_type: Type.Base):
     return (
-        isinstance(value_type, WDL.Type.Array)
+        isinstance(value_type, Type.Array)
         and _array_levels(value_type) > _array_levels(expr_type)
-        and not isinstance(expr_type, WDL.Type.Any)
-        and expr_type != WDL.Type.Array(WDL.Type.Any())
+        and not isinstance(expr_type, Type.Any)
+        and expr_type != Type.Array(Type.Any())
     )
 
 
 @a_linter
 class ArrayCoercion(Linter):
     # implicit promotion of T to Array[T]
-    def decl(self, obj: WDL.Tree.Decl) -> Any:
+    def decl(self, obj: Tree.Decl) -> Any:
         if obj.expr and _is_array_coercion(obj.type, obj.expr.type):
             msg = "{} {} = :{}:".format(str(obj.type), obj.name, str(obj.expr.type))
             self.add(obj, msg)
 
-    def expr(self, obj: WDL.Expr.Base) -> Any:
+    def expr(self, obj: Expr.Base) -> Any:
         pt = getattr(obj, "parent")
-        if isinstance(obj, WDL.Expr.Apply):
-            F = getattr(WDL.StdLib.Base(), obj.function_name)
-            if isinstance(F, WDL.StdLib.StaticFunction):
+        if isinstance(obj, Expr.Apply):
+            F = getattr(StdLib.Base(), obj.function_name)
+            if isinstance(F, StdLib.StaticFunction):
                 for i in range(min(len(F.argument_types), len(obj.arguments))):
                     F_i = F.argument_types[i]
                     arg_i = obj.arguments[i]
@@ -342,7 +331,7 @@ class ArrayCoercion(Linter):
                         msg = "{} argument of {}() = :{}:".format(str(F_i), F.name, str(arg_i.type))
                         self.add(pt, msg, arg_i.pos)
 
-    def call(self, obj: WDL.Tree.Call) -> Any:
+    def call(self, obj: Tree.Call) -> Any:
         for name, inp_expr in obj.inputs.items():
             decl = _find_input_decl(obj, name)
             if _is_array_coercion(decl.type, inp_expr.type):
@@ -355,15 +344,14 @@ class OptionalCoercion(Linter):
     # Expression of optional type where a non-optional value is expected
     # Normally these fail typechecking, but the enforcement isn't stringent in
     # older WDLs.
-    def expr(self, obj: WDL.Expr.Base) -> Any:
-        if isinstance(obj, WDL.Expr.Apply):
+    def expr(self, obj: Expr.Base) -> Any:
+        if isinstance(obj, Expr.Apply):
             if obj.function_name in ["_add", "_sub", "_mul", "_div", "_land", "_lor"]:
                 assert len(obj.arguments) == 2
                 arg0ty = obj.arguments[0].type
                 arg1ty = obj.arguments[1].type
                 if (arg0ty.optional or arg1ty.optional) and (
-                    obj.function_name != "_add"
-                    or not isinstance(getattr(obj, "parent"), WDL.Tree.Task)
+                    obj.function_name != "_add" or not isinstance(getattr(obj, "parent"), Tree.Task)
                 ):
                     # exception for + in task command because the coercion is
                     # probably intentional, per "Prepending a String to an
@@ -377,8 +365,8 @@ class OptionalCoercion(Linter):
                         ),
                     )
             else:
-                F = getattr(WDL.StdLib.Base(), obj.function_name)
-                if isinstance(F, WDL.StdLib.StaticFunction):
+                F = getattr(StdLib.Base(), obj.function_name)
+                if isinstance(F, StdLib.StaticFunction):
                     for i in range(min(len(F.argument_types), len(obj.arguments))):
                         F_i = F.argument_types[i]
                         arg_i = obj.arguments[i]
@@ -390,7 +378,7 @@ class OptionalCoercion(Linter):
                             )
                             self.add(getattr(obj, "parent"), msg, obj.arguments[i].pos)
 
-    def decl(self, obj: WDL.Tree.Decl) -> Any:
+    def decl(self, obj: Tree.Decl) -> Any:
         if (
             obj.expr
             and not obj.expr.type.coerces(obj.type, check_quant=True)
@@ -398,7 +386,7 @@ class OptionalCoercion(Linter):
         ):
             self.add(obj, "{} {} = :{}:".format(str(obj.type), obj.name, str(obj.expr.type)))
 
-    def call(self, obj: WDL.Tree.Call) -> Any:
+    def call(self, obj: Tree.Call) -> Any:
         for name, inp_expr in obj.inputs.items():
             decl = _find_input_decl(obj, name)
             if not inp_expr.type.coerces(decl.type, check_quant=True) and not _is_array_coercion(
@@ -408,10 +396,10 @@ class OptionalCoercion(Linter):
                 self.add(obj, msg, inp_expr.pos)
 
 
-def _is_nonempty_coercion(value_type: WDL.Type.Base, expr_type: WDL.Type.Base):
+def _is_nonempty_coercion(value_type: Type.Base, expr_type: Type.Base):
     return (
-        isinstance(value_type, WDL.Type.Array)
-        and isinstance(expr_type, WDL.Type.Array)
+        isinstance(value_type, Type.Array)
+        and isinstance(expr_type, Type.Array)
         and value_type.nonempty
         and not expr_type.nonempty
     )
@@ -421,10 +409,10 @@ def _is_nonempty_coercion(value_type: WDL.Type.Base, expr_type: WDL.Type.Base):
 @a_linter
 class NonemptyCoercion(Linter):
     # An array of possibly-empty type where a nonempty array is expected
-    def expr(self, obj: WDL.Expr.Base) -> Any:
-        if isinstance(obj, WDL.Expr.Apply):
-            F = getattr(WDL.StdLib.Base(), obj.function_name)
-            if isinstance(F, WDL.StdLib.StaticFunction):
+    def expr(self, obj: Expr.Base) -> Any:
+        if isinstance(obj, Expr.Apply):
+            F = getattr(StdLib.Base(), obj.function_name)
+            if isinstance(F, StdLib.StaticFunction):
                 for i in range(min(len(F.argument_types), len(obj.arguments))):
                     F_i = F.argument_types[i]
                     arg_i = obj.arguments[i]
@@ -434,19 +422,19 @@ class NonemptyCoercion(Linter):
                         )
                         self.add(getattr(obj, "parent"), msg, obj.arguments[i].pos)
 
-    def decl(self, obj: WDL.Tree.Decl) -> Any:
+    def decl(self, obj: Tree.Decl) -> Any:
         # heuristic exception for: Array[File]+ outp = glob(...)
         if (
             obj.expr
             and _is_nonempty_coercion(obj.type, obj.expr.type)
             and not (
-                isinstance(obj.expr, WDL.Expr.Apply)
+                isinstance(obj.expr, Expr.Apply)
                 and obj.expr.function_name in ["glob", "read_lines", "read_tsv", "read_array"]
             )
         ):
             self.add(obj, "{} {} = :{}:".format(str(obj.type), obj.name, str(obj.expr.type)))
 
-    def call(self, obj: WDL.Tree.Call) -> Any:
+    def call(self, obj: Tree.Call) -> Any:
         for name, inp_expr in obj.inputs.items():
             decl = _find_input_decl(obj, name)
             if _is_nonempty_coercion(decl.type, inp_expr.type):
@@ -457,7 +445,7 @@ class NonemptyCoercion(Linter):
 @a_linter
 class IncompleteCall(Linter):
     # Call without all required inputs (allowed for top-level workflow)
-    def call(self, obj: WDL.Tree.Call) -> Any:
+    def call(self, obj: Tree.Call) -> Any:
         assert obj.callee is not None
         # pyre-fixme
         required_inputs = set(decl.name for decl in obj.callee.required_inputs)
@@ -491,11 +479,11 @@ class NameCollision(Linter):
     # - task and struct type/alias
     # - struct type/alias and import
     # These are allowed, but confusing.
-    def call(self, obj: WDL.Tree.Call) -> Any:
+    def call(self, obj: Tree.Call) -> Any:
         doc = obj
-        while not isinstance(doc, WDL.Tree.Document):
+        while not isinstance(doc, Tree.Document):
             doc = getattr(doc, "parent")
-        assert isinstance(doc, WDL.Tree.Document)
+        assert isinstance(doc, Tree.Document)
         for imp in doc.imports:
             if imp.namespace == obj.name:
                 msg = "call name '{}' collides with imported document namespace".format(obj.name)
@@ -504,18 +492,18 @@ class NameCollision(Linter):
             msg = "call name '{}' collides with workflow name".format(obj.name)
             self.add(obj, msg)
         for stb in doc.struct_typedefs:
-            assert isinstance(stb, WDL.Env.Binding) and isinstance(stb.rhs, WDL.Tree.StructTypeDef)
+            assert isinstance(stb, Env.Binding) and isinstance(stb.rhs, Tree.StructTypeDef)
             if stb.name == obj.name:
                 msg = "call name '{}' colides with {}struct type".format(
                     obj.name, "imported " if stb.rhs.imported else ""
                 )
                 self.add(obj, msg)
 
-    def decl(self, obj: WDL.Tree.Decl) -> Any:
+    def decl(self, obj: Tree.Decl) -> Any:
         doc = obj
-        while not isinstance(doc, WDL.Tree.Document):
+        while not isinstance(doc, Tree.Document):
             doc = getattr(doc, "parent")
-        assert isinstance(doc, WDL.Tree.Document)
+        assert isinstance(doc, Tree.Document)
         for imp in doc.imports:
             if imp.namespace == obj.name:
                 msg = "declaration of '{}' collides with imported document namespace".format(
@@ -530,18 +518,18 @@ class NameCollision(Linter):
                 msg = "declaration of '{}' collides with a task name".format(obj.name)
                 self.add(obj, msg)
         for stb in doc.struct_typedefs:
-            assert isinstance(stb, WDL.Env.Binding) and isinstance(stb.rhs, WDL.Tree.StructTypeDef)
+            assert isinstance(stb, Env.Binding) and isinstance(stb.rhs, Tree.StructTypeDef)
             if stb.name == obj.name:
                 msg = "declaration of '{}' colides with {}struct type".format(
                     obj.name, "imported " if stb.rhs.imported else ""
                 )
                 self.add(obj, msg)
 
-    def scatter(self, obj: WDL.Tree.Scatter) -> Any:
+    def scatter(self, obj: Tree.Scatter) -> Any:
         doc = obj
-        while not isinstance(doc, WDL.Tree.Document):
+        while not isinstance(doc, Tree.Document):
             doc = getattr(doc, "parent")
-        assert isinstance(doc, WDL.Tree.Document)
+        assert isinstance(doc, Tree.Document)
         for imp in doc.imports:
             if imp.namespace == obj.variable:
                 msg = "scatter variable '{}' collides with imported document namespace".format(
@@ -556,18 +544,18 @@ class NameCollision(Linter):
                 msg = "scatter variable '{}' collides with a task name".format(obj.variable)
                 self.add(obj, msg)
         for stb in doc.struct_typedefs:
-            assert isinstance(stb, WDL.Env.Binding) and isinstance(stb.rhs, WDL.Tree.StructTypeDef)
+            assert isinstance(stb, Env.Binding) and isinstance(stb.rhs, Tree.StructTypeDef)
             if stb.name == obj.variable:
                 msg = "scatter variable '{}' colides with {}struct type".format(
                     obj.variable, "imported " if stb.rhs.imported else ""
                 )
                 self.add(obj, msg)
 
-    def workflow(self, obj: WDL.Tree.Workflow) -> Any:
+    def workflow(self, obj: Tree.Workflow) -> Any:
         doc = obj
-        while not isinstance(doc, WDL.Tree.Document):
+        while not isinstance(doc, Tree.Document):
             doc = getattr(doc, "parent")
-        assert isinstance(doc, WDL.Tree.Document)
+        assert isinstance(doc, Tree.Document)
         for imp in doc.imports:
             if imp.namespace == obj.name:
                 msg = "workflow name '{}' collides with imported document namespace".format(
@@ -575,36 +563,34 @@ class NameCollision(Linter):
                 )
                 self.add(obj, msg)
         for stb in doc.struct_typedefs:
-            assert isinstance(stb, WDL.Env.Binding) and isinstance(stb.rhs, WDL.Tree.StructTypeDef)
+            assert isinstance(stb, Env.Binding) and isinstance(stb.rhs, Tree.StructTypeDef)
             if stb.name == obj.name:
                 msg = "workflow name '{}' colides with {}struct type".format(
                     obj.name, "imported " if stb.rhs.imported else ""
                 )
                 self.add(obj, msg)
 
-    def task(self, obj: WDL.Tree.Task) -> Any:
+    def task(self, obj: Tree.Task) -> Any:
         doc = obj
-        while not isinstance(doc, WDL.Tree.Document):
+        while not isinstance(doc, Tree.Document):
             doc = getattr(doc, "parent")
-        assert isinstance(doc, WDL.Tree.Document)
+        assert isinstance(doc, Tree.Document)
         for imp in doc.imports:
             if imp.namespace == obj.name:
                 msg = "task name '{}' collides with imported document namespace".format(obj.name)
                 self.add(obj, msg)
         for stb in doc.struct_typedefs:
-            assert isinstance(stb, WDL.Env.Binding) and isinstance(stb.rhs, WDL.Tree.StructTypeDef)
+            assert isinstance(stb, Env.Binding) and isinstance(stb.rhs, Tree.StructTypeDef)
             if stb.name == obj.name:
                 msg = "task name '{}' colides with {}struct type".format(
                     obj.name, "imported " if stb.rhs.imported else ""
                 )
                 self.add(obj, msg)
 
-    def document(self, obj: WDL.Tree.Document) -> Any:
+    def document(self, obj: Tree.Document) -> Any:
         for imp in obj.imports:
             for stb in obj.struct_typedefs:
-                assert isinstance(stb, WDL.Env.Binding) and isinstance(
-                    stb.rhs, WDL.Tree.StructTypeDef
-                )
+                assert isinstance(stb, Env.Binding) and isinstance(stb.rhs, Tree.StructTypeDef)
                 if stb.name == imp.namespace:
                     msg = "imported document namespace '{}' collides with {}struct type".format(
                         imp.namespace, "imported " if stb.rhs.imported else ""
@@ -616,7 +602,7 @@ class NameCollision(Linter):
 class UnusedImport(Linter):
     # Nothing used from an imported document
     # TODO: suppress if document is imported just to use its struct type declarations
-    def document(self, obj: WDL.Tree.Document) -> Any:
+    def document(self, obj: Tree.Document) -> Any:
         for imp in obj.imports:
             assert imp.doc is not None
             any_called = False
@@ -634,18 +620,18 @@ class UnusedImport(Linter):
 @a_linter
 class ForwardReference(Linter):
     # Ident referencing a value or call output lexically precedes Decl/Call
-    def expr(self, obj: WDL.Expr.Base) -> Any:
+    def expr(self, obj: Expr.Base) -> Any:
         if (
-            isinstance(obj, WDL.Expr.Ident)
-            and isinstance(obj.ctx, (WDL.Tree.Decl, WDL.Tree.Call))
+            isinstance(obj, Expr.Ident)
+            and isinstance(obj.ctx, (Tree.Decl, Tree.Call))
             and (
                 obj.ctx.pos.line > obj.pos.line
                 or (obj.ctx.pos.line == obj.pos.line and obj.ctx.pos.column > obj.pos.column)
             )
         ):
-            if isinstance(obj.ctx, WDL.Tree.Decl):
+            if isinstance(obj.ctx, Tree.Decl):
                 msg = "reference to {} precedes its declaration".format(obj.name)
-            elif isinstance(obj.ctx, WDL.Tree.Call):
+            elif isinstance(obj.ctx, Tree.Call):
                 msg = "reference to output of {} precedes the call".format(".".join(obj.namespace))
             else:
                 assert False
@@ -655,10 +641,10 @@ class ForwardReference(Linter):
 @a_linter
 class UnusedDeclaration(Linter):
     # Nothing references a (non-input) Decl
-    def decl(self, obj: WDL.Tree.Decl) -> Any:
+    def decl(self, obj: Tree.Decl) -> Any:
         pt = getattr(obj, "parent")
         is_output = (
-            isinstance(pt, (WDL.Tree.Workflow, WDL.Tree.Task))
+            isinstance(pt, (Tree.Workflow, Tree.Task))
             and getattr(pt, "outputs")
             and obj in getattr(pt, "outputs")
         )
@@ -683,16 +669,16 @@ class UnusedDeclaration(Linter):
             ]
             if not (
                 (
-                    isinstance(obj.type, WDL.Type.File)
+                    isinstance(obj.type, Type.File)
                     and sum(1 for sfx in index_suffixes if obj.name.lower().endswith(sfx))
                 )
                 or (
-                    isinstance(obj.type, WDL.Type.Array)
-                    and isinstance(obj.type.item_type, WDL.Type.File)
+                    isinstance(obj.type, Type.Array)
+                    and isinstance(obj.type.item_type, Type.File)
                     and sum(1 for sfx in index_suffixes if obj.name.lower().endswith(sfx))
                 )
                 or (
-                    isinstance(pt, WDL.Tree.Task)
+                    isinstance(pt, Tree.Task)
                     and pt.meta.get("type") == "native"
                     and pt.meta.get("id")
                 )
@@ -704,12 +690,12 @@ class UnusedDeclaration(Linter):
 class UnusedCall(Linter):
     # the outputs of a Call are neither used nor propagated
 
-    def call(self, obj: WDL.Tree.Call) -> Any:
+    def call(self, obj: Tree.Call) -> Any:
         if obj.effective_outputs and not getattr(obj, "referrers", []):
             workflow = obj
-            while not isinstance(workflow, WDL.Tree.Workflow):
+            while not isinstance(workflow, Tree.Workflow):
                 workflow = getattr(workflow, "parent")
-            assert isinstance(workflow, WDL.Tree.Workflow)
+            assert isinstance(workflow, Tree.Workflow)
             if workflow.outputs is not None:
                 self.add(
                     obj,
@@ -727,12 +713,12 @@ class UnnecessaryQuantifier(Linter):
     # input section (where it denotes that the default value can be overridden
     # by expressly passing null)
 
-    def decl(self, obj: WDL.Tree.Decl) -> Any:
+    def decl(self, obj: Tree.Decl) -> Any:
         if obj.type.optional and obj.expr and not obj.expr.type.optional:
             tw = obj
-            while not isinstance(tw, (WDL.Tree.Task, WDL.Tree.Workflow)):
+            while not isinstance(tw, (Tree.Task, Tree.Workflow)):
                 tw = getattr(tw, "parent")
-            assert isinstance(tw, (WDL.Tree.Task, WDL.Tree.Workflow))
+            assert isinstance(tw, (Tree.Task, Tree.Workflow))
             if tw.inputs is not None and obj not in tw.inputs:
                 self.add(
                     obj,
@@ -774,7 +760,7 @@ class CommandShellCheck(Linter):
     def __del__(self):
         shutil.rmtree(self._tmpdir, ignore_errors=True)
 
-    def task(self, obj: WDL.Tree.Task) -> Any:
+    def task(self, obj: Tree.Task) -> Any:
         global _shellcheck_available
         if not _shellcheck_available:
             return
@@ -783,12 +769,12 @@ class CommandShellCheck(Linter):
         # of the appropriate type that shouldn't trigger shellcheck
         command = []
         for part in obj.command.parts:
-            if isinstance(part, WDL.Expr.Placeholder):
+            if isinstance(part, Expr.Placeholder):
                 command.append(_shellcheck_dummy_value(part.expr.type, part.pos))
             else:
                 assert isinstance(part, str)
                 command.append(part)
-        col_offset, command = WDL._util.strip_leading_whitespace("".join(command))
+        col_offset, command = _util.strip_leading_whitespace("".join(command))
 
         # write out a temp file with this fake script
         tfn = os.path.join(self._tmpdir, obj.name)
@@ -832,7 +818,7 @@ class CommandShellCheck(Linter):
                     self.add(
                         obj,
                         "SC{} {}".format(item["code"], item["message"]),
-                        WDL.Error.SourcePosition(
+                        Error.SourcePosition(
                             filename=obj.command.pos.filename,
                             line=line,
                             column=column,
@@ -849,16 +835,16 @@ class CommandShellCheck(Linter):
 
 
 def _shellcheck_dummy_value(ty, pos):
-    if isinstance(ty, WDL.Type.Array):
+    if isinstance(ty, Type.Array):
         return _shellcheck_dummy_value(ty.item_type, pos)
-    if isinstance(ty, WDL.Type.Boolean):
+    if isinstance(ty, Type.Boolean):
         return "false"
     # estimate the length of the interpolation in the original source, so that
     # shellcheck will see the same column numbers. + 3 accounts for "~{" and "}"
     desired_length = max(1, pos.end_column - pos.column) + 3
-    if isinstance(ty, (WDL.Type.Int, WDL.Type.Float)):
+    if isinstance(ty, (Type.Int, Type.Float)):
         return "4" * desired_length
-    # assert ty.coerces(WDL.Type.String), str(ty)
+    # assert ty.coerces(Type.String), str(ty)
     # https://github.com/HumanCellAtlas/skylab/blob/a99b8ddffdb3c0ebdea1a8905d28f01a4d365af5/pipelines/10x/count/count.wdl#L325
     # https://github.com/openwdl/wdl/blob/master/versions/draft-2/SPEC.md#map-serialization
     return "x" * desired_length
@@ -867,7 +853,7 @@ def _shellcheck_dummy_value(ty, pos):
 @a_linter
 class MixedIndentation(Linter):
     # Line of task command mixes tab and space indentation
-    def task(self, obj: WDL.Tree.Task) -> Any:
+    def task(self, obj: Tree.Task) -> Any:
         command_lines = "".join(
             (s if isinstance(s, str) else "$") for s in obj.command.parts
         ).split("\n")
@@ -877,7 +863,7 @@ class MixedIndentation(Linter):
                 self.add(
                     obj,
                     "command indented with both spaces & tabs",
-                    WDL.Error.SourcePosition(
+                    Error.SourcePosition(
                         filename=obj.command.pos.filename,
                         line=obj.command.pos.line + ofs,
                         column=1,
@@ -891,11 +877,11 @@ class MixedIndentation(Linter):
 @a_linter
 class SelectArray(Linter):
     # application of select_first or select_all on a non-optional array
-    def expr(self, obj: WDL.Expr.Base) -> Any:
+    def expr(self, obj: Expr.Base) -> Any:
         pt = getattr(obj, "parent")
-        if isinstance(obj, WDL.Expr.Apply) and obj.function_name in ["select_first", "select_all"]:
+        if isinstance(obj, Expr.Apply) and obj.function_name in ["select_first", "select_all"]:
             arg0 = obj.arguments[0]
-            if isinstance(arg0.type, WDL.Type.Array) and not arg0.type.item_type.optional:
+            if isinstance(arg0.type, Type.Array) and not arg0.type.item_type.optional:
                 self.add(
                     pt,
                     "array of non-optional items passed to " + obj.function_name,
@@ -937,7 +923,7 @@ class UnknownRuntimeKey(Linter):
         ]
     )
 
-    def task(self, obj: WDL.Tree.Task) -> Any:
+    def task(self, obj: Tree.Task) -> Any:
         for k in obj.runtime:
             if k not in self.known_keys:
                 self.add(obj, "unknown entry in task runtime section: " + k, obj.runtime[k].pos)

--- a/WDL/StdLib.py
+++ b/WDL/StdLib.py
@@ -5,11 +5,7 @@ import re
 from typing import List, Tuple, Callable, Any
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-import WDL.Type as T
-import WDL.Value as V
-import WDL.Expr as E
-import WDL.Env as Env
-import WDL.Error as Error
+from . import Type, Value, Expr, Env, Error
 
 
 class Base:
@@ -29,14 +25,14 @@ class Base:
         self._land = _And()
         self._lor = _Or()
         self._negate = StaticFunction(
-            "_negate", [T.Boolean()], T.Boolean(), lambda x: V.Boolean(not x.value)
+            "_negate", [Type.Boolean()], Type.Boolean(), lambda x: Value.Boolean(not x.value)
         )
         self._add = _AddOperator()
         self._sub = _ArithmeticOperator("-", lambda l, r: l - r)
         self._mul = _ArithmeticOperator("*", lambda l, r: l * r)
         self._div = _ArithmeticOperator("/", lambda l, r: l // r)
         self._rem = StaticFunction(
-            "_rem", [T.Int(), T.Int()], T.Int(), lambda l, r: V.Int(l.value % r.value)
+            "_rem", [Type.Int(), Type.Int()], Type.Int(), lambda l, r: Value.Int(l.value % r.value)
         )
         self._eqeq = _ComparisonOperator("==", lambda l, r: l == r)
         self._neq = _ComparisonOperator("!=", lambda l, r: l != r)
@@ -47,34 +43,34 @@ class Base:
 
         # static stdlib functions
         for (name, argument_types, return_type, F) in [
-            ("floor", [T.Float()], T.Int(), lambda v: V.Int(math.floor(v.value))),
-            ("ceil", [T.Float()], T.Int(), lambda v: V.Int(math.ceil(v.value))),
-            ("round", [T.Float()], T.Int(), lambda v: V.Int(round(v.value))),
-            ("length", [T.Array(T.Any())], T.Int(), lambda v: V.Int(len(v.value))),
-            ("sub", [T.String(), T.String(), T.String()], T.String(), _sub),
-            ("basename", [T.String(), T.String(optional=True)], T.String(), _basename),
+            ("floor", [Type.Float()], Type.Int(), lambda v: Value.Int(math.floor(v.value))),
+            ("ceil", [Type.Float()], Type.Int(), lambda v: Value.Int(math.ceil(v.value))),
+            ("round", [Type.Float()], Type.Int(), lambda v: Value.Int(round(v.value))),
+            ("length", [Type.Array(Type.Any())], Type.Int(), lambda v: Value.Int(len(v.value))),
+            ("sub", [Type.String(), Type.String(), Type.String()], Type.String(), _sub),
+            ("basename", [Type.String(), Type.String(optional=True)], Type.String(), _basename),
             (
                 "defined",
-                [T.Any(optional=True)],
-                T.Boolean(),
-                lambda v: V.Boolean(not isinstance(v, V.Null)),
+                [Type.Any(optional=True)],
+                Type.Boolean(),
+                lambda v: Value.Boolean(not isinstance(v, Value.Null)),
             ),
             # context-dependent:
-            ("write_lines", [T.Array(T.String())], T.File(), _notimpl),
-            ("write_tsv", [T.Array(T.Array(T.String()))], T.File(), _notimpl),
-            ("write_map", [T.Map((T.Any(), T.Any()))], T.File(), _notimpl),
-            ("write_json", [T.Any()], T.File(), _notimpl),
-            ("stdout", [], T.File(), _notimpl),
-            ("stderr", [], T.File(), _notimpl),
-            ("glob", [T.String()], T.Array(T.File()), _notimpl),
-            ("read_int", [T.File()], T.Int(), _notimpl),
-            ("read_boolean", [T.File()], T.Boolean(), _notimpl),
-            ("read_string", [T.File()], T.String(), _notimpl),
-            ("read_float", [T.File()], T.Float(), _notimpl),
-            ("read_map", [T.File()], T.Map((T.String(), T.String())), _notimpl),
-            ("read_lines", [T.File()], T.Array(T.Any()), _notimpl),
-            ("read_tsv", [T.File()], T.Array(T.Array(T.String())), _notimpl),
-            ("read_json", [T.File()], T.Any(), _notimpl),
+            ("write_lines", [Type.Array(Type.String())], Type.File(), _notimpl),
+            ("write_tsv", [Type.Array(Type.Array(Type.String()))], Type.File(), _notimpl),
+            ("write_map", [Type.Map((Type.Any(), Type.Any()))], Type.File(), _notimpl),
+            ("write_json", [Type.Any()], Type.File(), _notimpl),
+            ("stdout", [], Type.File(), _notimpl),
+            ("stderr", [], Type.File(), _notimpl),
+            ("glob", [Type.String()], Type.Array(Type.File()), _notimpl),
+            ("read_int", [Type.File()], Type.Int(), _notimpl),
+            ("read_boolean", [Type.File()], Type.Boolean(), _notimpl),
+            ("read_string", [Type.File()], Type.String(), _notimpl),
+            ("read_float", [Type.File()], Type.Float(), _notimpl),
+            ("read_map", [Type.File()], Type.Map((Type.String(), Type.String())), _notimpl),
+            ("read_lines", [Type.File()], Type.Array(Type.Any()), _notimpl),
+            ("read_tsv", [Type.File()], Type.Array(Type.Array(Type.String())), _notimpl),
+            ("read_json", [Type.File()], Type.Any(), _notimpl),
         ]:
             setattr(self, name, StaticFunction(name, argument_types, return_type, F))
 
@@ -117,14 +113,14 @@ class Function(ABC):
     # Abstract interface to a standard library function implementation
 
     @abstractmethod
-    def infer_type(self, expr: E.Apply) -> T.Base:
+    def infer_type(self, expr: Expr.Apply) -> Type.Base:
         # Typecheck the Apply expression (including the argument expressions);
         # raise an exception or return the function's return type, which may
         # depend on the argument types.
         pass
 
     @abstractmethod
-    def __call__(self, expr: E.Apply, env: Env.Values, stdlib: Base) -> V.Base:
+    def __call__(self, expr: Expr.Apply, env: Env.Values, stdlib: Base) -> Value.Base:
         # Invoke the function, evaluating the arguments as needed
         pass
 
@@ -135,10 +131,10 @@ class EagerFunction(Function):
     # argument and return values.
 
     @abstractmethod
-    def _call_eager(self, expr: E.Apply, arguments: List[V.Base]) -> V.Base:
+    def _call_eager(self, expr: Expr.Apply, arguments: List[Value.Base]) -> Value.Base:
         pass
 
-    def __call__(self, expr: E.Apply, env: Env.Values, stdlib: Base) -> V.Base:
+    def __call__(self, expr: Expr.Apply, env: Env.Values, stdlib: Base) -> Value.Base:
         return self._call_eager(expr, [arg.eval(env, stdlib=stdlib) for arg in expr.arguments])
 
 
@@ -147,19 +143,19 @@ class StaticFunction(EagerFunction):
     # In this case the boilerplate can handle the coercions.
 
     name: str
-    argument_types: List[T.Base]
-    return_type: T.Base
+    argument_types: List[Type.Base]
+    return_type: Type.Base
     F: Callable
 
     def __init__(
-        self, name: str, argument_types: List[T.Base], return_type: T.Base, F: Callable
+        self, name: str, argument_types: List[Type.Base], return_type: Type.Base, F: Callable
     ) -> None:
         self.name = name
         self.argument_types = argument_types
         self.return_type = return_type
         self.F = F
 
-    def infer_type(self, expr: E.Apply) -> T.Base:
+    def infer_type(self, expr: Expr.Apply) -> Type.Base:
         min_args = len(self.argument_types)
         for ty in reversed(self.argument_types):
             if ty.optional:
@@ -180,10 +176,10 @@ class StaticFunction(EagerFunction):
                 ) from None
         return self.return_type
 
-    def _call_eager(self, expr: E.Apply, arguments: List[V.Base]) -> V.Base:
+    def _call_eager(self, expr: Expr.Apply, arguments: List[Value.Base]) -> Value.Base:
         argument_values = [arg.coerce(ty) for arg, ty in zip(arguments, self.argument_types)]
         try:
-            ans: V.Base = self.F(*argument_values)
+            ans: Value.Base = self.F(*argument_values)
         except Exception as exn:
             msg = "function evaluation failed"
             if str(exn):
@@ -196,40 +192,40 @@ def _notimpl(*args, **kwargs) -> None:
     exec("raise NotImplementedError('function not available in this context')")
 
 
-def _basename(*args) -> V.String:
+def _basename(*args) -> Value.String:
     assert len(args) in (1, 2)
-    assert isinstance(args[0], V.String)
+    assert isinstance(args[0], Value.String)
     path = args[0].value
     if len(args) > 1:
-        assert isinstance(args[1], V.String)
+        assert isinstance(args[1], Value.String)
         suffix = args[1].value
         if path.endswith(suffix):
             path = path[: -len(suffix)]
-    return V.String(os.path.basename(path))
+    return Value.String(os.path.basename(path))
 
 
-def _sub(input: V.String, pattern: V.String, replace: V.String) -> V.String:
-    return V.String(re.compile(pattern.value).sub(replace.value, input.value))
+def _sub(input: Value.String, pattern: Value.String, replace: Value.String) -> Value.String:
+    return Value.String(re.compile(pattern.value).sub(replace.value, input.value))
 
 
 class _At(EagerFunction):
     # Special function for array access arr[index], returning the element type
     #                   or map access map[key], returning the value type
 
-    def infer_type(self, expr: E.Apply) -> T.Base:
+    def infer_type(self, expr: Expr.Apply) -> Type.Base:
         assert len(expr.arguments) == 2
         lhs = expr.arguments[0]
         rhs = expr.arguments[1]
-        if isinstance(lhs.type, T.Array):
-            if isinstance(lhs, E.Array) and not lhs.items:
+        if isinstance(lhs.type, Type.Array):
+            if isinstance(lhs, Expr.Array) and not lhs.items:
                 # the user wrote: [][idx]
                 raise Error.OutOfBounds(expr)
             try:
-                rhs.typecheck(T.Int())
+                rhs.typecheck(Type.Int())
             except Error.StaticTypeMismatch:
-                raise Error.StaticTypeMismatch(rhs, T.Int(), rhs.type, "Array index") from None
+                raise Error.StaticTypeMismatch(rhs, Type.Int(), rhs.type, "Array index") from None
             return lhs.type.item_type
-        if isinstance(lhs.type, T.Map):
+        if isinstance(lhs.type, Type.Map):
             if lhs.type.item_type is None:
                 raise Error.OutOfBounds(expr)
             try:
@@ -241,13 +237,13 @@ class _At(EagerFunction):
             return lhs.type.item_type[1]
         raise Error.NotAnArray(lhs)
 
-    def _call_eager(self, expr: E.Apply, arguments: List[V.Base]) -> V.Base:
+    def _call_eager(self, expr: Expr.Apply, arguments: List[Value.Base]) -> Value.Base:
         assert len(expr.arguments) == 2 and len(arguments) == 2
         lhs = arguments[0]
         rhs = arguments[1]
-        if isinstance(lhs, V.Map):
+        if isinstance(lhs, Value.Map):
             mty = expr.arguments[0].type
-            assert isinstance(mty, T.Map)
+            assert isinstance(mty, Type.Map)
             key = rhs.coerce(mty.item_type[0])
             ans = None
             for k, v in lhs.value:
@@ -257,8 +253,8 @@ class _At(EagerFunction):
                 raise Error.OutOfBounds(expr.arguments[1])  # TODO: KeyNotFound
             return ans
         else:
-            lhs = lhs.coerce(T.Array(T.Any()))
-            rhs = rhs.coerce(T.Int())
+            lhs = lhs.coerce(Type.Array(Type.Any()))
+            rhs = rhs.coerce(Type.Int())
             if rhs.value < 0 or rhs.value >= len(lhs.value):
                 raise Error.OutOfBounds(expr.arguments[1])
             return lhs.value[rhs.value]
@@ -266,38 +262,38 @@ class _At(EagerFunction):
 
 class _And(Function):
     # logical && with short-circuit evaluation
-    def infer_type(self, expr: E.Apply) -> T.Base:
+    def infer_type(self, expr: Expr.Apply) -> Type.Base:
         assert len(expr.arguments) == 2
         for arg in expr.arguments:
-            if not isinstance(arg.type, T.Boolean):
+            if not isinstance(arg.type, Type.Boolean):
                 raise Error.IncompatibleOperand(arg, "non-Boolean operand to &&")
             if expr._check_quant and arg.type.optional:
                 raise Error.IncompatibleOperand(arg, "optional Boolean? operand to &&")
-        return T.Boolean()
+        return Type.Boolean()
 
-    def __call__(self, expr: E.Apply, env: Env.Values, stdlib: Base) -> V.Base:
-        lhs = expr.arguments[0].eval(env, stdlib=stdlib).expect(T.Boolean()).value
+    def __call__(self, expr: Expr.Apply, env: Env.Values, stdlib: Base) -> Value.Base:
+        lhs = expr.arguments[0].eval(env, stdlib=stdlib).expect(Type.Boolean()).value
         if not lhs:
-            return V.Boolean(False)
-        return expr.arguments[1].eval(env, stdlib=stdlib).expect(T.Boolean())
+            return Value.Boolean(False)
+        return expr.arguments[1].eval(env, stdlib=stdlib).expect(Type.Boolean())
 
 
 class _Or(Function):
     # logical || with short-circuit evaluation
-    def infer_type(self, expr: E.Apply) -> T.Base:
+    def infer_type(self, expr: Expr.Apply) -> Type.Base:
         assert len(expr.arguments) == 2
         for arg in expr.arguments:
-            if not isinstance(arg.type, T.Boolean):
+            if not isinstance(arg.type, Type.Boolean):
                 raise Error.IncompatibleOperand(arg, "non-Boolean operand to ||")
             if expr._check_quant and arg.type.optional:
                 raise Error.IncompatibleOperand(arg, "optional Boolean? operand to ||")
-        return T.Boolean()
+        return Type.Boolean()
 
-    def __call__(self, expr: E.Apply, env: Env.Values, stdlib: Base) -> V.Base:
-        lhs = expr.arguments[0].eval(env, stdlib=stdlib).expect(T.Boolean()).value
+    def __call__(self, expr: Expr.Apply, env: Env.Values, stdlib: Base) -> Value.Base:
+        lhs = expr.arguments[0].eval(env, stdlib=stdlib).expect(Type.Boolean()).value
         if lhs:
-            return V.Boolean(True)
-        return expr.arguments[1].eval(env, stdlib=stdlib).expect(T.Boolean())
+            return Value.Boolean(True)
+        return expr.arguments[1].eval(env, stdlib=stdlib).expect(Type.Boolean())
 
 
 class _ArithmeticOperator(EagerFunction):
@@ -311,13 +307,13 @@ class _ArithmeticOperator(EagerFunction):
         self.name = name
         self.op = op
 
-    def infer_type(self, expr: E.Apply) -> T.Base:
+    def infer_type(self, expr: Expr.Apply) -> Type.Base:
         assert len(expr.arguments) == 2
-        rt = T.Int()
-        if isinstance(expr.arguments[0].type, T.Float) or isinstance(
-            expr.arguments[1].type, T.Float
+        rt = Type.Int()
+        if isinstance(expr.arguments[0].type, Type.Float) or isinstance(
+            expr.arguments[1].type, Type.Float
         ):
-            rt = T.Float()
+            rt = Type.Float()
         try:
             expr.arguments[0].typecheck(rt)
             expr.arguments[1].typecheck(rt)
@@ -327,14 +323,14 @@ class _ArithmeticOperator(EagerFunction):
             ) from None
         return rt
 
-    def _call_eager(self, expr: E.Apply, arguments: List[V.Base]) -> V.Base:
+    def _call_eager(self, expr: Expr.Apply, arguments: List[Value.Base]) -> Value.Base:
         ans_type = self.infer_type(expr)
         ans = self.op(arguments[0].coerce(ans_type).value, arguments[1].coerce(ans_type).value)
-        if ans_type == T.Int():
+        if ans_type == Type.Int():
             assert isinstance(ans, int)
-            return V.Int(ans)
+            return Value.Int(ans)
         assert isinstance(ans, float)
-        return V.Float(ans)
+        return Value.Float(ans)
 
 
 class _AddOperator(_ArithmeticOperator):
@@ -342,55 +338,56 @@ class _AddOperator(_ArithmeticOperator):
     def __init__(self) -> None:
         super().__init__("+", lambda l, r: l + r)
 
-    def infer_type(self, expr: E.Apply) -> T.Base:
+    def infer_type(self, expr: Expr.Apply) -> Type.Base:
         assert len(expr.arguments) == 2
         t2 = None
-        if isinstance(expr.arguments[0].type, T.String):
+        if isinstance(expr.arguments[0].type, Type.String):
             t2 = expr.arguments[1].type
-        elif isinstance(expr.arguments[1].type, T.String):
+        elif isinstance(expr.arguments[1].type, Type.String):
             t2 = expr.arguments[0].type
         if t2 is None:
             # neither operand is a string; defer to _ArithmeticOperator
             return super().infer_type(expr)
-        if not t2.coerces(T.String(optional=not expr._check_quant)):
+        if not t2.coerces(Type.String(optional=not expr._check_quant)):
             raise Error.IncompatibleOperand(
                 expr,
                 "Cannot add/concatenate {} and {}".format(
                     str(expr.arguments[0].type), str(expr.arguments[1].type)
                 ),
             )
-        return T.String()
+        return Type.String()
 
-    def _call_eager(self, expr: E.Apply, arguments: List[V.Base]) -> V.Base:
+    def _call_eager(self, expr: Expr.Apply, arguments: List[Value.Base]) -> Value.Base:
         ans_type = self.infer_type(expr)
-        if not isinstance(ans_type, T.String):
+        if not isinstance(ans_type, Type.String):
             return super()._call_eager(expr, arguments)
         ans = self.op(
-            str(arguments[0].coerce(T.String()).value), str(arguments[1].coerce(T.String()).value)
+            str(arguments[0].coerce(Type.String()).value),
+            str(arguments[1].coerce(Type.String()).value),
         )
         assert isinstance(ans, str)
-        return V.String(ans)
+        return Value.String(ans)
 
 
 class InterpolationAddOperator(_AddOperator):
     # + operator within an interpolation; accepts String? operands, evaluating to None if either
     # operand is None.
 
-    def infer_type(self, expr: E.Apply) -> T.Base:
-        either_string = sum(1 for arg in expr.arguments if isinstance(arg.type, T.String)) > 0
+    def infer_type(self, expr: Expr.Apply) -> Type.Base:
+        either_string = sum(1 for arg in expr.arguments if isinstance(arg.type, Type.String)) > 0
         either_optional = sum(1 for arg in expr.arguments if arg.type.optional) > 0
         both_stringifiable = (
-            sum(1 for arg in expr.arguments if arg.type.coerces(T.String(optional=True))) > 1
+            sum(1 for arg in expr.arguments if arg.type.coerces(Type.String(optional=True))) > 1
         )
         return (
-            T.String(optional=True)
+            Type.String(optional=True)
             if either_string and either_optional and both_stringifiable
             else super().infer_type(expr)
         )
 
-    def _call_eager(self, expr: E.Apply, arguments: List[V.Base]) -> V.Base:
-        if sum(1 for arg in arguments if isinstance(arg, V.Null)):
-            return V.Null()
+    def _call_eager(self, expr: Expr.Apply, arguments: List[Value.Base]) -> Value.Base:
+        if sum(1 for arg in arguments if isinstance(arg, Value.Null)):
+            return Value.Null()
         return super()._call_eager(expr, arguments)
 
 
@@ -406,7 +403,7 @@ class _ComparisonOperator(EagerFunction):
         self.name = name
         self.op = op
 
-    def infer_type(self, expr: E.Apply) -> T.Base:
+    def infer_type(self, expr: Expr.Apply) -> Type.Base:
         assert len(expr.arguments) == 2
         if (
             (
@@ -422,12 +419,12 @@ class _ComparisonOperator(EagerFunction):
                     expr.arguments[0].type.copy(optional=False)
                     == expr.arguments[1].type.copy(optional=False)
                     or (
-                        isinstance(expr.arguments[0].type, T.Int)
-                        and isinstance(expr.arguments[1].type, T.Float)
+                        isinstance(expr.arguments[0].type, Type.Int)
+                        and isinstance(expr.arguments[1].type, Type.Float)
                     )
                     or (
-                        isinstance(expr.arguments[0].type, T.Float)
-                        and isinstance(expr.arguments[1].type, T.Int)
+                        isinstance(expr.arguments[0].type, Type.Float)
+                        and isinstance(expr.arguments[1].type, Type.Int)
                     )
                 )
             )
@@ -438,44 +435,46 @@ class _ComparisonOperator(EagerFunction):
                     str(expr.arguments[0].type), str(expr.arguments[1].type)
                 ),
             )
-        return T.Boolean()
+        return Type.Boolean()
 
-    def _call_eager(self, expr: E.Apply, arguments: List[V.Base]) -> V.Base:
+    def _call_eager(self, expr: Expr.Apply, arguments: List[Value.Base]) -> Value.Base:
         assert len(arguments) == 2
-        return V.Boolean(self.op(arguments[0].value, arguments[1].value))
+        return Value.Boolean(self.op(arguments[0].value, arguments[1].value))
 
 
 class _Size(EagerFunction):
     # size(): first argument can be File? or Array[File?]
 
-    def infer_type(self, expr: E.Apply) -> T.Base:
+    def infer_type(self, expr: Expr.Apply) -> Type.Base:
         if not expr.arguments:
             raise Error.WrongArity(expr, 1)
-        if not expr.arguments[0].type.coerces(T.File(optional=True)):
-            if isinstance(expr.arguments[0].type, T.Array):
+        if not expr.arguments[0].type.coerces(Type.File(optional=True)):
+            if isinstance(expr.arguments[0].type, Type.Array):
                 if expr.arguments[0].type.optional or not expr.arguments[0].type.item_type.coerces(
-                    T.File(optional=True)
+                    Type.File(optional=True)
                 ):
                     raise Error.StaticTypeMismatch(
-                        expr.arguments[0], T.Array(T.File(optional=True)), expr.arguments[0].type
+                        expr.arguments[0],
+                        Type.Array(Type.File(optional=True)),
+                        expr.arguments[0].type,
                     )
             else:
                 raise Error.StaticTypeMismatch(
-                    expr.arguments[0], T.File(optional=True), expr.arguments[0].type
+                    expr.arguments[0], Type.File(optional=True), expr.arguments[0].type
                 )
         if len(expr.arguments) == 2:
-            if expr.arguments[1].type != T.String():
+            if expr.arguments[1].type != Type.String():
                 raise Error.StaticTypeMismatch(
-                    expr.arguments[1], T.String(), expr.arguments[1].type
+                    expr.arguments[1], Type.String(), expr.arguments[1].type
                 )
         elif len(expr.arguments) > 2:
             raise Error.WrongArity(expr, 2)
-        return T.Float()
+        return Type.Float()
 
-    def _call_eager(self, expr: E.Apply, arguments: List[V.Base]) -> V.Base:
+    def _call_eager(self, expr: Expr.Apply, arguments: List[Value.Base]) -> Value.Base:
         # this default implementation attempts os.path.getsize() on the argument(s)
-        files = arguments[0].coerce(T.Array(T.File()))
-        unit = arguments[1].coerce(T.String()) if len(arguments) > 1 else None
+        files = arguments[0].coerce(Type.Array(Type.File()))
+        unit = arguments[1].coerce(Type.String()) if len(arguments) > 1 else None
 
         ans = sum(float(os.path.getsize(fn.value)) for fn in files.value)
 
@@ -484,7 +483,7 @@ class _Size(EagerFunction):
                 ans /= float(_Size.unit_divisors[unit.value])
             except KeyError:
                 raise Error.EvalError(expr, "size(): invalid unit " + unit.value)
-        return V.Float(ans)
+        return Value.Float(ans)
 
     unit_divisors = {
         "K": 1000,
@@ -503,104 +502,105 @@ class _Size(EagerFunction):
 
 
 class _SelectFirst(EagerFunction):
-    def infer_type(self, expr: E.Apply) -> T.Base:
+    def infer_type(self, expr: Expr.Apply) -> Type.Base:
         if len(expr.arguments) != 1:
             raise Error.WrongArity(expr, 1)
-        if not isinstance(expr.arguments[0].type, T.Array) or (
+        if not isinstance(expr.arguments[0].type, Type.Array) or (
             expr.arguments[0]._check_quant and expr.arguments[0].type.optional
         ):
             raise Error.StaticTypeMismatch(
-                expr.arguments[0], T.Array(T.Any()), expr.arguments[0].type
+                expr.arguments[0], Type.Array(Type.Any()), expr.arguments[0].type
             )
-        if isinstance(expr.arguments[0].type.item_type, T.Any):
+        if isinstance(expr.arguments[0].type.item_type, Type.Any):
             raise Error.IndeterminateType(expr.arguments[0], "can't infer item type of empty array")
         ty = expr.arguments[0].type.item_type
-        assert isinstance(ty, T.Base)
+        assert isinstance(ty, Type.Base)
         return ty.copy(optional=False)
 
-    def _call_eager(self, expr: E.Apply, arguments: List[V.Base]) -> V.Base:
-        arr = arguments[0].coerce(T.Array(T.Any()))
-        assert isinstance(arr, V.Array)
+    def _call_eager(self, expr: Expr.Apply, arguments: List[Value.Base]) -> Value.Base:
+        arr = arguments[0].coerce(Type.Array(Type.Any()))
+        assert isinstance(arr, Value.Array)
         for arg in arr.value:
-            if not isinstance(arg, V.Null):
+            if not isinstance(arg, Value.Null):
                 return arg
         raise Error.NullValue(expr)
 
 
 class _SelectAll(EagerFunction):
-    def infer_type(self, expr: E.Apply) -> T.Base:
+    def infer_type(self, expr: Expr.Apply) -> Type.Base:
         if len(expr.arguments) != 1:
             raise Error.WrongArity(expr, 1)
-        if not isinstance(expr.arguments[0].type, T.Array) or (
+        if not isinstance(expr.arguments[0].type, Type.Array) or (
             expr.arguments[0]._check_quant and expr.arguments[0].type.optional
         ):
             raise Error.StaticTypeMismatch(
-                expr.arguments[0], T.Array(T.Any()), expr.arguments[0].type
+                expr.arguments[0], Type.Array(Type.Any()), expr.arguments[0].type
             )
-        if isinstance(expr.arguments[0].type.item_type, T.Any):
+        if isinstance(expr.arguments[0].type.item_type, Type.Any):
             raise Error.IndeterminateType(expr.arguments[0], "can't infer item type of empty array")
         ty = expr.arguments[0].type.item_type
-        assert isinstance(ty, T.Base)
-        return T.Array(ty.copy(optional=False))
+        assert isinstance(ty, Type.Base)
+        return Type.Array(ty.copy(optional=False))
 
-    def _call_eager(self, expr: E.Apply, arguments: List[V.Base]) -> V.Base:
-        arr = arguments[0].coerce(T.Array(T.Any()))
-        assert isinstance(arr, V.Array)
+    def _call_eager(self, expr: Expr.Apply, arguments: List[Value.Base]) -> Value.Base:
+        arr = arguments[0].coerce(Type.Array(Type.Any()))
+        assert isinstance(arr, Value.Array)
         arrty = arr.type
-        assert isinstance(arrty, T.Array)
-        return V.Array(arrty, [arg for arg in arr.value if not isinstance(arg, V.Null)])
+        assert isinstance(arrty, Type.Array)
+        return Value.Array(arrty, [arg for arg in arr.value if not isinstance(arg, Value.Null)])
 
 
 class _ZipOrCross(EagerFunction):
     # 'a array -> 'b array -> ('a,'b) array
-    def infer_type(self, expr: E.Apply) -> T.Base:
+    def infer_type(self, expr: Expr.Apply) -> Type.Base:
         if len(expr.arguments) != 2:
             raise Error.WrongArity(expr, 2)
-        arg0ty: T.Base = expr.arguments[0].type
-        if not isinstance(arg0ty, T.Array) or (expr._check_quant and arg0ty.optional):
-            raise Error.StaticTypeMismatch(expr.arguments[0], T.Array(T.Any()), arg0ty)
-        if isinstance(arg0ty.item_type, T.Any):
+        arg0ty: Type.Base = expr.arguments[0].type
+        if not isinstance(arg0ty, Type.Array) or (expr._check_quant and arg0ty.optional):
+            raise Error.StaticTypeMismatch(expr.arguments[0], Type.Array(Type.Any()), arg0ty)
+        if isinstance(arg0ty.item_type, Type.Any):
             raise Error.IndeterminateType(expr.arguments[0], "can't infer item type of empty array")
-        arg1ty: T.Base = expr.arguments[1].type
-        if not isinstance(arg1ty, T.Array) or (expr._check_quant and arg1ty.optional):
-            raise Error.StaticTypeMismatch(expr.arguments[1], T.Array(T.Any()), arg1ty)
-        if isinstance(arg1ty.item_type, T.Any):
+        arg1ty: Type.Base = expr.arguments[1].type
+        if not isinstance(arg1ty, Type.Array) or (expr._check_quant and arg1ty.optional):
+            raise Error.StaticTypeMismatch(expr.arguments[1], Type.Array(Type.Any()), arg1ty)
+        if isinstance(arg1ty.item_type, Type.Any):
             raise Error.IndeterminateType(expr.arguments[1], "can't infer item type of empty array")
-        return T.Array(
-            T.Pair(arg0ty.item_type, arg1ty.item_type),
+        return Type.Array(
+            Type.Pair(arg0ty.item_type, arg1ty.item_type),
             nonempty=(arg0ty.nonempty or arg1ty.nonempty),
         )
 
     def _coerce_args(
-        self, expr: E.Apply, arguments: List[V.Base]
-    ) -> Tuple[T.Array, V.Array, V.Array]:
+        self, expr: Expr.Apply, arguments: List[Value.Base]
+    ) -> Tuple[Type.Array, Value.Array, Value.Array]:
         ty = self.infer_type(expr)
-        assert isinstance(ty, T.Array) and isinstance(ty.item_type, T.Pair)
-        lhs = arguments[0].coerce(T.Array(ty.item_type.left_type))
-        rhs = arguments[1].coerce(T.Array(ty.item_type.right_type))
-        assert isinstance(lhs, V.Array) and isinstance(rhs, V.Array)
+        assert isinstance(ty, Type.Array) and isinstance(ty.item_type, Type.Pair)
+        lhs = arguments[0].coerce(Type.Array(ty.item_type.left_type))
+        rhs = arguments[1].coerce(Type.Array(ty.item_type.right_type))
+        assert isinstance(lhs, Value.Array) and isinstance(rhs, Value.Array)
         return (ty, lhs, rhs)
 
 
 class _Zip(_ZipOrCross):
-    def _call_eager(self, expr: E.Apply, arguments: List[V.Base]) -> V.Array:
+    def _call_eager(self, expr: Expr.Apply, arguments: List[Value.Base]) -> Value.Array:
         ty, lhs, rhs = self._coerce_args(expr, arguments)
-        assert isinstance(ty, T.Array) and isinstance(ty.item_type, T.Pair)
+        assert isinstance(ty, Type.Array) and isinstance(ty.item_type, Type.Pair)
         if len(lhs.value) != len(rhs.value):
             raise Error.EvalError(expr, "zip(): input arrays must have equal length")
-        return V.Array(
-            ty, [V.Pair(ty.item_type, (lhs.value[i], rhs.value[i])) for i in range(len(lhs.value))]
+        return Value.Array(
+            ty,
+            [Value.Pair(ty.item_type, (lhs.value[i], rhs.value[i])) for i in range(len(lhs.value))],
         )
 
 
 class _Cross(_ZipOrCross):
-    def _call_eager(self, expr: E.Apply, arguments: List[V.Base]) -> V.Array:
+    def _call_eager(self, expr: Expr.Apply, arguments: List[Value.Base]) -> Value.Array:
         ty, lhs, rhs = self._coerce_args(expr, arguments)
-        assert isinstance(ty, T.Array) and isinstance(ty.item_type, T.Pair)
-        return V.Array(
+        assert isinstance(ty, Type.Array) and isinstance(ty.item_type, Type.Pair)
+        return Value.Array(
             ty,
             [
-                V.Pair(ty.item_type, (lhs_item, rhs_item))
+                Value.Pair(ty.item_type, (lhs_item, rhs_item))
                 for lhs_item in lhs.value
                 for rhs_item in rhs.value
             ],
@@ -609,62 +609,62 @@ class _Cross(_ZipOrCross):
 
 class _Flatten(EagerFunction):
     # t array array -> t array
-    def infer_type(self, expr: E.Apply) -> T.Base:
+    def infer_type(self, expr: Expr.Apply) -> Type.Base:
         if len(expr.arguments) != 1:
             raise Error.WrongArity(expr, 1)
-        expr.arguments[0].typecheck(T.Array(T.Any()))
+        expr.arguments[0].typecheck(Type.Array(Type.Any()))
         # TODO: won't handle implicit coercion from T to Array[T]
-        assert isinstance(expr.arguments[0].type, T.Array)
+        assert isinstance(expr.arguments[0].type, Type.Array)
         if expr.arguments[0].type.item_type is None:
-            return T.Array(T.Any())
-        if not isinstance(expr.arguments[0].type.item_type, T.Array):
+            return Type.Array(Type.Any())
+        if not isinstance(expr.arguments[0].type.item_type, Type.Array):
             raise Error.StaticTypeMismatch(
-                expr.arguments[0], T.Array(T.Array(T.Any())), expr.arguments[0].type
+                expr.arguments[0], Type.Array(Type.Array(Type.Any())), expr.arguments[0].type
             )
-        return T.Array(expr.arguments[0].type.item_type.item_type)
+        return Type.Array(expr.arguments[0].type.item_type.item_type)
 
-    def _call_eager(self, expr: E.Apply, arguments: List[V.Base]) -> V.Base:
+    def _call_eager(self, expr: Expr.Apply, arguments: List[Value.Base]) -> Value.Base:
         ty = self.infer_type(expr)
-        assert isinstance(ty, T.Array)
+        assert isinstance(ty, Type.Array)
         ans = []
-        for row in arguments[0].coerce(T.Array(ty)).value:
+        for row in arguments[0].coerce(Type.Array(ty)).value:
             ans.extend(row.value)
-        return V.Array(ty, ans)
+        return Value.Array(ty, ans)
 
 
 class _Transpose(EagerFunction):
     # t array array -> t array array
-    def infer_type(self, expr: E.Apply) -> T.Base:
+    def infer_type(self, expr: Expr.Apply) -> Type.Base:
         if len(expr.arguments) != 1:
             raise Error.WrongArity(expr, 1)
-        expr.arguments[0].typecheck(T.Array(T.Any()))
+        expr.arguments[0].typecheck(Type.Array(Type.Any()))
         # TODO: won't handle implicit coercion from T to Array[T]
-        assert isinstance(expr.arguments[0].type, T.Array)
+        assert isinstance(expr.arguments[0].type, Type.Array)
         if expr.arguments[0].type.item_type is None:
-            return T.Array(T.Any())
-        if not isinstance(expr.arguments[0].type.item_type, T.Array):
+            return Type.Array(Type.Any())
+        if not isinstance(expr.arguments[0].type.item_type, Type.Array):
             raise Error.StaticTypeMismatch(
-                expr.arguments[0], T.Array(T.Array(T.Any())), expr.arguments[0].type
+                expr.arguments[0], Type.Array(Type.Array(Type.Any())), expr.arguments[0].type
             )
         return expr.arguments[0].type
 
-    def _call_eager(self, expr: E.Apply, arguments: List[V.Base]) -> V.Base:
+    def _call_eager(self, expr: Expr.Apply, arguments: List[Value.Base]) -> Value.Base:
         ty = self.infer_type(expr)
-        assert isinstance(ty, T.Array) and isinstance(ty.item_type, T.Array)
+        assert isinstance(ty, Type.Array) and isinstance(ty.item_type, Type.Array)
         mat = arguments[0].coerce(ty)
-        assert isinstance(mat, V.Array)
+        assert isinstance(mat, Value.Array)
         n = None
         ans = []
         for row in mat.value:
-            assert isinstance(row, V.Array)
+            assert isinstance(row, Value.Array)
             if n is None:
                 n = len(row.value)
-                ans = [V.Array(ty.item_type, []) for _ in row.value]
+                ans = [Value.Array(ty.item_type, []) for _ in row.value]
             if len(row.value) != n:
                 raise Error.EvalError(expr, "transpose(): ragged input matrix")
             for i in range(len(row.value)):
                 ans[i].value.append(row.value[i])
-        return V.Array(ty, ans)
+        return Value.Array(ty, ans)
 
 
 class _Range(EagerFunction):
@@ -672,47 +672,47 @@ class _Range(EagerFunction):
     # with special case: if the argument is a positive integer literal or
     # length(a_nonempty_array), then we can say the returned array is nonempty.
 
-    def infer_type(self, expr: E.Apply) -> T.Base:
+    def infer_type(self, expr: Expr.Apply) -> Type.Base:
         if len(expr.arguments) != 1:
             raise Error.WrongArity(expr, 1)
-        expr.arguments[0].typecheck(T.Int())
+        expr.arguments[0].typecheck(Type.Int())
         nonempty = False
         arg0 = expr.arguments[0]
-        if isinstance(arg0, E.Int) and arg0.value > 0:
+        if isinstance(arg0, Expr.Int) and arg0.value > 0:
             nonempty = True
-        if isinstance(arg0, E.Apply) and arg0.function_name == "length":
+        if isinstance(arg0, Expr.Apply) and arg0.function_name == "length":
             arg00ty = arg0.arguments[0].type
-            if isinstance(arg00ty, T.Array) and arg00ty.nonempty:
+            if isinstance(arg00ty, Type.Array) and arg00ty.nonempty:
                 nonempty = True
-        return T.Array(T.Int(), nonempty=nonempty)
+        return Type.Array(Type.Int(), nonempty=nonempty)
 
-    def _call_eager(self, expr: E.Apply, arguments: List[V.Base]) -> V.Base:
-        arg0 = arguments[0].coerce(T.Int())
-        assert isinstance(arg0, V.Int)
+    def _call_eager(self, expr: Expr.Apply, arguments: List[Value.Base]) -> Value.Base:
+        arg0 = arguments[0].coerce(Type.Int())
+        assert isinstance(arg0, Value.Int)
         if arg0.value < 0:
             raise Error.EvalError(expr, "range() got negative argument")
-        return V.Array(T.Array(T.Int()), [V.Int(x) for x in range(arg0.value)])
+        return Value.Array(Type.Array(Type.Int()), [Value.Int(x) for x in range(arg0.value)])
 
 
 class _Prefix(EagerFunction):
     # string -> t array -> string array
     # if input array is nonempty then so is output
 
-    def infer_type(self, expr: E.Apply) -> T.Base:
+    def infer_type(self, expr: Expr.Apply) -> Type.Base:
         if len(expr.arguments) != 2:
             raise Error.WrongArity(expr, 2)
-        expr.arguments[0].typecheck(T.String())
-        expr.arguments[1].typecheck(T.Array(T.String()))
-        return T.Array(
-            T.String(),
+        expr.arguments[0].typecheck(Type.String())
+        expr.arguments[1].typecheck(Type.Array(Type.String()))
+        return Type.Array(
+            Type.String(),
             nonempty=(
-                isinstance(expr.arguments[1].type, T.Array) and expr.arguments[1].type.nonempty
+                isinstance(expr.arguments[1].type, Type.Array) and expr.arguments[1].type.nonempty
             ),
         )
 
-    def _call_eager(self, expr: E.Apply, arguments: List[V.Base]) -> V.Base:
-        pfx = arguments[0].coerce(T.String()).value
-        return V.Array(
-            T.Array(T.String()),
-            [V.String(pfx + s.coerce(T.String()).value) for s in arguments[1].value],
+    def _call_eager(self, expr: Expr.Apply, arguments: List[Value.Base]) -> Value.Base:
+        pfx = arguments[0].coerce(Type.String()).value
+        return Value.Array(
+            Type.Array(Type.String()),
+            [Value.String(pfx + s.coerce(Type.String()).value) for s in arguments[1].value],
         )

--- a/WDL/Walker.py
+++ b/WDL/Walker.py
@@ -1,6 +1,6 @@
 # pylint: disable=assignment-from-no-return
 from typing import Any, List, Optional
-import WDL
+from . import Error, Expr, Tree
 
 
 class Base:
@@ -36,25 +36,25 @@ class Base:
         self.auto_descend = auto_descend
         self.descend_imports = descend_imports
 
-    def __call__(self, obj: WDL.Error.SourceNode, descend: Optional[bool] = None) -> Any:
+    def __call__(self, obj: Error.SourceNode, descend: Optional[bool] = None) -> Any:
         ans = None
-        if isinstance(obj, WDL.Tree.Document):
+        if isinstance(obj, Tree.Document):
             ans = self.document(obj)
-        elif isinstance(obj, WDL.Tree.Workflow):
+        elif isinstance(obj, Tree.Workflow):
             ans = self.workflow(obj)
-        elif isinstance(obj, WDL.Tree.Call):
+        elif isinstance(obj, Tree.Call):
             ans = self.call(obj)
-        elif isinstance(obj, WDL.Tree.Scatter):
+        elif isinstance(obj, Tree.Scatter):
             ans = self.scatter(obj)
-        elif isinstance(obj, WDL.Tree.Conditional):
+        elif isinstance(obj, Tree.Conditional):
             ans = self.conditional(obj)
-        elif isinstance(obj, WDL.Tree.Decl):
+        elif isinstance(obj, Tree.Decl):
             ans = self.decl(obj)
-        elif isinstance(obj, WDL.Tree.Task):
+        elif isinstance(obj, Tree.Task):
             ans = self.task(obj)
-        elif isinstance(obj, WDL.Tree.StructTypeDef):
+        elif isinstance(obj, Tree.StructTypeDef):
             ans = self.struct_typedef(obj)
-        elif isinstance(obj, WDL.Expr.Base):
+        elif isinstance(obj, Expr.Base):
             ans = self.expr(obj)
         else:
             assert False
@@ -62,41 +62,41 @@ class Base:
             descend = self.auto_descend
         if descend:
             for ch in obj.children:
-                if not isinstance(ch, WDL.Tree.Document) or self.descend_imports:
+                if not isinstance(ch, Tree.Document) or self.descend_imports:
                     self(ch)
         return ans
 
-    def _descend(self, obj: WDL.Error.SourceNode) -> Any:
+    def _descend(self, obj: Error.SourceNode) -> Any:
         if not self.auto_descend:
             for ch in obj.children:
-                if not isinstance(ch, WDL.Tree.Document) or self.descend_imports:
+                if not isinstance(ch, Tree.Document) or self.descend_imports:
                     self(ch)
 
-    def document(self, obj: WDL.Tree.Document) -> Any:
+    def document(self, obj: Tree.Document) -> Any:
         self._descend(obj)
 
-    def workflow(self, obj: WDL.Tree.Workflow) -> Any:
+    def workflow(self, obj: Tree.Workflow) -> Any:
         self._descend(obj)
 
-    def call(self, obj: WDL.Tree.Call) -> Any:
+    def call(self, obj: Tree.Call) -> Any:
         self._descend(obj)
 
-    def scatter(self, obj: WDL.Tree.Scatter) -> Any:
+    def scatter(self, obj: Tree.Scatter) -> Any:
         self._descend(obj)
 
-    def conditional(self, obj: WDL.Tree.Conditional) -> Any:
+    def conditional(self, obj: Tree.Conditional) -> Any:
         self._descend(obj)
 
-    def decl(self, obj: WDL.Tree.Decl) -> Any:
+    def decl(self, obj: Tree.Decl) -> Any:
         self._descend(obj)
 
-    def task(self, obj: WDL.Tree.Task) -> Any:
+    def task(self, obj: Tree.Task) -> Any:
         self._descend(obj)
 
-    def struct_typedef(self, obj: WDL.Tree.StructTypeDef) -> Any:
+    def struct_typedef(self, obj: Tree.StructTypeDef) -> Any:
         self._descend(obj)
 
-    def expr(self, obj: WDL.Expr.Base) -> Any:
+    def expr(self, obj: Expr.Base) -> Any:
         self._descend(obj)
 
 
@@ -115,39 +115,39 @@ class Multi(Base):
         self._walkers = walkers
         super().__init__(auto_descend=True, descend_imports=descend_imports)
 
-    def document(self, obj: WDL.Tree.Document) -> Any:
+    def document(self, obj: Tree.Document) -> Any:
         for w in self._walkers:
             w.document(obj)
 
-    def workflow(self, obj: WDL.Tree.Workflow) -> Any:
+    def workflow(self, obj: Tree.Workflow) -> Any:
         for w in self._walkers:
             w.workflow(obj)
 
-    def call(self, obj: WDL.Tree.Call) -> Any:
+    def call(self, obj: Tree.Call) -> Any:
         for w in self._walkers:
             w.call(obj)
 
-    def scatter(self, obj: WDL.Tree.Scatter) -> Any:
+    def scatter(self, obj: Tree.Scatter) -> Any:
         for w in self._walkers:
             w.scatter(obj)
 
-    def conditional(self, obj: WDL.Tree.Conditional) -> Any:
+    def conditional(self, obj: Tree.Conditional) -> Any:
         for w in self._walkers:
             w.conditional(obj)
 
-    def decl(self, obj: WDL.Tree.Decl) -> Any:
+    def decl(self, obj: Tree.Decl) -> Any:
         for w in self._walkers:
             w.decl(obj)
 
-    def task(self, obj: WDL.Tree.Task) -> Any:
+    def task(self, obj: Tree.Task) -> Any:
         for w in self._walkers:
             w.task(obj)
 
-    def struct_typedef(self, obj: WDL.Tree.StructTypeDef) -> Any:
+    def struct_typedef(self, obj: Tree.StructTypeDef) -> Any:
         for w in self._walkers:
             w.struct_typedef(obj)
 
-    def expr(self, obj: WDL.Expr.Base) -> Any:
+    def expr(self, obj: Expr.Base) -> Any:
         for w in self._walkers:
             w.expr(obj)
 
@@ -168,9 +168,9 @@ class SetParents(Base):
     On each Expr, the containing Decl, Call, Scatter, Conditional, or Task.
     """
 
-    _parent_stack: List[WDL.Error.SourceNode] = []
+    _parent_stack: List[Error.SourceNode] = []
 
-    def document(self, obj: WDL.Tree.Document) -> None:
+    def document(self, obj: Tree.Document) -> None:
         super().document(obj)
         obj.parent = None
         for imp in obj.imports:
@@ -182,18 +182,18 @@ class SetParents(Base):
         if obj.workflow:
             obj.workflow.parent = obj
 
-    def workflow(self, obj: WDL.Tree.Workflow) -> None:
+    def workflow(self, obj: Tree.Workflow) -> None:
         super().workflow(obj)
         obj.parent = None
         for elt in (obj.inputs or []) + obj.elements + (obj.outputs or []):
             elt.parent = obj
 
-    def call(self, obj: WDL.Tree.Call) -> None:
+    def call(self, obj: Tree.Call) -> None:
         self._parent_stack.append(obj)
         super().call(obj)
         self._parent_stack.pop()
 
-    def scatter(self, obj: WDL.Tree.Scatter) -> None:
+    def scatter(self, obj: Tree.Scatter) -> None:
         self._parent_stack.append(obj)
         super().scatter(obj)
         self._parent_stack.pop()
@@ -201,7 +201,7 @@ class SetParents(Base):
         for elt in obj.elements:
             elt.parent = obj
 
-    def conditional(self, obj: WDL.Tree.Conditional) -> None:
+    def conditional(self, obj: Tree.Conditional) -> None:
         self._parent_stack.append(obj)
         super().conditional(obj)
         self._parent_stack.pop()
@@ -209,7 +209,7 @@ class SetParents(Base):
         for elt in obj.elements:
             elt.parent = obj
 
-    def task(self, obj: WDL.Tree.Task) -> None:
+    def task(self, obj: Tree.Task) -> None:
         self._parent_stack.append(obj)
         super().task(obj)
         self._parent_stack.pop()
@@ -217,12 +217,12 @@ class SetParents(Base):
         for elt in (obj.inputs or []) + obj.postinputs + obj.outputs:
             elt.parent = obj
 
-    def decl(self, obj: WDL.Tree.Decl) -> None:
+    def decl(self, obj: Tree.Decl) -> None:
         self._parent_stack.append(obj)
         super().decl(obj)
         self._parent_stack.pop()
 
-    def expr(self, obj: WDL.Expr.Base) -> None:
+    def expr(self, obj: Expr.Base) -> None:
         super().expr(obj)
         obj.parent = self._parent_stack[-1]
 
@@ -238,7 +238,7 @@ class MarkCalled(Base):
 
     marking: bool = False  # True while recursing from the top-level workflow
 
-    def workflow(self, obj: WDL.Tree.Workflow) -> None:
+    def workflow(self, obj: Tree.Workflow) -> None:
         obj.called = False
         if obj.parent.parent is None:  # pyre-ignore
             assert not self.marking
@@ -249,13 +249,13 @@ class MarkCalled(Base):
         elif self.marking:
             super().workflow(obj)
 
-    def call(self, obj: WDL.Tree.Call) -> None:
+    def call(self, obj: Tree.Call) -> None:
         assert self.marking
-        if isinstance(obj.callee, WDL.Tree.Workflow):
+        if isinstance(obj.callee, Tree.Workflow):
             self(obj.callee)
         obj.callee.called = True
 
-    def task(self, obj: WDL.Tree.Task) -> None:
+    def task(self, obj: Tree.Task) -> None:
         obj.called = False
 
 
@@ -271,6 +271,6 @@ class SetReferrers(Base):
     def __init__(self):
         super().__init__(auto_descend=True)
 
-    def expr(self, obj: WDL.Expr.Base) -> None:
-        if isinstance(obj, WDL.Expr.Ident) and isinstance(obj.ctx, (WDL.Tree.Decl, WDL.Tree.Call)):
+    def expr(self, obj: Expr.Base) -> None:
+        if isinstance(obj, Expr.Ident) and isinstance(obj.ctx, (Tree.Decl, Tree.Call)):
             setattr(obj.ctx, "referrers", getattr(obj.ctx, "referrers", []) + [obj])

--- a/WDL/__init__.py
+++ b/WDL/__init__.py
@@ -72,10 +72,10 @@ def parse_tasks(txt: str, version: Optional[str] = None) -> List[Task]:
 
 def values_from_json(
     values_json: Dict[str, Any],
-    available: "WDL.Env.Decls",
-    required: "Optional[WDL.Env.Decls]" = None,
+    available: Env.Decls,
+    required: Optional[Env.Decls] = None,
     namespace: Optional[List[str]] = None,
-) -> "WDL.Env.Values":
+) -> Env.Values:
     """
     Given a dict parsed from Cromwell-style JSON and the available input (or
     output) declarations of a task or workflow, create a ``WDL.Env.Values``.
@@ -107,9 +107,7 @@ def values_from_json(
     return ans
 
 
-def values_to_json(
-    values_env: "WDL.Env.Values", namespace: Optional[List[str]] = None
-) -> Dict[str, Any]:
+def values_to_json(values_env: Env.Values, namespace: Optional[List[str]] = None) -> Dict[str, Any]:
     """
     Convert a ``WDL.Env.Values`` to a dict which ``json.dumps`` to
     Cromwell-style JSON.

--- a/WDL/__main__.py
+++ b/WDL/__main__.py
@@ -1,5 +1,5 @@
 # PYTHON_ARGCOMPLETE_OK
-import WDL.CLI
+from . import CLI
 
 if __name__ == "__main__":
-    WDL.CLI.main()
+    CLI.main()

--- a/WDL/_util.py
+++ b/WDL/_util.py
@@ -2,7 +2,6 @@
 # misc utility functions...
 
 from typing import Tuple, Dict, Set, Iterable, List
-import WDL.Error
 
 
 def strip_leading_whitespace(txt: str) -> Tuple[int, str]:

--- a/WDL/runtime/error.py
+++ b/WDL/runtime/error.py
@@ -1,4 +1,4 @@
-from WDL.Error import RuntimeError as _RuntimeError
+from ..Error import RuntimeError as _RuntimeError
 
 
 class CommandError(_RuntimeError):


### PR DESCRIPTION
Make all of the `WDL` package's internal imports relative.

Avoid abbreviating imported module names, to improve readability.