### PR TITLE
task runtime: switch to docker swarm for container scheduling

### DIFF
--- a/WDL/CLI.py
+++ b/WDL/CLI.py
@@ -23,7 +23,7 @@ from ._util import (
     VERBOSE_LEVEL,
     NOTICE_LEVEL,
     install_coloredlogs,
-    ensure_swarm
+    ensure_swarm,
 )
 
 quant_warning = False

--- a/WDL/CLI.py
+++ b/WDL/CLI.py
@@ -23,6 +23,7 @@ from ._util import (
     VERBOSE_LEVEL,
     NOTICE_LEVEL,
     install_coloredlogs,
+    ensure_swarm
 )
 
 quant_warning = False
@@ -364,6 +365,8 @@ def runner(
         logger.debug("miniwdl version unknown ({}: {})".format(type(exc).__name__, exc))
     for pkg in ["docker", "lark-parser", "argcomplete", "pygtail"]:
         logger.debug(pkg_resources.get_distribution(pkg))
+
+    ensure_swarm(logger)
 
     try:
         entrypoint = (

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -9,6 +9,7 @@ import copy
 import traceback
 import glob
 import signal
+import time
 from abc import ABC, abstractmethod
 from typing import Tuple, List, Dict, Optional
 from types import FrameType
@@ -16,7 +17,7 @@ from types import FrameType
 from requests.exceptions import ReadTimeout
 import docker
 from .. import Error, Type, Env, Expr, Value, StdLib, Tree, _util
-from .._util import write_values_json, provision_run_dir, LOGGING_FORMAT, PygtailLogger
+from .._util import write_values_json, provision_run_dir, LOGGING_FORMAT, PygtailLogger, ensure_swarm
 from .error import *
 
 
@@ -124,6 +125,7 @@ class TaskContainer(ABC):
 
             self._running = True
             try:
+                os.makedirs(os.path.join(self.host_dir, "work"))
                 exit_status = self._run(logger, command)
             finally:
                 self._running = False
@@ -198,7 +200,7 @@ class TaskDockerContainer(TaskContainer):
     docker image tag (set as desired before running)
     """
 
-    def _run(self, logger: logging.Logger, command: str) -> int:
+    def _run(self, logger: logging.Logger, command: str, cpu: int = 1) -> int:
         with open(os.path.join(self.host_dir, "command"), "x") as outfile:
             outfile.write(command)
         pipe_files = ["stdout.txt", "stderr.txt"]
@@ -206,80 +208,79 @@ class TaskDockerContainer(TaskContainer):
             with open(os.path.join(self.host_dir, touch_file), "x") as outfile:
                 pass
 
-        volumes = {}
+        mounts = []
         # mount input files and command read-only
         for host_path, container_path in self.input_file_map.items():
-            volumes[host_path] = {"bind": container_path, "mode": "ro"}
-        volumes[os.path.join(self.host_dir, "command")] = {
-            "bind": os.path.join(self.container_dir, "command"),
-            "mode": "ro",
-        }
+            mounts.append(f"{host_path}:{container_path}:ro")
+        mounts.append(f"{os.path.join(self.host_dir, 'command')}:{os.path.join(self.container_dir, 'command')}:ro")
         # mount stdout, stderr, and working directory read/write
         for pipe_file in pipe_files:
-            volumes[os.path.join(self.host_dir, pipe_file)] = {
-                "bind": os.path.join(self.container_dir, pipe_file),
-                "mode": "rw",
-            }
-        volumes[os.path.join(self.host_dir, "work")] = {
-            "bind": os.path.join(self.container_dir, "work"),
-            "mode": "rw",
-        }
-        logger.debug("docker volume map: " + str(volumes))
+            mounts.append(f"{os.path.join(self.host_dir, pipe_file)}:{os.path.join(self.container_dir, pipe_file)}:rw")
+        mounts.append(f"{os.path.join(self.host_dir, 'work')}:{os.path.join(self.container_dir, 'work')}:rw")
+        logger.debug("docker mounts: " + str(mounts))
 
         # connect to dockerd
         client = docker.from_env()
+        svc = None
         try:
             # run container
             logger.info("docker starting image {}".format(self.image_tag))
-            container = client.containers.run(
+            svc = client.services.create(
                 self.image_tag,
                 command=[
                     "/bin/bash",
                     "-c",
                     "/bin/bash ../command >> ../stdout.txt 2>> ../stderr.txt",
                 ],
-                detach=True,
-                auto_remove=True,
-                working_dir=os.path.join(self.container_dir, "work"),
-                volumes=volumes,
+                # restart_policy 'none' so that swarm runs the container just once
+                restart_policy=docker.types.RestartPolicy("none"),
+                workdir=os.path.join(self.container_dir, "work"),
+                mounts=mounts,
+                resources=docker.types.Resources(
+                    # cpu_limit throttles container to desired # of cpus.
+                    # the unit expected by swarm is "NanoCPUs"
+                    cpu_limit=cpu*1_000_000_000,
+                    # cpu_reservation makes swarm delay starting the container until the desired # of
+                    # cpus are available (considering other running services)
+                    cpu_reservation=cpu*1_000_000_000,
+                ),
             )
-            logger.debug("docker container name = {}, id = {}".format(container.name, container.id))
+            logger.debug("docker service name = {}, id = {}".format(svc.name, svc.short_id))
 
-            exit_info = None
+            exit_code = None
             # stream stderr into log
             with PygtailLogger(logger, os.path.join(self.host_dir, "stderr.txt")) as poll_stderr:
                 try:
-                    # long-poll for container exit
-                    while exit_info is None:
-                        try:
-                            exit_info = container.wait(timeout=1)
-                        except Exception as exn:
-                            if self._terminate:
-                                raise Terminated() from None
-                            # workaround for docker-py not throwing the exception class
-                            # it's supposed to
-                            s_exn = str(exn)
-                            if "timed out" not in s_exn and "Timeout" not in s_exn:
-                                raise
+                    # poll for container exit
+                    while exit_code is None:
+                        time.sleep(1)
+                        if self._terminate:
+                            raise Terminated() from None
+                        svc.reload()
+                        tasks = svc.tasks()
+                        logger.debug("docker task status = " + str(tasks))
+                        assert len(tasks) == 1
+                        state = tasks[0]["Status"]["State"]
+                        if state in ["complete", "failed"]:
+                            exit_code = tasks[0]["Status"]["ContainerStatus"]["ExitCode"]
+                            assert isinstance(exit_code, int)
+                        # TODO: handle state 'rejected'
                         poll_stderr()
-                    logger.info("container exit info = " + str(exit_info))
+                    logger.info("container exit code = " + str(exit_code))
                 except:
-                    # make sure to stop & clean up the container if we're stopping due
-                    # to SIGTERM or something. Most other cases should be handled by
-                    # auto_remove.
-                    try:
-                        container.remove(force=True)
-                        logger.info("force-removed docker container")
-                    except Exception as exn:
-                        logger.exception("failed to remove docker container")
+                    if self._terminate:
+                        raise Terminated() from None
                     raise
 
             # retrieve and check container exit status
-            assert (
-                exit_info and "StatusCode" in exit_info and isinstance(exit_info["StatusCode"], int)
-            )
-            return exit_info["StatusCode"]
+            assert isinstance(exit_code, int)
+            return exit_code
         finally:
+            if svc:
+                try:
+                    svc.remove()
+                except:
+                    logger.exception("failed to remove docker service")
             try:
                 client.close()
             except:

--- a/stubs/docker/__init__.py
+++ b/stubs/docker/__init__.py
@@ -23,21 +23,23 @@ class Swarm:
     def init(self, **kwargs) -> str:
         ...
 
-class Service:
-    short_id: str
-    name: str
+class models:
+    class services:
+        class Service:
+            short_id: str
+            name: str
 
-    def tasks(self) -> List[Dict[str, Any]]:
-        ...
+            def tasks(self) -> List[Dict[str, Any]]:
+                ...
 
-    def reload(self) -> None:
-        ...
+            def reload(self) -> None:
+                ...
 
-    def remove(self) -> None:
-        ...
+            def remove(self) -> None:
+                ...
 
 class Services:
-    def create(self, image: str, **kwargs) -> Service:
+    def create(self, image: str, **kwargs) -> model.services.Service:
         ...
 
 class types:

--- a/stubs/docker/__init__.py
+++ b/stubs/docker/__init__.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Any, List
 
 class Container:
     @property
@@ -19,12 +19,51 @@ class Containers:
     def run(self, image_tag: str, **kwargs) -> Container:
         ...
 
-class Client:
-    @property
-    def containers() -> Containers:
+class Swarm:
+    def init(self, **kwargs) -> str:
         ...
 
-    def close() -> None:
+class Service:
+    short_id: str
+    name: str
+
+    def tasks(self) -> List[Dict[str, Any]]:
+        ...
+
+    def reload(self) -> None:
+        ...
+
+    def remove(self) -> None:
+        ...
+
+class Services:
+    def create(self, image: str, **kwargs) -> Service:
+        ...
+
+class types:
+    def RestartPolicy(p: str) -> Any:
+        ...
+
+    def Resources(**kwargs) -> Any:
+        ...
+
+class Client:
+    @property
+    def containers(self) -> Containers:
+        ...
+
+    def close(self) -> None:
+        ...
+
+    def info(self) -> Dict[str, Any]:
+        ...
+
+    @property
+    def swarm(self) -> Swarm:
+        ...
+
+    @property
+    def services(self) -> Services:
         ...
 
 def from_env() -> Client:

--- a/tests/test_4taskrun.py
+++ b/tests/test_4taskrun.py
@@ -659,3 +659,46 @@ class TestTaskRunner(unittest.TestCase):
         }
         """, {"w": 2})
         self.assertAlmostEqual(output["logsize"], 0.0)
+
+    def test_cpu_limit(self):
+        txt = R"""
+        version 1.0
+        task spin {
+            input {
+                Int n
+                Int cpu
+            }
+            command <<<
+                set -x
+                source /root/.profile
+                cat << EOF > spin_one_cpu_second.py
+                import time
+                while time.process_time() < 1.0:
+                    pass
+                EOF
+                t0=$(date +"%s")
+                for i in $(seq ~{n}); do
+                    python3 spin_one_cpu_second.py &
+                done
+                wait
+                t1=$(date +"%s")
+                echo $(( t1 - t0 )) > wall_seconds
+            >>>
+            output {
+                Int wall_seconds = read_int("wall_seconds")
+            }
+            runtime {
+                docker: "continuumio/miniconda3"
+                cpu: cpu
+            }
+        }
+        """
+        # 4 concurrent spinners limited to 1 cpu should take 4 seconds
+        outputs = self._test_task(txt, {"n": 4, "cpu": 1})
+        self.assertGreaterEqual(outputs["wall_seconds"], 3)
+        # 8 concurrent spinners on >1 cpus should take <8 seconds
+        outputs = self._test_task(txt, {"n": 8, "cpu": 4})
+        self.assertLessEqual(outputs["wall_seconds"], 6)
+        # check task with overkill number of CPUs gets scheduled
+        outputs = self._test_task(txt, {"n": 8, "cpu": 9999})
+        self.assertLessEqual(outputs["wall_seconds"], 6)

--- a/tests/test_4taskrun.py
+++ b/tests/test_4taskrun.py
@@ -93,7 +93,7 @@ class TestTaskRunner(unittest.TestCase):
                 docker: "nonexistent:202407"
             }
         }
-        """, expected_exception=docker.errors.ImageNotFound)
+        """, expected_exception=RuntimeError)
 
     @log_capture()
     def test_logging_std_err(self, capture):

--- a/tests/test_4taskrun.py
+++ b/tests/test_4taskrun.py
@@ -15,6 +15,7 @@ class TestTaskRunner(unittest.TestCase):
         self._dir = tempfile.mkdtemp(prefix="miniwdl_test_taskrun_")
 
     def _test_task(self, wdl:str, inputs = None, expected_exception: Exception = None):
+        WDL._util.ensure_swarm(logging.getLogger("test_task"))
         try:
             doc = WDL.parse_document(wdl)
             assert len(doc.tasks) == 1

--- a/tests/test_5stdlib.py
+++ b/tests/test_5stdlib.py
@@ -12,6 +12,7 @@ class TestStdLib(unittest.TestCase):
         self._dir = tempfile.mkdtemp(prefix="miniwdl_test_stdlib_")
 
     def _test_task(self, wdl:str, inputs = None, expected_exception: Exception = None):
+        WDL._util.ensure_swarm(logging.getLogger("test_task"))
         try:
             doc = WDL.parse_document(wdl)
             assert len(doc.tasks) == 1

--- a/tests/test_6workflowrun.py
+++ b/tests/test_6workflowrun.py
@@ -14,6 +14,7 @@ class TestWorkflowRunner(unittest.TestCase):
         self._dir = tempfile.mkdtemp(prefix="miniwdl_test_workflowrun_")
 
     def _test_workflow(self, wdl:str, inputs = None, expected_exception: Exception = None):
+        WDL._util.ensure_swarm(logging.getLogger("test_workflow"))
         try:
             with tempfile.NamedTemporaryFile(dir=self._dir, suffix=".wdl", delete=False) as outfile:
                 outfile.write(wdl.encode("utf-8"))


### PR DESCRIPTION
Switches the task runtime to schedule the docker container using swarm instead of the lower-level container API. Swarm is built into docker and includes useful resource scheduling logic (e.g. waiting until desired number of CPUs are "available") which we won't have to reinvent this way. 