### PR TITLE
task runtime: option to copy input files and mount them read/write

### DIFF
--- a/WDL/CLI.py
+++ b/WDL/CLI.py
@@ -381,7 +381,7 @@ def runner(
         if isinstance(exn, runtime.task.CommandFailure) and not (
             kwargs["verbose"] or kwargs["debug"]
         ):
-            logger.error("run with --verbose for standard error logging")
+            logger.error("run with --verbose to include task standard error streams in this log")
             logger.error("see task's standard error in %s", getattr(exn, "stderr_file"))
         if isinstance(getattr(exn, "pos", None), SourcePosition):
             pos = getattr(exn, "pos")

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -500,7 +500,7 @@ def _copy_input_files(logger: logging.Logger, container: TaskContainer) -> None:
         rel_filename = container_filename[len(container_inputs_dir) :]
         host_copy_filename = os.path.join(container.host_dir, "inputs", rel_filename)
         os.makedirs(os.path.dirname(host_copy_filename), exist_ok=True)
-        logger.info("copy input file %s -> %s", host_filename, host_copy_filename)
+        logger.info("copy host input file %s -> %s", host_filename, host_copy_filename)
         shutil.copy(host_filename, host_copy_filename)
 
 

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -495,12 +495,15 @@ def _copy_input_files(logger: logging.Logger, container: TaskContainer) -> None:
     # for each virtualized filename in container.input_file_map, copy the corresponding host file
     # into appropriate subdirectory of host_dir/inputs; making the virtualized mapping "real."
     container_inputs_dir = os.path.join(container.container_dir, "inputs") + "/"
+
     for host_filename, container_filename in container.input_file_map.items():
         assert container_filename.startswith(container_inputs_dir)
-        rel_filename = container_filename[len(container_inputs_dir) :]
-        host_copy_filename = os.path.join(container.host_dir, "inputs", rel_filename)
-        os.makedirs(os.path.dirname(host_copy_filename), exist_ok=True)
+        host_copy_filename = os.path.join(
+            container.host_dir, "inputs", os.path.relpath(container_filename, container_inputs_dir)
+        )
+
         logger.info("copy host input file %s -> %s", host_filename, host_copy_filename)
+        os.makedirs(os.path.dirname(host_copy_filename), exist_ok=True)
         shutil.copy(host_filename, host_copy_filename)
 
 

--- a/WDL/runtime/workflow.py
+++ b/WDL/runtime/workflow.py
@@ -40,7 +40,7 @@ from typing import Optional, List, Set, Tuple, NamedTuple, Dict, Union, Iterable
 from .. import Env, Type, Value, Tree, StdLib
 from ..Error import InputError
 from .._util import write_values_json, provision_run_dir, LOGGING_FORMAT, install_coloredlogs
-from .task import run_local_task
+from .task import run_local_task, _filenames
 from .error import TaskFailure
 
 
@@ -550,21 +550,6 @@ class _StdLib(StdLib.Base):
     def _virtualize_filename(self, filename: str) -> str:
         self.state.filename_whitelist.add(filename)
         return filename
-
-
-def _filenames(env: Env.Bindings[Value.Base]) -> Set[str]:
-    "Get the filenames of all File values in the environment"
-    ans = set()
-
-    def collector(v: Value.Base) -> None:
-        if isinstance(v, Value.File):
-            ans.add(v.value)
-        for ch in v.children:
-            collector(ch)
-
-    for b in env:
-        collector(b.value)
-    return ans
 
 
 def run_local_workflow(

--- a/tests/test_4taskrun.py
+++ b/tests/test_4taskrun.py
@@ -578,7 +578,7 @@ class TestTaskRunner(unittest.TestCase):
             outfile.write("x\n")
         with open(os.path.join(self._dir, "b", "x.y"), "w") as outfile:
             outfile.write("x.y\n")
-        outputs = self._test_task(R"""
+        txt = R"""
         version 1.0
         task t {
             input {
@@ -591,23 +591,29 @@ class TestTaskRunner(unittest.TestCase):
                 Array[String] outfiles = read_lines(stdout())
             }
         }
-        """, {"files": [
+        """
+        inp = {"files": [
             os.path.join(self._dir, "a", "x"),
             os.path.join(self._dir, "a", "x.y"),
             os.path.join(self._dir, "b", "x"),
             os.path.join(self._dir, "b", "x.y"),
             os.path.join(self._dir, "b", "x.y") # intentional duplicate
-        ]})
-        outfiles = outputs["outfiles"]
-        self.assertEqual(len(outfiles), 5)
-        self.assertEqual(os.path.basename(outfiles[0]), "x")
-        self.assertEqual(os.path.basename(outfiles[1]), "x.y")
-        self.assertEqual(os.path.dirname(outfiles[0]), os.path.dirname(outfiles[1]))
-        self.assertEqual(os.path.basename(outfiles[2]), "x")
-        self.assertEqual(os.path.basename(outfiles[3]), "x.y")
-        self.assertEqual(os.path.dirname(outfiles[2]), os.path.dirname(outfiles[3]))
-        self.assertNotEqual(os.path.dirname(outfiles[0]), os.path.dirname(outfiles[2]))
-        self.assertEqual(outfiles[3], outfiles[4])
+        ]}
+        def chk(outfiles):
+            self.assertEqual(len(outfiles), 5)
+            self.assertEqual(os.path.basename(outfiles[0]), "x")
+            self.assertEqual(os.path.basename(outfiles[1]), "x.y")
+            self.assertEqual(os.path.dirname(outfiles[0]), os.path.dirname(outfiles[1]))
+            self.assertEqual(os.path.basename(outfiles[2]), "x")
+            self.assertEqual(os.path.basename(outfiles[3]), "x.y")
+            self.assertEqual(os.path.dirname(outfiles[2]), os.path.dirname(outfiles[3]))
+            self.assertNotEqual(os.path.dirname(outfiles[0]), os.path.dirname(outfiles[2]))
+            self.assertEqual(outfiles[3], outfiles[4])
+
+        outputs = self._test_task(txt, inp)
+        chk(outputs["outfiles"])
+        outputs = self._test_task(txt, inp, copy_input_files=True)
+        chk(outputs["outfiles"])
 
     def test_topsort(self):
         txt = R"""

--- a/tests/test_4taskrun.py
+++ b/tests/test_4taskrun.py
@@ -585,7 +585,7 @@ class TestTaskRunner(unittest.TestCase):
                 Array[File] files
             }
             command {
-                sort "~{write_lines(files)}"
+                cat "~{write_lines(files)}"
             }
             output {
                 Array[String] outfiles = read_lines(stdout())
@@ -725,7 +725,7 @@ class TestTaskRunner(unittest.TestCase):
             outfile.write("Alyssa\n")
         with open(os.path.join(self._dir, "ben.txt"), "w") as outfile:
             outfile.write("Ben\n")
-        
+
         self._test_task(txt, {"files": [os.path.join(self._dir, "alyssa.txt"), os.path.join(self._dir, "ben.txt")]},
                         expected_exception=WDL.runtime.task.CommandFailure)
 

--- a/tests/test_4taskrun.py
+++ b/tests/test_4taskrun.py
@@ -711,6 +711,7 @@ class TestTaskRunner(unittest.TestCase):
                 Array[File] files
             }
             command <<<
+                set -x
                 touch ~{sep=" " files}
                 mv ~{files[0]} alyssa2.txt
                 rm ~{files[1]}
@@ -730,4 +731,4 @@ class TestTaskRunner(unittest.TestCase):
 
         outputs = self._test_task(txt, {"files": [os.path.join(self._dir, "alyssa.txt"), os.path.join(self._dir, "ben.txt")]},
                                   copy_input_files=True)
-        self.assertTrue(outputs[outfile].endswith("alyssa2.txt"))
+        self.assertTrue(outputs["outfile"].endswith("alyssa2.txt"))

--- a/tests/test_4taskrun.py
+++ b/tests/test_4taskrun.py
@@ -14,7 +14,7 @@ class TestTaskRunner(unittest.TestCase):
         logging.basicConfig(level=logging.DEBUG, format='%(name)s %(levelname)s %(message)s')
         self._dir = tempfile.mkdtemp(prefix="miniwdl_test_taskrun_")
 
-    def _test_task(self, wdl:str, inputs = None, expected_exception: Exception = None):
+    def _test_task(self, wdl:str, inputs = None, expected_exception: Exception = None, copy_input_files: bool = False):
         WDL._util.ensure_swarm(logging.getLogger("test_task"))
         try:
             doc = WDL.parse_document(wdl)
@@ -22,7 +22,7 @@ class TestTaskRunner(unittest.TestCase):
             doc.typecheck()
             if isinstance(inputs, dict):
                 inputs = WDL.values_from_json(inputs, doc.tasks[0].available_inputs, doc.tasks[0].required_inputs)
-            rundir, outputs = WDL.runtime.run_local_task(doc.tasks[0], (inputs or WDL.Env.Bindings()), run_dir=self._dir)
+            rundir, outputs = WDL.runtime.run_local_task(doc.tasks[0], (inputs or WDL.Env.Bindings()), run_dir=self._dir, copy_input_files=copy_input_files)
         except WDL.runtime.TaskFailure as exn:
             if expected_exception:
                 self.assertIsInstance(exn.__context__, expected_exception)
@@ -702,3 +702,32 @@ class TestTaskRunner(unittest.TestCase):
         # check task with overkill number of CPUs gets scheduled
         outputs = self._test_task(txt, {"n": 8, "cpu": 9999})
         self.assertLessEqual(outputs["wall_seconds"], 6)
+
+    def test_input_files_rw(self):
+        txt = R"""
+        version 1.0
+        task clobber {
+            input {
+                Array[File] files
+            }
+            command <<<
+                touch ~{sep=" " files}
+                mv ~{files[0]} alyssa2.txt
+                rm ~{files[1]}
+            >>>
+            output {
+                File outfile = glob("*.txt")[0]
+            }
+        }
+        """
+        with open(os.path.join(self._dir, "alyssa.txt"), "w") as outfile:
+            outfile.write("Alyssa\n")
+        with open(os.path.join(self._dir, "ben.txt"), "w") as outfile:
+            outfile.write("Ben\n")
+        
+        self._test_task(txt, {"files": [os.path.join(self._dir, "alyssa.txt"), os.path.join(self._dir, "ben.txt")]},
+                        expected_exception=WDL.runtime.task.CommandFailure)
+
+        outputs = self._test_task(txt, {"files": [os.path.join(self._dir, "alyssa.txt"), os.path.join(self._dir, "ben.txt")]},
+                                  copy_input_files=True)
+        self.assertTrue(outputs[outfile].endswith("alyssa2.txt"))


### PR DESCRIPTION
cf. #210 

This implements the option to `run_local_task` but doesn't yet expose it through `run_local_workflow` or the CLI, to avoid creating merge conflicts with #229 