### PR TITLE
refactoring workflow AST to facilitate runtime dependency analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,13 +142,13 @@ import WDL
 doc = WDL.load('skylab/pipelines/optimus/Optimus.wdl',
                path=['skylab/library/tasks/'])
 
-def show(elements):
-  for elt in elements:
+def show(body):
+  for elt in body:
     if isinstance(elt, WDL.Decl):
       print(str(elt.type) + ' ' + elt.name)
     elif isinstance(elt, WDL.Scatter) or isinstance(elt, WDL.Conditional):
-      show(elt.elements)
-show(doc.workflow.elements)
+      show(elt.body)
+show(doc.workflow.body)
 "
 
 String version

--- a/WDL/CLI.py
+++ b/WDL/CLI.py
@@ -174,7 +174,7 @@ def outline(obj, level, file=sys.stdout, show_called=True):
             ),
             file=file,
         )
-        for elt in (obj.inputs or []) + obj.elements + (obj.outputs or []):
+        for elt in (obj.inputs or []) + obj.body + (obj.outputs or []):
             descend(elt)
     # task
     elif isinstance(obj, Task):
@@ -195,12 +195,12 @@ def outline(obj, level, file=sys.stdout, show_called=True):
     # scatter
     elif isinstance(obj, Scatter):
         print("{}scatter {}".format(s, obj.variable), file=file)
-        for elt in obj.elements:
+        for elt in obj.body:
             descend(elt)
     # if
     elif isinstance(obj, Conditional):
         print("{}if".format(s), file=file)
-        for elt in obj.elements:
+        for elt in obj.body:
             descend(elt)
     # decl
     elif isinstance(obj, Decl):

--- a/WDL/Error.py
+++ b/WDL/Error.py
@@ -194,7 +194,10 @@ class StrayInputDeclaration(ValidationError):
 
 class CircularDependencies(ValidationError):
     def __init__(self, node: SourceNode) -> None:
-        super().__init__(node, "circular dependencies involving {}".format(getattr(node, "name")))
+        nm = getattr(node, "name", None)
+        if not nm:
+            nm = getattr(node, "workflow_node_id")
+        super().__init__(node, "circular dependencies involving " + nm)
 
 
 class MultipleValidationErrors(Exception):

--- a/WDL/Error.py
+++ b/WDL/Error.py
@@ -194,10 +194,14 @@ class StrayInputDeclaration(ValidationError):
 
 class CircularDependencies(ValidationError):
     def __init__(self, node: SourceNode) -> None:
-        nm = getattr(node, "name", None)
-        if not nm:
-            nm = getattr(node, "workflow_node_id")
-        super().__init__(node, "circular dependencies involving " + nm)
+        msg = "circular dependencies"
+        nm = next(
+            (getattr(node, attr) for attr in ("name", "workflow_node_id") if hasattr(node, attr)),
+            None,
+        )
+        if nm:
+            nm += " involving " + nm
+        super().__init__(node, msg)
 
 
 class MultipleValidationErrors(Exception):

--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -999,7 +999,7 @@ class Workflow(SourceNode):
                     output_names.add(output.name)
                     # tricky sequence here: we need to call Decl.add_to_type_env to resolve
                     # potential struct type, but:
-                    # 1. we may not want it to check for name collision in the usual way in order to
+                    # 1. we don't want it to check for name collision in the usual way in order to
                     #    handle a quirk of draft-2 workflow output style, where an output may take
                     #    the name of another decl in the workflow. Instead we've tracked and
                     #    rejected any duplicate names among the workflow outputs.

--- a/WDL/Walker.py
+++ b/WDL/Walker.py
@@ -185,7 +185,7 @@ class SetParents(Base):
     def workflow(self, obj: Tree.Workflow) -> None:
         super().workflow(obj)
         obj.parent = None
-        for elt in (obj.inputs or []) + obj.elements + (obj.outputs or []):
+        for elt in (obj.inputs or []) + obj.body + (obj.outputs or []):
             elt.parent = obj
 
     def call(self, obj: Tree.Call) -> None:
@@ -198,7 +198,7 @@ class SetParents(Base):
         super().scatter(obj)
         self._parent_stack.pop()
         obj.parent = None
-        for elt in obj.elements:
+        for elt in obj.body:
             elt.parent = obj
 
     def conditional(self, obj: Tree.Conditional) -> None:
@@ -206,7 +206,7 @@ class SetParents(Base):
         super().conditional(obj)
         self._parent_stack.pop()
         obj.parent = None
-        for elt in obj.elements:
+        for elt in obj.body:
             elt.parent = obj
 
     def task(self, obj: Tree.Task) -> None:

--- a/tests/test_1doc.py
+++ b/tests/test_1doc.py
@@ -1101,7 +1101,7 @@ class TestDoc(unittest.TestCase):
                     sum.*
                     adder.*
                     k
-                    Int j2 = j
+                    Int j = j
                 }
             }
         """)

--- a/tests/test_1doc.py
+++ b/tests/test_1doc.py
@@ -439,8 +439,8 @@ class TestTypes(unittest.TestCase):
             }}
             """.format(t=t)
             doc = WDL.parse_document(doc_txt, v)
-            self.assertEqual(str(doc.workflow.elements[0].type), t)
-            self.assertEqual(doc.workflow.elements[0].type.optional, t.endswith("?"))
+            self.assertEqual(str(doc.workflow.body[0].type), t)
+            self.assertEqual(doc.workflow.body[0].type.optional, t.endswith("?"))
             self.assertEqual(str(doc.workflow.effective_outputs[0].rhs), t)
         for t in ["Int", "Int?",
                   "Array[Int]", "Array[Int]?", "Array[Int]+?", "Array[Int?]+?",
@@ -500,7 +500,7 @@ class TestDoc(unittest.TestCase):
         """
         doc = WDL.parse_document(doc)
         self.assertIsInstance(doc.workflow, WDL.Tree.Workflow)
-        self.assertEqual(len(doc.workflow.elements), 2)
+        self.assertEqual(len(doc.workflow.body), 2)
         self.assertEqual(len(doc.tasks), 2)
         doc.typecheck()
 
@@ -558,9 +558,9 @@ class TestDoc(unittest.TestCase):
         """
         doc = WDL.parse_document(doc, version="draft-2")
         self.assertIsInstance(doc.workflow, WDL.Tree.Workflow)
-        self.assertEqual(len(doc.workflow.elements), 3)
-        self.assertIsInstance(doc.workflow.elements[2], WDL.Tree.Scatter)
-        self.assertEqual(len(doc.workflow.elements[2].elements), 1)
+        self.assertEqual(len(doc.workflow.body), 3)
+        self.assertIsInstance(doc.workflow.body[2], WDL.Tree.Scatter)
+        self.assertEqual(len(doc.workflow.body[2].body), 1)
         self.assertEqual(len(doc.tasks), 2)
         self.assertEqual(doc.tasks[0].name, "slice_bam")
         self.assertEqual(len(doc.tasks[0].command.parts), 7)
@@ -602,8 +602,8 @@ class TestDoc(unittest.TestCase):
         """
         doc = WDL.parse_document(doc)
         self.assertIsInstance(doc.workflow, WDL.Tree.Workflow)
-        self.assertIsInstance(doc.workflow.elements[2], WDL.Tree.Scatter)
-        self.assertIsInstance(doc.workflow.elements[2].elements[0], WDL.Tree.Scatter)
+        self.assertIsInstance(doc.workflow.body[2], WDL.Tree.Scatter)
+        self.assertIsInstance(doc.workflow.body[2].body[0], WDL.Tree.Scatter)
         self.assertEqual(len(doc.tasks), 1)
         doc.typecheck()
         self.assertEqual(len(doc.imports), 2)

--- a/tests/test_1doc.py
+++ b/tests/test_1doc.py
@@ -831,18 +831,6 @@ class TestDoc(unittest.TestCase):
             doc.typecheck()
 
         doc = r"""
-        workflow contrived {
-            Int x
-            output {
-                Int x = 1
-            }
-        }
-        """
-        doc = WDL.parse_document(doc)
-        with self.assertRaises(WDL.Error.MultipleDefinitions):
-            doc.typecheck()
-
-        doc = r"""
         import "x.wdl"
         import "x.wdl"
         """

--- a/tests/test_1doc.py
+++ b/tests/test_1doc.py
@@ -831,6 +831,18 @@ class TestDoc(unittest.TestCase):
             doc.typecheck()
 
         doc = r"""
+        workflow contrived {
+            Int x
+            output {
+                Int x = 1
+            }
+        }
+        """
+        doc = WDL.parse_document(doc)
+        with self.assertRaises(WDL.Error.MultipleDefinitions):
+            doc.typecheck()
+
+        doc = r"""
         import "x.wdl"
         import "x.wdl"
         """
@@ -1101,7 +1113,7 @@ class TestDoc(unittest.TestCase):
                     sum.*
                     adder.*
                     k
-                    Int j = j
+                    Int j2 = j
                 }
             }
         """)

--- a/tests/test_2calls.py
+++ b/tests/test_2calls.py
@@ -442,7 +442,7 @@ class TestCalls(unittest.TestCase):
         """
         doc = WDL.parse_document(txt)
         doc.typecheck()
-        assert(doc.workflow.elements[0].type.nonempty and doc.workflow.elements[0].type.optional)
+        assert(doc.workflow.body[0].type.nonempty and doc.workflow.body[0].type.optional)
 
         txt = tsk + r"""
         workflow contrived {


### PR DESCRIPTION
- Introduces `WorkflowNode` as a base class for `Decl`, `Call`, `Scatter`, and `Conditional`. Each workflow node has a string ID (unique within the workflow) and reports the IDs of its dependencies.
- Furthermore `Scatter` and `Conditional` inherit `WorkflowSection : WorkflowNode` which centralizes access to the `Gather` nodes.
- Renames `{Workflow,Scatter,Conditional}.elements` to `.body`

The typechecker and cycle detection are unchanged, but probably can be simplified by using these new constructs (especially the gathers for typechecking).