### PR TITLE
download URI input files

### DIFF
--- a/WDL/runtime/download.py
+++ b/WDL/runtime/download.py
@@ -1,0 +1,63 @@
+from typing import Optional, List
+
+_downloaders = {}
+_downloaders[
+    "https"
+] = r"""
+task aria2c {
+    input {
+        String uri
+        Int connections = 10
+    }
+ 
+    command <<<
+        set -euxo pipefail
+        mkdir __out
+        cd __out
+        aria2c -x ~{connections} -s ~{connections} \
+            --file-allocation=none --retry-wait=2 --stderr=true \
+            "~{uri}"
+    >>>
+
+    output {
+        File file = glob("__out/*")[0]
+    }
+
+    runtime {
+        cpu: 4
+        memory: "1G"
+        docker: "hobbsau/aria2"
+    }
+}
+"""
+_downloaders["http"] = _downloaders["https"]
+_downloaders["ftp"] = _downloaders["https"]
+
+
+def _downloader(uri: str) -> Optional[str]:
+    colon = uri.find(":")
+    if colon <= 0:
+        return None
+    scheme = uri[:colon]
+    return _downloaders.get(scheme, None)
+
+
+def able(uri: str) -> bool:
+    return _downloader(uri) is not None
+
+
+def run(uri: str, dir: str, logger_prefix: Optional[List[str]] = None) -> str:
+    from . import run_local_task, DownloadFailed, RunFailed
+    from .. import parse_tasks, values_from_json
+
+    downloader_wdl = _downloader(uri)
+    if not downloader_wdl:
+        raise DownloadFailed(uri, "no downloader for scheme " + uri)
+    task = parse_tasks(downloader_wdl, version="1.0")[0]  # pyre-ignore
+    task.typecheck()
+    inputs = values_from_json({"uri": uri}, task.available_inputs)  # pyre-ignore
+    try:
+        subdir, outputs = run_local_task(task, inputs, run_dir=dir, logger_prefix=logger_prefix)
+    except RunFailed as exn:
+        raise DownloadFailed(uri, str(exn.__cause__))
+    return outputs["file"].value

--- a/WDL/runtime/download.py
+++ b/WDL/runtime/download.py
@@ -22,7 +22,7 @@ task aria2c {
         mkdir __out
         cd __out
         aria2c -x ~{connections} -s ~{connections} \
-            --file-allocation=none --retry-wait=2 --stderr=true \
+            --file-allocation=none --retry-wait=2 --stderr=true --enable-color=false \
             "~{uri}"
     >>>
 

--- a/WDL/runtime/download.py
+++ b/WDL/runtime/download.py
@@ -73,7 +73,7 @@ def run(uri: str, **kwargs) -> str:
     task.typecheck()
     inputs = values_from_json({"uri": uri}, task.available_inputs)  # pyre-ignore
     try:
-        subdir, outputs = run_local_task(task, inputs, **kwargs)
+        subdir, outputs = run_local_task(task, inputs, as_me=True, **kwargs)
     except RunFailed as exn:
         raise DownloadFailed(uri) from exn.__cause__
     return outputs["file"].value

--- a/WDL/runtime/download.py
+++ b/WDL/runtime/download.py
@@ -1,4 +1,11 @@
-from typing import Optional, List
+"""
+Logic for downloading input files from URIs
+"""
+import os
+from typing import Optional, List, Iterable, Dict
+
+# WDL tasks for downloading a file based on its URI scheme
+# TODO: formalize plugin mechanism
 
 _downloaders = {}
 _downloaders[
@@ -43,21 +50,30 @@ def _downloader(uri: str) -> Optional[str]:
 
 
 def able(uri: str) -> bool:
+    """
+    Returns True if uri appears to be a URI we know how to download
+    """
     return _downloader(uri) is not None
 
 
-def run(uri: str, dir: str, logger_prefix: Optional[List[str]] = None) -> str:
-    from . import run_local_task, DownloadFailed, RunFailed
+def run(uri: str, **kwargs) -> str:
+    """
+    Download the URI and return the local filename.
+
+    kwargs are passed through to ``run_local_task``, so ``run_dir`` and ``logger_prefix`` may be
+    useful in particular.
+    """
+    from . import run_local_task, RunFailed, DownloadFailed
     from .. import parse_tasks, values_from_json
 
     downloader_wdl = _downloader(uri)
-    if not downloader_wdl:
-        raise DownloadFailed(uri, "no downloader for scheme " + uri)
+    assert downloader_wdl
+
     task = parse_tasks(downloader_wdl, version="1.0")[0]  # pyre-ignore
     task.typecheck()
     inputs = values_from_json({"uri": uri}, task.available_inputs)  # pyre-ignore
     try:
-        subdir, outputs = run_local_task(task, inputs, run_dir=dir, logger_prefix=logger_prefix)
+        subdir, outputs = run_local_task(task, inputs, **kwargs)
     except RunFailed as exn:
-        raise DownloadFailed(uri, str(exn.__cause__))
+        raise DownloadFailed(uri) from exn.__cause__
     return outputs["file"].value

--- a/WDL/runtime/error.py
+++ b/WDL/runtime/error.py
@@ -41,6 +41,18 @@ class OutputError(_RuntimeError):
     pass
 
 
+class DownloadFailed(_RuntimeError):
+    """
+    Failure to download a URI input file
+    """
+
+    uri: str
+
+    def __init__(self, uri: str, message: str = "") -> None:
+        super().__init__(message or ("unable to download " + uri))
+        self.uri = uri
+
+
 class RunFailed(_RuntimeError):
     """
 

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -510,11 +510,12 @@ def _download_input_files(
             if downloadable(v.value):
                 logger.info(_("download input file", uri=v.value))
                 v.value = download(
-                    v.value, os.path.join(run_dir, "download"), logger_prefix + ["download"]
+                    v.value,
+                    os.path.join(run_dir, "download", str(downloads)),
+                    logger_prefix + [f"download{downloads}"],
                 )
+                logger.info(_("downloaded input file", uri=v.value, file=v.value))
                 downloads += 1
-            elif not os.path.isfile(v.value):
-                raise Error.InputError("file not found: " + v.value)
         for ch in v.children:
             map_files(ch)
         return v

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -416,7 +416,7 @@ class TaskDockerContainer(TaskContainer):
         instead of leaving them root-owned. We do this in a funny way via Docker; see GitHub issue
         #271 for discussion of alternatives and their problems.
         """
-        if not self.as_me and (os.geteuid() or os.getegid()):
+        if os.geteuid() or os.getegid():
             script = f"""
             chown -RP {os.geteuid()}:{os.getegid()} {shlex.quote(os.path.join(self.container_dir, 'work'))}
             """.strip()

--- a/stubs/docker/__init__.py
+++ b/stubs/docker/__init__.py
@@ -38,6 +38,9 @@ class models:
             def remove(self) -> None:
                 ...
 
+            def logs(self, **kwargs) -> Iterable[bytes]:
+                ...
+
             @property
             def attrs(self) -> Dict[str, Any]:
                 ...

--- a/tests/runner.t
+++ b/tests/runner.t
@@ -11,7 +11,7 @@ source tests/bash-tap/bash-tap-bootstrap
 export PYTHONPATH="$SOURCE_DIR:$PYTHONPATH"
 miniwdl="python3 -m WDL"
 
-plan tests 50
+plan tests 52
 
 $miniwdl run_self_test
 is "$?" "0" "run_self_test"
@@ -161,16 +161,42 @@ is "$(ls scatterrun/output_links/echo.t.out_f/1/1)" "brown" "scatter product 1 b
 is "$(ls scatterrun/output_links/echo.t.out_f/1/2)" "fox" "scatter product 1 fox link"
 is "$(find scatterrun/ | xargs -n 1 stat -c %U | sort | uniq)" "$(whoami)" "scatter files all owned by $(whoami)"
 
-$miniwdl run --dir failer2000/. --verbose <(echo "
+cat << 'EOF' > failer2000.wdl
 version 1.0
-workflow failer2000 { call failer }
-task failer { command { echo >&2 this is the end, beautiful friend; exit 1 } }
-") 2> failer2000.log.txt
+
+workflow failer2000 {
+    call failer {
+        input:
+            message = "this is the end, beautiful friend"
+    }
+}
+
+task failer {
+    input {
+        String message
+        Int retries = 2
+    }
+    File messagefile = write_lines([message])
+    command {
+        cat "~{messagefile}" | tee iwuzhere > /dev/stderr
+        exit 1
+    }
+    runtime {
+        maxRetries: 2
+    }
+}
+EOF
+$miniwdl run --dir failer2000/. --verbose failer2000.wdl 2> failer2000.log.txt
 is "$?" "2" "failer2000"
 grep -q beautiful failer2000/call-failer/stderr.txt
 is "$?" "0" "failer2000 stderr"
 grep -q beautiful failer2000.log.txt
 is "$?" "0" "failer2000 stderr logged"
+grep -q beautiful failer2000/call-failer/failed_tries/1/stderr.txt
+is "$?" "0" "failer2000 try1 stderr"
+grep -q beautiful failer2000/call-failer/failed_tries/1/work/iwuzhere
+is "$?" "0" "failer2000 try1 iwuzhere"
+
 
 cat << 'EOF' > multitask.wdl
 version 1.0

--- a/tests/test_4taskrun.py
+++ b/tests/test_4taskrun.py
@@ -817,3 +817,19 @@ class TestTaskRunner(unittest.TestCase):
         self.assertEqual(len(outputs["files"]), 2)
         self.assertIsNotNone(outputs["files"][0])
         self.assertIsNone(outputs["files"][1])
+
+    def test_download_input_files(self):
+        self._test_task(R"""
+        version 1.0
+        task lines {
+            input {
+                File file
+            }
+            command {
+                cat "~{file}" | wc -l
+            }
+            output {
+                Int count = read_int(stdout())
+            }
+        }
+        """, {"file": "https://google.com/robots.txt"})

--- a/tests/test_6workflowrun.py
+++ b/tests/test_6workflowrun.py
@@ -976,7 +976,7 @@ class TestWorkflowRunner(unittest.TestCase):
         self.assertGreaterEqual(outputs["finish_time"], outputs["start_time"] + 20)
 
     def test_download_input_files(self):
-        self._test_workflow(R"""
+        count = R"""
         version 1.0
         workflow count {
             input {
@@ -989,4 +989,7 @@ class TestWorkflowRunner(unittest.TestCase):
                 Int lines = length(flatten(file_lines))
             }
         }
-        """, {"files": ["https://google.com/robots.txt", "https://raw.githubusercontent.com/chanzuckerberg/miniwdl/master/tests/alyssa_ben.txt"]})
+        """
+        self._test_workflow(count, {"files": ["https://google.com/robots.txt", "https://raw.githubusercontent.com/chanzuckerberg/miniwdl/master/tests/alyssa_ben.txt"]})
+        self._test_workflow(count, {"files": ["https://google.com/robots.txt", "https://raw.githubusercontent.com/chanzuckerberg/miniwdl/master/nonexistent12345.txt"]},
+                            expected_exception=WDL.runtime.DownloadFailed)

--- a/tests/test_6workflowrun.py
+++ b/tests/test_6workflowrun.py
@@ -974,3 +974,19 @@ class TestWorkflowRunner(unittest.TestCase):
         }
         """)
         self.assertGreaterEqual(outputs["finish_time"], outputs["start_time"] + 20)
+
+    def test_download_input_files(self):
+        self._test_workflow(R"""
+        version 1.0
+        workflow count {
+            input {
+                Array[File] files
+            }
+            scatter (file in files) {
+                Array[String] file_lines = read_lines(file)
+            }
+            output {
+                Int lines = length(flatten(file_lines))
+            }
+        }
+        """, {"files": ["https://google.com/robots.txt", "https://raw.githubusercontent.com/chanzuckerberg/miniwdl/master/tests/alyssa_ben.txt"]})


### PR DESCRIPTION
File inputs for tasks and workflows can be URIs instead of a local filenames (including File values nested inside compound WDL values). Upon receiving this, the task runtime downloads the file somewhere under the run directory, and rewrites the original File values to the local filename before proceeding.

Downloads are performed by running synthetic WDL tasks using aria2c for http[s] and ftp. This bootstrapping will let us plug in all sorts of download tools (`aws s3`, `gsutil`, etc.) without having to add them as miniwdl installation dependencies.

Incidentally introduces `--as-me` option to run container commands as the invoking uid:gid.