### PR TITLE
task runtime: revise input file mounting scheme

### DIFF
--- a/WDL/CLI.py
+++ b/WDL/CLI.py
@@ -310,6 +310,11 @@ def fill_run_subparser(subparsers):
         help="outputs and scratch will be stored in this directory if it doesn't already exist; if it does, a timestamp-based subdirectory is created and used (defaults to current working directory)",
     )
     run_parser.add_argument(
+        "--copy-input-files",
+        action="store_true",
+        help="copy input files for each task (for compatibility with commands assuming write access to them)",
+    )
+    run_parser.add_argument(
         "-t",
         "--task",
         metavar="TASK_NAME",
@@ -336,6 +341,7 @@ def runner(
     task=None,
     rundir=None,
     path=None,
+    copy_input_files=False,
     **kwargs,
 ):
     # load WDL document
@@ -374,7 +380,9 @@ def runner(
         entrypoint = (
             runtime.run_local_task if isinstance(target, Task) else runtime.run_local_workflow
         )
-        rundir, output_env = entrypoint(target, input_env, run_dir=rundir)
+        rundir, output_env = entrypoint(
+            target, input_env, run_dir=rundir, copy_input_files=copy_input_files
+        )
     except Exception as exn:
         if isinstance(exn, runtime.task.TaskFailure):
             logger.error(str(exn))

--- a/WDL/runtime/workflow.py
+++ b/WDL/runtime/workflow.py
@@ -565,6 +565,7 @@ def run_local_workflow(
     posix_inputs: Env.Bindings[Value.Base],
     run_id: Optional[str] = None,
     run_dir: Optional[str] = None,
+    copy_input_files: bool = False,
     _test_pickle: bool = False,
 ) -> Tuple[str, Env.Bindings[Value.Base]]:
     """
@@ -622,6 +623,7 @@ def run_local_workflow(
                             next_call.inputs,
                             run_id=next_call.id,
                             run_dir=os.path.join(run_dir, next_call.id),
+                            copy_input_files=copy_input_files,
                         )
                         future_task_map[future] = next_call.id
                         next_call = state.step()

--- a/tests/runner.t
+++ b/tests/runner.t
@@ -11,7 +11,7 @@ source tests/bash-tap/bash-tap-bootstrap
 export PYTHONPATH="$SOURCE_DIR:$PYTHONPATH"
 miniwdl="python3 -m WDL"
 
-plan tests 46
+plan tests 47
 
 $miniwdl run_self_test
 is "$?" "0" "run_self_test"
@@ -196,3 +196,21 @@ EOF
 $miniwdl run multitask.wdl --task second | tee stdout
 is "$?" "0" "multitask"
 is "$(jq -r '.outputs["second.msg"]' stdout)" "two" "multitask stdout"
+
+cat << 'EOF' > mv_input_file.wdl
+version 1.0
+task mv_input_file {
+    input {
+        File file
+    }
+    command {
+        mv "~{file}" xxx
+    }
+    output {
+        File xxx = "xxx"
+    }
+}
+EOF
+
+$miniwdl run --copy-input-files mv_input_file.wdl file=quick
+is "$?" "0" "copy input files"

--- a/tests/test_4taskrun.py
+++ b/tests/test_4taskrun.py
@@ -738,3 +738,18 @@ class TestTaskRunner(unittest.TestCase):
         outputs = self._test_task(txt, {"files": [os.path.join(self._dir, "alyssa.txt"), os.path.join(self._dir, "ben.txt")]},
                                   copy_input_files=True)
         self.assertTrue(outputs["outfile"].endswith("alyssa2.txt"))
+
+        self._test_task(R"""
+        version 1.0
+        task rmdir {
+            input {
+                Array[File] files
+            }
+            command <<<
+                set -x
+                rm -rf _miniwdl*
+            >>>
+        }
+        """, {"files": [os.path.join(self._dir, "alyssa.txt"), os.path.join(self._dir, "ben.txt")]},
+             expected_exception=WDL.runtime.task.CommandFailure)
+        self.assertTrue(os.path.exists(os.path.join(self._dir, "alyssa.txt")))


### PR DESCRIPTION
Mount the input files under the container working directory, so that they're always in a directory to which the command has read/write access, even though the individual files are (by default) read-only. Then the task can create files alongside the index files and output them (e.g. samtools/tabix index files).

Mount all input files into one flat directory to the extent possible (barring filename collisions), also improving compatibility with index file handling assumptions.

Expose `copy_input_files` through `run_local_workflow` and CLI.