### PR TITLE
reduce call stack depth for large workflows

### DIFF
--- a/WDL/CLI.py
+++ b/WDL/CLI.py
@@ -29,6 +29,8 @@ quant_warning = False
 
 
 def main(args=None):
+    sys.setrecursionlimit(1_000_000)  # permit as much call stack depth as OS can give us
+
     parser = ArgumentParser()
     parser.add_argument(
         "--version",

--- a/WDL/Value.py
+++ b/WDL/Value.py
@@ -8,7 +8,7 @@ Each value is represented by an instance of a Python class inheriting from
    :top-classes: WDL.Value.Base
 """
 from abc import ABC
-from typing import Any, List, Optional, Tuple, Dict, Iterable, Union, Set
+from typing import Any, List, Optional, Tuple, Dict, Iterable, Union
 import json
 from . import Error, Type
 from ._util import CustomDeepCopyMixin
@@ -30,7 +30,7 @@ class Base(CustomDeepCopyMixin, ABC):
     """
 
     # exempt type & expr from deep-copying since they're immutable
-    _shallow_copy_attrs: Set[str] = set(["expr", "type"])
+    _shallow_copy_attrs: List[str] = ["expr", "type"]
 
     def __init__(self, type: Type.Base, value: Any) -> None:
         assert isinstance(type, Type.Base)

--- a/WDL/Value.py
+++ b/WDL/Value.py
@@ -29,8 +29,8 @@ class Base(CustomDeepCopyMixin, ABC):
     from ``WDL.Expr.eval``
     """
 
-    # avoid deep-copying expr since it's immutable and potentially large
-    _shallow_copy_attrs: Set[str] = set("expr")
+    # exempt type & expr from deep-copying since they're immutable
+    _shallow_copy_attrs: Set[str] = set(["expr", "type"])
 
     def __init__(self, type: Type.Base, value: Any) -> None:
         assert isinstance(type, Type.Base)

--- a/WDL/Value.py
+++ b/WDL/Value.py
@@ -11,9 +11,10 @@ from abc import ABC
 from typing import Any, List, Optional, Tuple, Dict, Iterable, Union
 import json
 from . import Error, Type
+from ._util import CustomDeepCopyMixin
 
 
-class Base(ABC):
+class Base(CustomDeepCopyMixin, ABC):
     """The abstract base class for WDL values"""
 
     type: Type.Base
@@ -33,6 +34,8 @@ class Base(ABC):
         self.type = type
         self.value = value
         self.expr = None
+        # avoid deep-copying expr since it's immutable and potentially large
+        self._shallow_copy_attr("expr")
 
     def __eq__(self, other) -> bool:
         return self.type == other.type and self.value == other.value

--- a/WDL/Value.py
+++ b/WDL/Value.py
@@ -8,7 +8,7 @@ Each value is represented by an instance of a Python class inheriting from
    :top-classes: WDL.Value.Base
 """
 from abc import ABC
-from typing import Any, List, Optional, Tuple, Dict, Iterable, Union
+from typing import Any, List, Optional, Tuple, Dict, Iterable, Union, Set
 import json
 from . import Error, Type
 from ._util import CustomDeepCopyMixin
@@ -29,13 +29,14 @@ class Base(CustomDeepCopyMixin, ABC):
     from ``WDL.Expr.eval``
     """
 
+    # avoid deep-copying expr since it's immutable and potentially large
+    _shallow_copy_attrs: Set[str] = set("expr")
+
     def __init__(self, type: Type.Base, value: Any) -> None:
         assert isinstance(type, Type.Base)
         self.type = type
         self.value = value
         self.expr = None
-        # avoid deep-copying expr since it's immutable and potentially large
-        self._shallow_copy_attr("expr")
 
     def __eq__(self, other) -> bool:
         return self.type == other.type and self.value == other.value

--- a/WDL/_util.py
+++ b/WDL/_util.py
@@ -249,12 +249,15 @@ class CustomDeepCopyMixin:
     def __deepcopy__(self, memo: Dict[int, Any]) -> Any:  # pyre-ignore
         cls = self.__class__
         cp = cls.__new__(cls)
-        for k, v in self.__dict__.items():
-            vcp = (
-                copy.deepcopy(v, memo)
-                if self._shallow_copy_attrs is None or k not in self._shallow_copy_attrs
-                else v
-            )
-            setattr(cp, k, vcp)
         memo[id(self)] = cp
+        for k, v in self.__dict__.items():
+            setattr(
+                cp,
+                k,
+                (
+                    copy.deepcopy(v, memo)
+                    if self._shallow_copy_attrs is None or k not in self._shallow_copy_attrs
+                    else v
+                ),
+            )
         return cp

--- a/WDL/_util.py
+++ b/WDL/_util.py
@@ -236,7 +236,7 @@ def install_coloredlogs(logger: logging.Logger) -> None:
 
 class CustomDeepCopyMixin:
     """
-    Mixin class overrides __deepcopy__ to consult an internal list of attribute names to be merely
+    Mixin class overrides __deepcopy__ to consult an internal set of attribute names to be merely
     shallow-copied when the time comes. Useful for attributes referencing large, immutable data
     structures.
 

--- a/WDL/_util.py
+++ b/WDL/_util.py
@@ -240,15 +240,11 @@ class CustomDeepCopyMixin:
     shallow-copied when the time comes. Useful for attributes referencing large, immutable data
     structures.
 
-    Call self._shallow_copy_attr("attr_name") in subclass initializer to register.
+    Override class variable _shallow_copy_attrs to a set of the attribute names to be
+    shallow-copied.
     """
 
     _shallow_copy_attrs: Optional[Set[str]] = None
-
-    def _shallow_copy_attr(self, k: str) -> None:
-        if self._shallow_copy_attrs is None:
-            self._shallow_copy_attrs = set()
-        self._shallow_copy_attrs.add(k)
 
     def __deepcopy__(self, memo: Dict[int, Any]) -> Any:  # pyre-ignore
         cls = self.__class__

--- a/WDL/_util.py
+++ b/WDL/_util.py
@@ -236,28 +236,23 @@ def install_coloredlogs(logger: logging.Logger) -> None:
 
 class CustomDeepCopyMixin:
     """
-    Mixin class overrides __deepcopy__ to consult an internal set of attribute names to be merely
+    Mixin class overrides __deepcopy__ to consult an internal list of attribute names to be merely
     shallow-copied when the time comes. Useful for attributes referencing large, immutable data
     structures.
 
-    Override class variable _shallow_copy_attrs to a set of the attribute names to be
+    Override class variable _shallow_copy_attrs to a list of the attribute names to be
     shallow-copied.
     """
 
-    _shallow_copy_attrs: Optional[Set[str]] = None
+    _shallow_copy_attrs: Optional[List[str]] = None
 
     def __deepcopy__(self, memo: Dict[int, Any]) -> Any:  # pyre-ignore
         cls = self.__class__
         cp = cls.__new__(cls)
         memo[id(self)] = cp
+        for k in self._shallow_copy_attrs or []:
+            v = self.__dict__[k]
+            memo[id(v)] = v
         for k, v in self.__dict__.items():
-            setattr(
-                cp,
-                k,
-                (
-                    copy.deepcopy(v, memo)
-                    if self._shallow_copy_attrs is None or k not in self._shallow_copy_attrs
-                    else v
-                ),
-            )
+            setattr(cp, k, copy.deepcopy(v, memo))
         return cp

--- a/WDL/_util.py
+++ b/WDL/_util.py
@@ -233,6 +233,7 @@ def install_coloredlogs(logger: logging.Logger) -> None:
         fmt=LOGGING_FORMAT,
     )
 
+
 class CustomDeepCopyMixin:
     """
     Mixin class overrides __deepcopy__ to consult an internal list of attribute names to be merely

--- a/tests/test_6workflowrun.py
+++ b/tests/test_6workflowrun.py
@@ -5,6 +5,7 @@ import os
 import docker
 import signal
 import time
+import sys
 from .context import WDL
 
 class TestWorkflowRunner(unittest.TestCase):
@@ -14,6 +15,7 @@ class TestWorkflowRunner(unittest.TestCase):
         self._dir = tempfile.mkdtemp(prefix="miniwdl_test_workflowrun_")
 
     def _test_workflow(self, wdl:str, inputs = None, expected_exception: Exception = None):
+        sys.setrecursionlimit(180)  # set artificially low in unit tests to detect excessive recursion (issue #239)
         try:
             with tempfile.NamedTemporaryFile(dir=self._dir, suffix=".wdl", delete=False) as outfile:
                 outfile.write(wdl.encode("utf-8"))


### PR DESCRIPTION
Task runtime's use of `copy.deepcopy` on values (`WDL.Value.Base`) led to excessive deep copying of portions of the AST, since value instances refer back to the `WDL.Expr.Base` that evaluated to them. This could lead to Python `RecursionError` (issue #239)

Exempts this reference from deep-copying. Also increases the Python call stack depth limit in the main entry point.