### PR TITLE
allow unbound optional declarations outside of task/workflow inputs

### DIFF
--- a/WDL/CLI.py
+++ b/WDL/CLI.py
@@ -606,8 +606,8 @@ def runner_input_help(target):
     ans = []
     required_inputs = target.required_inputs
     ans.append("\nrequired inputs:")
-    for name, ty in values_to_json(required_inputs).items():
-        ans.append("  {} {}".format(ty, name))
+    for b in required_inputs:
+        ans.append("  {} {}".format(str(b.value.type), b.name))
     optional_inputs = target.available_inputs.subtract(target.required_inputs)
     if target.inputs is None:
         # if the target doesn't have an input{} section (pre WDL 1.0), exclude
@@ -617,11 +617,11 @@ def runner_input_help(target):
         )
     if optional_inputs:
         ans.append("\noptional inputs:")
-        for name, ty in values_to_json(optional_inputs).items():
-            ans.append("  {} {}".format(ty, name))
+        for b in optional_inputs:
+            ans.append("  {} {}".format(str(b.value.type), b.name))
     ans.append("\noutputs:")
-    for name, ty in values_to_json(target.effective_outputs).items():
-        ans.append("  {} {}".format(ty, name))
+    for b in target.effective_outputs:
+        ans.append("  {} {}".format(str(b.value), b.name))
     return "\n".join(ans)
 
 

--- a/WDL/Error.py
+++ b/WDL/Error.py
@@ -159,18 +159,18 @@ class NoSuchMember(ValidationError):
 
 class StaticTypeMismatch(ValidationError):
     def __init__(
-        self,
-        node: SourceNode,
-        expected: Type.Base,
-        actual: Type.Base,
-        message: Optional[str] = None,
+        self, node: SourceNode, expected: Type.Base, actual: Type.Base, message: str = ""
     ) -> None:
         self.expected = expected
         self.actual = actual
-        msg = "Expected {} instead of {}".format(str(expected), str(actual))
-        if message is not None:
-            msg = msg + " " + message
-        super().__init__(node, msg)
+        super().__init__(node, message)
+
+    def __str__(self) -> str:
+        msg = "Expected {} instead of {}".format(str(self.expected), str(self.actual))
+        msg2 = super().__str__()
+        if msg2:
+            msg += " " + msg2
+        return msg
 
 
 class IncompatibleOperand(ValidationError):

--- a/WDL/Error.py
+++ b/WDL/Error.py
@@ -158,18 +158,20 @@ class NoSuchMember(ValidationError):
 
 
 class StaticTypeMismatch(ValidationError):
+    message: str
+
     def __init__(
         self, node: SourceNode, expected: Type.Base, actual: Type.Base, message: str = ""
     ) -> None:
         self.expected = expected
         self.actual = actual
+        self.message = message
         super().__init__(node, message)
 
     def __str__(self) -> str:
         msg = "Expected {} instead of {}".format(str(self.expected), str(self.actual))
-        msg2 = super().__str__()
-        if msg2:
-            msg += " " + msg2
+        if self.message:
+            msg += " " + self.message
         return msg
 
 

--- a/WDL/Lint.py
+++ b/WDL/Lint.py
@@ -345,6 +345,7 @@ class OptionalCoercion(Linter):
     # Expression of optional type where a non-optional value is expected
     # Normally these fail typechecking, but the enforcement isn't stringent in
     # older WDLs.
+    # TODO: suppress within 'if (defined(x))' consequent
     def expr(self, obj: Expr.Base) -> Any:
         if isinstance(obj, Expr.Apply):
             if obj.function_name in ["_add", "_sub", "_mul", "_div", "_land", "_lor"]:

--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -1538,7 +1538,7 @@ def _translate_struct_mismatch(doc: Document, stmt: Callable[[], Any]) -> Callab
                     if id(stb.value.members) == id(actual.members):
                         actual = Type.StructInstance(stb.name, optional=actual.optional)
                         actual.members = stb.value.members
-            raise Error.StaticTypeMismatch(exc.node or exc.pos, expected, actual, exc.args[0])
+            raise Error.StaticTypeMismatch(exc.node or exc.pos, expected, actual, exc.message)
 
     return f
 

--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -301,7 +301,7 @@ class Task(SourceNode):
         Each input is at the top level of the Env, with no namespace.
         """
         ans = Env.Bindings()
-        for decl in self.inputs if self.inputs is not None else self.postinputs:
+        for decl in reversed(self.inputs if self.inputs is not None else self.postinputs):
             ans = ans.bind(decl.name, decl)
         return ans
 
@@ -315,7 +315,7 @@ class Task(SourceNode):
         Each input is at the top level of the Env, with no namespace.
         """
         ans = Env.Bindings()
-        for b in self.available_inputs:
+        for b in reversed(list(self.available_inputs)):
             assert isinstance(b, Env.Binding)
             d: Decl = b.value
             if d.expr is None and d.type.optional is False:
@@ -331,7 +331,7 @@ class Task(SourceNode):
         ``Workflow.effective_outputs``)
         """
         ans = Env.Bindings()
-        for decl in self.outputs:
+        for decl in reversed(self.outputs):
             ans = ans.bind(decl.name, decl.type, decl)
         return ans
 
@@ -358,10 +358,10 @@ class Task(SourceNode):
         # must be bound
         if self.inputs is not None:
             for decl in self.postinputs:
-                if not decl.expr:
+                if not decl.type.optional and not decl.expr:
                     raise Error.StrayInputDeclaration(
                         self,
-                        "unbound declaration {} {} outside task input{} section".format(
+                        "unbound non-optional declaration {} {} outside task input{} section".format(
                             str(decl.type), decl.name, "{}"
                         ),
                     )
@@ -567,7 +567,7 @@ class Call(WorkflowNode):
         """
         ans = Env.Bindings()
         assert self.callee
-        for outp in self.callee.effective_outputs:
+        for outp in reversed(list(self.callee.effective_outputs)):
             ans = ans.bind(self.name + "." + outp.name, outp.value, self)
         return ans
 
@@ -925,30 +925,28 @@ class Workflow(SourceNode):
     def available_inputs(self) -> Env.Bindings[Decl]:
         """:type: WDL.Env.Bindings[WDL.Tree.Decl]
 
-        Yields the workflow's input declarations. This includes:
+        The workflow's input declarations. This includes:
 
-        1. If the ``input{}`` workflow section is present, all declarations
-        within that section. Otherwise, all declarations in the workflow body,
-        excluding outputs. (This dichotomy bridges pre-1.0 and 1.0+ WDL
-        versions.) These appear at the top level of the Env, with no namepsace.
+        1. If the ``input{}`` workflow section is present, all declarations within that section.
+        Otherwise, all declarations in the top-level workflow body, excluding outputs. (This
+        dichotomy bridges pre-1.0 and 1.0+ WDL versions.) These appear at the top level of the Env,
+        with no namespace.
 
-        2. Available inputs of all calls in the workflow, namespaced by the
-        call names.
+        2. Available inputs of all calls in the workflow, namespaced by the call names.
         """
         ans = Env.Bindings()
 
-        if self.inputs is not None:
-            for decl in self.inputs:
-                ans = ans.bind(decl.name, decl)
+        # order of operations here ensures that iterating the env yields decls in the source order
+        for c in reversed(list(_calls(self))):
+            ans = Env.merge(c.available_inputs, ans)
 
-        for elt in _decls_and_calls(self, exclude_outputs=True):
-            if isinstance(elt, Decl):
-                if self.inputs is None:
+        if self.inputs is not None:
+            for decl in reversed(self.inputs):
+                ans = ans.bind(decl.name, decl)
+        else:
+            for elt in reversed(self.body):
+                if isinstance(elt, Decl):
                     ans = ans.bind(elt.name, elt)
-            elif isinstance(elt, Call):
-                ans = Env.merge(elt.available_inputs, ans)
-            else:
-                assert False
 
         return ans
 
@@ -956,23 +954,19 @@ class Workflow(SourceNode):
     def required_inputs(self) -> Env.Bindings[Decl]:
         """:type: WDL.Env.Bindings[Decl]
 
-        Yields the subset of available inputs which are required to start the
-        workflow."""
+        The subset of available inputs which are required to start the workflow.
+        """
         ans = Env.Bindings()
 
-        if self.inputs is not None:
-            for decl in self.inputs:
-                if decl.expr is None and decl.type.optional is False:
-                    ans = ans.bind(decl.name, decl)
+        for c in reversed(list(_calls(self))):
+            ans = Env.merge(c.required_inputs, ans)
 
-        for elt in _decls_and_calls(self, exclude_outputs=True):
-            if isinstance(elt, Decl):
-                if self.inputs is None and elt.expr is None and elt.type.optional is False:
-                    ans = ans.bind(elt.name, elt)
-            elif isinstance(elt, Call):
-                ans = Env.merge(elt.required_inputs, ans)
-            else:
-                assert False
+        for b in reversed(list(self.available_inputs)):
+            if "." not in b.name:
+                d = b.value
+                assert isinstance(d, Decl)
+                if not d.type.optional and not d.expr:
+                    ans = ans.bind(b.name, b.value)
 
         return ans
 
@@ -987,10 +981,10 @@ class Workflow(SourceNode):
         ans = Env.Bindings()
 
         if self.outputs is not None:
-            for decl in self.outputs:
+            for decl in reversed(self.outputs):
                 ans = ans.bind(decl.name, decl.type, decl)
         else:
-            for elt in self.body:
+            for elt in reversed(self.body):
                 if isinstance(elt, (Call, WorkflowSection)):
                     ans = Env.merge(elt.effective_outputs, ans)
 
@@ -1353,21 +1347,13 @@ def load(
 #
 
 
-def _decls_and_calls(
-    element: Union[Workflow, Scatter, Conditional], exclude_outputs: bool = True
-) -> Generator[Union[Decl, Call], None, None]:
-    # Yield each Decl and Call in the workflow, including those nested within
-    # scatter/conditional sections
-    children = element.children
-    if isinstance(element, Workflow) and exclude_outputs:
-        children = element.inputs if element.inputs else []
-        children = children + element.body
-    for ch in children:
-        if isinstance(ch, (Decl, Call)):
+def _calls(element: Union[Workflow, WorkflowSection]) -> Generator[Call, None, None]:
+    # Yield each Call in the workflow, including those nested withis scatter/conditional sections
+    for ch in element.children:
+        if isinstance(ch, Call):
             yield ch
-        elif isinstance(ch, (Scatter, Conditional)):
-            for gch in _decls_and_calls(ch):
-                yield gch
+        elif isinstance(ch, WorkflowSection):
+            yield from _calls(ch)
 
 
 def _resolve_calls(doc: Document) -> None:
@@ -1375,9 +1361,8 @@ def _resolve_calls(doc: Document) -> None:
     # sections).
     if doc.workflow:
         with Error.multi_context() as errors:
-            for c in _decls_and_calls(doc.workflow):
-                if isinstance(c, Call):
-                    errors.try1(lambda c=c: c.resolve(doc))
+            for c in _calls(doc.workflow):
+                errors.try1(lambda c=c: c.resolve(doc))
 
 
 def _build_workflow_type_env(
@@ -1459,13 +1444,21 @@ def _build_workflow_type_env(
                         doc.struct_typedefs, child_outer_type_env
                     )
             _build_workflow_type_env(doc, check_quant, child, child_outer_type_env)
-        elif doc.workflow.inputs is not None and isinstance(child, Decl) and not child.expr:
-            raise Error.StrayInputDeclaration(
-                self,
-                "unbound declaration {} {} outside workflow input{} section".format(
-                    str(child.type), child.name, "{}"
-                ),
-            )
+        elif isinstance(child, Decl) and not child.type.optional and not child.expr:
+            if doc.workflow.inputs is not None:
+                raise Error.StrayInputDeclaration(
+                    self,
+                    "unbound non-optional declaration {} {} outside workflow input{} section".format(
+                        str(child.type), child.name, "{}"
+                    ),
+                )
+            elif not isinstance(self, Workflow):
+                raise Error.StrayInputDeclaration(
+                    self,
+                    "unbound non-optional declaration {} {} inside scatter/conditional section".format(
+                        str(child.type), child.name
+                    ),
+                )
 
     # finally, populate self._type_env with all our children
     for child in self.body:

--- a/WDL/Type.py
+++ b/WDL/Type.py
@@ -69,12 +69,14 @@ class Base(ABC):
         if not check_quant and isinstance(rhs, Array) and self.coerces(rhs.item_type, check_quant):
             # coerce T to Array[T]
             return True
-        return (type(rhs).__name__ in [type(self).__name__, "Any"]) and self._check_optional(
-            rhs, check_quant
-        )
+        return (
+            type(self).__name__ == type(rhs).__name__ or isinstance(rhs, Any)
+        ) and self._check_optional(rhs, check_quant)
 
     def _check_optional(self, rhs: "Base", check_quant: bool) -> bool:
-        return not (check_quant and (self.optional and not rhs.optional))
+        return not (
+            check_quant and (self.optional and not rhs.optional and not isinstance(rhs, Any))
+        )
 
     @property
     def optional(self) -> bool:
@@ -119,10 +121,10 @@ class Any(Base):
     """
 
     def __init__(self, optional: bool = False) -> None:
-        self._optional = optional
+        self._optional = False  # no point, since this unconditionally coerces to anything
 
     def coerces(self, rhs: Base, check_quant: bool = True) -> bool:
-        return self._check_optional(rhs, check_quant)
+        return True
 
 
 class Boolean(Base):

--- a/WDL/Type.py
+++ b/WDL/Type.py
@@ -393,9 +393,7 @@ class StructInstance(Base):
         self.members = None
 
     def __str__(self) -> str:
-        return (_struct_type_id(self.members) if self.members else self.type_name) + (
-            "?" if self.optional else ""
-        )
+        return self.type_name + ("?" if self.optional else "")
 
     def coerces(self, rhs: Base, check_quant: bool = True) -> bool:
         ""

--- a/WDL/_parser.py
+++ b/WDL/_parser.py
@@ -75,7 +75,7 @@ call_inputs: "input" ":" [call_input ("," call_input)*] ","?
 call: "call" namespaced_ident call_body? -> call
     | "call" namespaced_ident "as" CNAME call_body? -> call_as
 
-?inner_workflow_element: bound_decl | call | scatter | conditional
+?inner_workflow_element: any_decl | call | scatter | conditional
 scatter: "scatter" "(" CNAME "in" expr ")" "{" inner_workflow_element* "}"
 conditional: "if" "(" expr ")" "{" inner_workflow_element* "}"
 

--- a/tests/test_1doc.py
+++ b/tests/test_1doc.py
@@ -1744,7 +1744,7 @@ class TestStruct(unittest.TestCase):
         }
         """
         doc = WDL.parse_document(doc)
-        with self.assertRaises(WDL.Error.StaticTypeMismatch):
+        with self.assertRaisesRegex(WDL.Error.StaticTypeMismatch, "Expected Person instead of Car"):
             doc.typecheck()
 
         doc = r"""
@@ -2195,6 +2195,7 @@ class TestStruct(unittest.TestCase):
         self.assertEqual(len(ctx.exception.exceptions), 4)
         for i in range(4):
             self.assertTrue(isinstance(ctx.exception.exceptions[i], WDL.Error.StaticTypeMismatch))
+        self.assertEqual(str(ctx.exception.exceptions[2]), "Expected Person instead of object(age : Boolean, name : String)")
 
         doc = r"""
         version 1.0

--- a/tests/test_3corpi.py
+++ b/tests/test_3corpi.py
@@ -208,7 +208,7 @@ class ENCODE_ChIPseq(unittest.TestCase):
 
 @wdl_corpus(
     ["test_corpi/ENCODE-DCC/atac-seq-pipeline/**"],
-    expected_lint={'StringCoercion': 195, 'FileCoercion': 204, 'OptionalCoercion': 26, 'UnusedCall': 13, 'MixedIndentation': 13},
+    expected_lint={'UnusedDeclaration': 63, 'MixedIndentation': 15, 'OptionalCoercion': 1020, 'UnusedCall': 45, 'StringCoercion': 90, 'FileCoercion': 71},
     check_quant=False,
 )
 class ENCODE_ATACseq(unittest.TestCase):

--- a/tests/test_4taskrun.py
+++ b/tests/test_4taskrun.py
@@ -20,6 +20,7 @@ class TestTaskRunner(unittest.TestCase):
             doc = WDL.parse_document(wdl)
             assert len(doc.tasks) == 1
             doc.typecheck()
+            assert len(doc.tasks[0].required_inputs.subtract(doc.tasks[0].available_inputs)) == 0
             if isinstance(inputs, dict):
                 inputs = WDL.values_from_json(inputs, doc.tasks[0].available_inputs, doc.tasks[0].required_inputs)
             rundir, outputs = WDL.runtime.run_local_task(doc.tasks[0], (inputs or WDL.Env.Bindings()), run_dir=self._dir, copy_input_files=copy_input_files)
@@ -491,6 +492,7 @@ class TestTaskRunner(unittest.TestCase):
                 String s1 = "ben"
                 String? s2
             }
+            String? ns
             command {
                 echo "~{s0}"
                 echo "~{s1}"
@@ -498,11 +500,13 @@ class TestTaskRunner(unittest.TestCase):
             }
             output {
                 String out = read_string(stdout())
+                String? null_string = ns
             }
         }
         """
         outputs = self._test_task(code, {"s0": "alyssa"})
         self.assertEqual(outputs["out"], "alyssa\nben\nNone")
+        self.assertEqual(outputs["null_string"], None)
 
         outputs = self._test_task(code, {"s0": "alyssa", "s1": "cy"})
         self.assertEqual(outputs["out"], "alyssa\ncy\nNone")

--- a/tests/test_5stdlib.py
+++ b/tests/test_5stdlib.py
@@ -17,6 +17,7 @@ class TestStdLib(unittest.TestCase):
             doc = WDL.parse_document(wdl)
             assert len(doc.tasks) == 1
             doc.typecheck()
+            assert len(doc.tasks[0].required_inputs.subtract(doc.tasks[0].available_inputs)) == 0
             if isinstance(inputs, dict):
                 inputs = WDL.values_from_json(inputs, doc.tasks[0].available_inputs, doc.tasks[0].required_inputs)
             rundir, outputs = WDL.runtime.run_local_task(doc.tasks[0], (inputs or WDL.Env.Bindings()), run_dir=self._dir)


### PR DESCRIPTION
These are always null at runtime; some existing workflows use this as a way of declaring a null value for later use.

Misc:
- Any coerces to/from optional types
- Update ENCODE ATAC-seq corpus
- Ensure {Task,Call,Workflow}.{available,required}_inputs iterate in source order
- Fix repetition in StaticTypeMismatch messages