### PR TITLE
UnusedImport linter: detect use of imported struct typedefs

### DIFF
--- a/WDL/CLI.py
+++ b/WDL/CLI.py
@@ -175,7 +175,7 @@ def outline(obj, level, file=sys.stdout, show_called=True):
         if obj.workflow:
             descend(obj.workflow)
         # tasks
-        for task in sorted(obj.tasks, key=lambda task: (not task.called, task.name)):
+        for task in sorted(obj.tasks, key=lambda task: (not task.used, task.name)):
             descend(task)
         # imports
         for imp in sorted(obj.imports, key=lambda t: t.namespace):
@@ -185,7 +185,7 @@ def outline(obj, level, file=sys.stdout, show_called=True):
     elif isinstance(obj, Workflow):
         print(
             "{}workflow {}{}".format(
-                s, obj.name, " (not called)" if show_called and not obj.called else ""
+                s, obj.name, " (not called)" if show_called and not obj.used else ""
             ),
             file=file,
         )
@@ -195,7 +195,7 @@ def outline(obj, level, file=sys.stdout, show_called=True):
     elif isinstance(obj, Task):
         print(
             "{}task {}{}".format(
-                s, obj.name, " (not called)" if show_called and not obj.called else ""
+                s, obj.name, " (not called)" if show_called and not obj.used else ""
             ),
             file=file,
         )

--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -49,15 +49,20 @@ class StructTypeDef(SourceNode):
     Member names and types
     """
 
-    imported: bool
+    imported: "Optional[Tuple[Document,StructTypeDef]]"
     """
-    :type: bool
+    :type: Optional[Tuple[Document,StructTypeDef]]
 
-    True if this struct type was imported from another document
+    If this struct is imported from another document, references that document and its definition
+    there. The referenced definition might itself be imported from yet another document.
     """
 
     def __init__(
-        self, pos: SourcePosition, name: str, members: Dict[str, Type.Base], imported: bool = False
+        self,
+        pos: SourcePosition,
+        name: str,
+        members: Dict[str, Type.Base],
+        imported: "Optional[Tuple[Document,StructTypeDef]]" = None,
     ) -> None:
         super().__init__(pos)
         self.name = name
@@ -1681,7 +1686,7 @@ def _import_structs(doc: Document):
             except KeyError:
                 pass
             if not existing:
-                st2 = StructTypeDef(imp.pos, name, st.members, imported=True)
+                st2 = StructTypeDef(imp.pos, name, st.members, imported=(imp, st))
                 doc.struct_typedefs = doc.struct_typedefs.bind(name, st2)
 
 

--- a/tests/test_3corpi.py
+++ b/tests/test_3corpi.py
@@ -268,14 +268,14 @@ class Contrived2(unittest.TestCase):
         # these use the pattern 'input { Type? x = default }' and need check_quant=False
         "mergecounts","somaticseq"
     ],
-    expected_lint={'UnusedImport': 8, 'OptionalCoercion': 9, 'StringCoercion': 14, 'UnusedDeclaration': 18, 'UnnecessaryQuantifier': 41, 'NonemptyCoercion': 1, 'NameCollision': 1, 'SelectArray': 1},
+    expected_lint={'OptionalCoercion': 9, 'StringCoercion': 14, 'UnusedDeclaration': 18, 'UnnecessaryQuantifier': 41, 'NonemptyCoercion': 1, 'NameCollision': 1, 'SelectArray': 1},
 )
 class BioWDLTasks(unittest.TestCase):
     pass
 
 @wdl_corpus(
     ["test_corpi/biowdl/aligning/**"],
-    expected_lint={'UnusedImport': 12, 'OptionalCoercion': 12, 'StringCoercion': 14, 'UnusedDeclaration': 12, 'UnnecessaryQuantifier': 41, 'NonemptyCoercion': 1, 'NameCollision': 1},
+    expected_lint={'OptionalCoercion': 12, 'StringCoercion': 14, 'UnusedDeclaration': 12, 'UnnecessaryQuantifier': 41, 'NonemptyCoercion': 1, 'NameCollision': 1},
     check_quant=False,
 )
 class BioWDLAligning(unittest.TestCase):
@@ -283,7 +283,7 @@ class BioWDLAligning(unittest.TestCase):
 
 @wdl_corpus(
     ["test_corpi/biowdl/expression-quantification/**"],
-    expected_lint={'UnusedImport': 12, 'OptionalCoercion': 11, 'StringCoercion': 14, 'UnusedDeclaration': 12, 'UnnecessaryQuantifier': 41, 'NonemptyCoercion': 3, 'NameCollision': 1},
+    expected_lint={'OptionalCoercion': 11, 'StringCoercion': 14, 'UnusedDeclaration': 12, 'UnnecessaryQuantifier': 41, 'NonemptyCoercion': 3, 'NameCollision': 1},
     check_quant=False,
 )
 class BioWDLExpressionQuantification(unittest.TestCase):
@@ -291,7 +291,7 @@ class BioWDLExpressionQuantification(unittest.TestCase):
 
 @wdl_corpus(
     ["test_corpi/biowdl/somatic-variantcalling"],
-    expected_lint={'UnusedImport': 12, 'OptionalCoercion': 11, 'StringCoercion': 16, 'UnusedDeclaration': 11, 'UnnecessaryQuantifier': 166, 'NonemptyCoercion': 37, 'SelectArray': 5},
+    expected_lint={'UnusedImport': 2, 'OptionalCoercion': 11, 'StringCoercion': 16, 'UnusedDeclaration': 11, 'UnnecessaryQuantifier': 166, 'NonemptyCoercion': 37, 'SelectArray': 5},
     check_quant=False,
 )
 class BioWDLSomaticVariantCalling(unittest.TestCase):


### PR DESCRIPTION
fix #236 
