### PR TITLE
fix bug which causes AttributeError when calling str for some functions

### DIFF
--- a/WDL/Expr.py
+++ b/WDL/Expr.py
@@ -1031,9 +1031,9 @@ class Apply(Base):
             return "{} && {}".format(arguments[0], arguments[1])
         elif isinstance(func, StdLib._Or):
             return "{} || {}".format(arguments[0], arguments[1])
-        elif func.name == "_rem":
+        elif self.function_name == "_rem":
             return "{} % {}".format(arguments[0], arguments[1])
-        elif func.name == "_negate":
+        elif self.function_name == "_negate":
             return "!{}".format(arguments[0])
         else:
             return "{}({})".format(self.function_name, ",".join(arguments))

--- a/tests/test_0eval.py
+++ b/tests/test_0eval.py
@@ -38,6 +38,7 @@ class TestEval(unittest.TestCase):
 
         # functions
         self.assertEqual(str(WDL.parse_expr("defined(value)")), "defined(value)")
+        self.assertEqual(str(WDL.parse_expr("select_first([1, 2])")), "select_first([1, 2])")
 
         # access
         self.assertEqual(str(WDL.parse_expr("[1,2][1]")), "[1, 2][1]")


### PR DESCRIPTION
The PR fixes #241 

The classes from StdLib which represent the functions don't always have the `name` attribute. As such `func.name` would throw an AttributeError.