### PR TITLE
add __str__ to Expr classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ docs/_build/
 dist/
 build/
 *.egg-info/
+venv/

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ docs/_build/
 dist/
 build/
 *.egg-info/
-venv/

--- a/WDL/Expr.py
+++ b/WDL/Expr.py
@@ -730,7 +730,7 @@ class Ident(Base):
         self.referee = None
 
     def __str__(self):
-        return self.name
+        return ".".join(self.namespace + [self.name])
 
     @property
     def children(self) -> Iterable[SourceNode]:


### PR DESCRIPTION
I was working on a script to compile user documentation for WDL workflows and I found myself writing functions to render WDL expressions so the default values of inputs could be shown in these docs. It seemed to me that it might be be more appropriate to add these functions to the WDL bindings, hence this PR.

If this PR were to get merged, calling `str()` on most WDL.Expr classes would return a human-readable expression. The returned strings should look similar to how the expression would be written in WDL in most cases. For structs they currently would look like this, though: `(field: "A",  another_field: 1.1, yet_another_field: (another_struct: true))`.

Let me know what you think and if this is even something you're interested in. If so, could you point me to where I should add tests for this?
