### PR TITLE
explicate Gather operations in workflow dependencies

### DIFF
--- a/WDL/Expr.py
+++ b/WDL/Expr.py
@@ -647,11 +647,12 @@ class Ident(Base):
     name: str
     ":type: str"
 
-    referee: Optional[SourceNode]
+    referee: "Union[None, WDL.Tree.Decl, WDL.Tree.Call, WDL.Tree.Scatter, WDL.Tree.Gather]"
     """
     After typechecking within a task or workflow, stores the AST node to which the identifier
-    refers: a ``WDL.Tree.Decl`` for value references; a ``WDL.Tree.Call`` for call outputs; or a
-    ``WDL.Tree.Scatter`` for scatter variables.
+    refers: a ``WDL.Tree.Decl`` for value references; a ``WDL.Tree.Call`` for call outputs; a
+    ``WDL.Tree.Scatter`` for scatter variables; or a ``WDL.Tree.Gather`` object representing a
+    value or call output that resides within a scatter or conditional section.
     """
 
     def __init__(self, pos: SourcePosition, parts: List[str]) -> None:
@@ -672,8 +673,12 @@ class Ident(Base):
         # referee comes from the type environment's context values
         referee = Env.resolve_ctx(type_env, self.namespace, self.name)
         if referee:
-            assert isinstance(referee, SourceNode)
-            assert referee.__class__.__name__ in ["Decl", "Call", "Scatter"]
+            assert referee.__class__.__name__ in [
+                "Decl",
+                "Call",
+                "Scatter",
+                "Gather",
+            ], referee.__class__.__name__
             self.referee = referee
         return ans
 

--- a/WDL/Lint.py
+++ b/WDL/Lint.py
@@ -621,23 +621,23 @@ class UnusedImport(Linter):
 class ForwardReference(Linter):
     # Ident referencing a value or call output lexically precedes Decl/Call
     def expr(self, obj: Expr.Base) -> Any:
-        if (
-            isinstance(obj, Expr.Ident)
-            and isinstance(obj.referee, (Tree.Decl, Tree.Call))
-            and (
-                obj.referee.pos.line > obj.pos.line
-                or (
-                    obj.referee.pos.line == obj.pos.line and obj.referee.pos.column > obj.pos.column
-                )
-            )
-        ):
-            if isinstance(obj.referee, Tree.Decl):
-                msg = "reference to {} precedes its declaration".format(obj.name)
-            elif isinstance(obj.referee, Tree.Call):
-                msg = "reference to output of {} precedes the call".format(".".join(obj.namespace))
-            else:
-                assert False
-            self.add(getattr(obj, "parent"), msg, obj.pos)
+        if isinstance(obj, Expr.Ident):
+            referee = obj.referee
+            while isinstance(referee, Tree.Gather):
+                referee = referee.referee
+            if isinstance(referee, (Tree.Decl, Tree.Call)) and (
+                referee.pos.line > obj.pos.line
+                or (referee.pos.line == obj.pos.line and referee.pos.column > obj.pos.column)
+            ):
+                if isinstance(referee, Tree.Decl):
+                    msg = "reference to {} precedes its declaration".format(obj.name)
+                elif isinstance(referee, Tree.Call):
+                    msg = "reference to output of {} precedes the call".format(
+                        ".".join(obj.namespace)
+                    )
+                else:
+                    assert False
+                self.add(getattr(obj, "parent"), msg, obj.pos)
 
 
 @a_linter

--- a/WDL/Walker.py
+++ b/WDL/Walker.py
@@ -272,5 +272,9 @@ class SetReferrers(Base):
         super().__init__(auto_descend=True)
 
     def expr(self, obj: Expr.Base) -> None:
-        if isinstance(obj, Expr.Ident) and isinstance(obj.referee, (Tree.Decl, Tree.Call)):
-            setattr(obj.referee, "referrers", getattr(obj.referee, "referrers", []) + [obj])
+        if isinstance(obj, Expr.Ident):
+            referee = obj.referee
+            while isinstance(referee, Tree.Gather):
+                referee = referee.referee
+            if isinstance(referee, (Tree.Decl, Tree.Call)):
+                setattr(referee, "referrers", getattr(referee, "referrers", []) + [obj])


### PR DESCRIPTION
When a value or call output inside a workflow scatter or conditional section is referenced by some identifier expression outside of that section, there's an implied operation to gather the array of values/outputs (or conditional value). We add a little `Gather` AST node which may sit in `WDL.Expr.Ident.referee` to represent this operation abstractly, which will be useful in scheduling workflow execution.