### PR TITLE
add invoking user's group to docker containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,14 @@ export TMPDIR = /tmp
 test: check check_check
 	python3 tests/no_docker_services.py
 	pytest -v -n `python3 -c 'import multiprocessing as mp; print(mp.cpu_count())'` --dist=loadscope --cov=WDL tests
-	prove -v tests/*.t
+	prove -v tests/{check,runner,cromwell}.t
 	python3 tests/no_docker_services.py
 
 # fail fast
 qtest:
 	python3 tests/no_docker_services.py
 	pytest -vx -n `python3 -c 'import multiprocessing as mp; print(mp.cpu_count())'` --dist=loadscope tests
-	prove -v tests/check.t tests/runner.t
+	prove -v tests/{check,runner}.t
 	python3 tests/no_docker_services.py
 
 check:

--- a/WDL/CLI.py
+++ b/WDL/CLI.py
@@ -314,11 +314,6 @@ def fill_run_subparser(subparsers):
         action="store_true",
         help="just print Cromwell-style input JSON to standard output, then exit",
     )
-    group.add_argument(
-        "--copy-input-files",
-        action="store_true",
-        help="copy input files for each task and mount them read/write (unblocks task commands that mv/rm/write)",
-    )
     group = run_parser.add_argument_group("output")
     group.add_argument(
         "-d",
@@ -327,14 +322,14 @@ def fill_run_subparser(subparsers):
         dest="rundir",
         help="directory under which to create a timestamp-named subdirectory for this run (defaults to current working directory); supply '.' or 'some/dir/.' to instead run in this directory exactly",
     )
-    group = run_parser.add_argument_group("resourcing")
+    group = run_parser.add_argument_group("provisioning")
     group.add_argument(
         "-@",
         metavar="N",
         dest="max_tasks",
         type=int,
         default=None,
-        help="maximum concurrent tasks (default: # host processors; limit effectively lower when tasks require multiple processors)",
+        help="maximum concurrent tasks (default: # host processors, effectively lower when tasks require multiple processors)",
     )
     group.add_argument(
         "--max-runtime-cpu",
@@ -350,16 +345,21 @@ def fill_run_subparser(subparsers):
         default=None,
         help="maximum effective runtime.memory for any task (default: total host memory)",
     )
+    group.add_argument(
+        "--copy-input-files",
+        action="store_true",
+        help="copy input files for each task and mount them read/write (unblocks task commands that mv/rm/write them)",
+    )
+    group.add_argument(
+        "--as-me",
+        action="store_true",
+        help="run all containers as the invoking user uid:gid (more secure, but potentially blocks task commands e.g. apt-get)",
+    )
     run_parser.add_argument(
         "-v",
         "--verbose",
         action="store_true",
         help="increase logging detail & stream tasks' stderr",
-    )
-    run_parser.add_argument(
-        "--as-me",
-        action="store_true",
-        help="run all containers as the invoking user uid:gid; more secure, but potentially blocks task commands e.g. apt-get",
     )
     run_parser.add_argument(
         "--no-color",

--- a/WDL/StdLib.py
+++ b/WDL/StdLib.py
@@ -7,7 +7,7 @@ import tempfile
 from typing import List, Tuple, Callable, BinaryIO
 from abc import ABC, abstractmethod
 from . import Type, Value, Expr, Env, Error
-from ._util import byte_size_units, file_mode, dir_mode
+from ._util import byte_size_units, chmod_R_plus
 
 
 class Base:
@@ -166,12 +166,12 @@ class Base:
         "generate write_* function implementation based on serialize"
 
         def _f(v: Value.Base,) -> Value.File:
-            os.makedirs(self._write_dir, exist_ok=True, mode=dir_mode())
+            os.makedirs(self._write_dir, exist_ok=True)
             with tempfile.NamedTemporaryFile(dir=self._write_dir, delete=False) as outfile:
                 outfile: BinaryIO = outfile  # pyre-ignore
                 serialize(v, outfile)
                 filename = outfile.name
-            os.chmod(filename, file_mode())
+            chmod_R_plus(filename, file_bits=0o660)
             vfn = self._virtualize_filename(filename)
             return Value.File(vfn)
 

--- a/WDL/StdLib.py
+++ b/WDL/StdLib.py
@@ -7,7 +7,7 @@ import tempfile
 from typing import List, Tuple, Callable, BinaryIO
 from abc import ABC, abstractmethod
 from . import Type, Value, Expr, Env, Error
-from ._util import byte_size_units
+from ._util import byte_size_units, file_mode, dir_mode
 
 
 class Base:
@@ -166,11 +166,12 @@ class Base:
         "generate write_* function implementation based on serialize"
 
         def _f(v: Value.Base,) -> Value.File:
-            os.makedirs(self._write_dir, exist_ok=True)
+            os.makedirs(self._write_dir, exist_ok=True, mode=dir_mode())
             with tempfile.NamedTemporaryFile(dir=self._write_dir, delete=False) as outfile:
                 outfile: BinaryIO = outfile  # pyre-ignore
                 serialize(v, outfile)
                 filename = outfile.name
+            os.chmod(filename, file_mode())
             vfn = self._virtualize_filename(filename)
             return Value.File(vfn)
 

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -27,8 +27,8 @@ from .._util import (
     PygtailLogger,
     TerminationSignalFlag,
     parse_byte_size,
-    file_mode,
-    dir_mode,
+    chmod_R_plus,
+    path_really_within,
 )
 from .._util import StructuredLogMessage as _
 from .download import able as downloadable, run as download
@@ -78,7 +78,7 @@ class TaskContainer(ABC):
         self.input_file_map = {}
         self.input_file_map_rev = {}
         self._running = False
-        os.makedirs(os.path.join(self.host_dir, "work"), mode=dir_mode())
+        os.makedirs(os.path.join(self.host_dir, "work"))
 
     def add_files(self, host_files: Iterable[str]) -> None:
         """
@@ -126,7 +126,7 @@ class TaskContainer(ABC):
             )
 
             logger.info(_("copy host input file", input=host_filename, copy=host_copy_filename))
-            os.makedirs(os.path.dirname(host_copy_filename), exist_ok=True, mode=dir_mode())
+            os.makedirs(os.path.dirname(host_copy_filename), exist_ok=True)
             shutil.copy(host_filename, host_copy_filename)
 
     def run(self, logger: logging.Logger, command: str, cpu: int, memory: int) -> None:
@@ -187,7 +187,7 @@ class TaskContainer(ABC):
         logger.info(
             _("archived failed task artifacts", artifacts=artifacts_moved, dest=artifacts_dir)
         )
-        os.makedirs(os.path.join(self.host_dir, "work"), mode=dir_mode())
+        os.makedirs(os.path.join(self.host_dir, "work"))
 
     def host_file(self, container_file: str, inputs_only: bool = False) -> Optional[str]:
         """
@@ -218,11 +218,10 @@ class TaskContainer(ABC):
                 container_file, os.path.join(self.container_dir, "work")
             )
 
-        host_workdir = os.path.realpath(os.path.join(self.host_dir, "work"))
-        ans = os.path.realpath(os.path.join(host_workdir, container_file))
-        assert os.path.isabs(ans) and "/../" not in ans
+        host_workdir = os.path.join(self.host_dir, "work")
+        ans = os.path.join(host_workdir, container_file)
         if os.path.isfile(ans):
-            if ans.startswith(host_workdir + "/"):
+            if path_really_within(ans, host_workdir):
                 return ans
             raise OutputError(
                 "task outputs attempted to use a file outside its working directory: "
@@ -269,34 +268,22 @@ class TaskDockerContainer(TaskContainer):
         memory: int,
     ) -> int:
         self._observed_states = set()
-        command_file = os.path.join(self.host_dir, "command")
-        with open(command_file, "x") as outfile:
+        with open(os.path.join(self.host_dir, "command"), "x") as outfile:
             outfile.write(command)
-        os.chmod(command_file, file_mode())
 
-        mounts = []
-        # mount input files and command
-        if self._bind_input_files:
-            for host_path, container_path in self.input_file_map.items():
-                self.touch_mount_point(container_path)
-                mounts.append(f"{host_path}:{container_path}:{self._bind_input_files}")
-        mounts.append(
-            f"{os.path.join(self.host_dir, 'command')}:{os.path.join(self.container_dir, 'command')}:ro"
-        )
-        # mount stdout, stderr, and working directory read/write
-        for pipe_file in ["stdout.txt", "stderr.txt"]:
-            self.touch_mount_point(os.path.join(self.container_dir, pipe_file))
-            mounts.append(
-                f"{os.path.join(self.host_dir, pipe_file)}:{os.path.join(self.container_dir, pipe_file)}:rw"
-            )
-        mounts.append(
-            f"{os.path.join(self.host_dir, 'work')}:{os.path.join(self.container_dir, 'work')}:rw"
-        )
-        logger.debug(_("docker mounts", mounts=mounts))
-
+        # prepare docker configuration
         if ":" not in self.image_tag:
             # seems we need to do this explicitly under some configurations -- issue #232
             self.image_tag += ":latest"
+        logger.info(_("docker image", tag=self.image_tag))
+
+        mounts = self.prepare_mounts(logger)
+        # we want g+rw on files (and g+rwx on directories) under host_dir, to ensure the container
+        # command will be able to access them regardless of what user id it runs as (we will
+        # configure docker to make the container a member of the invoking user's primary group)
+        chmod_R_plus(self.host_dir, file_bits=0o660, dir_bits=0o770)
+
+        resources, user, groups = self.misc_config(logger, cpu, memory)
 
         # connect to dockerd
         client = docker.from_env()
@@ -304,31 +291,6 @@ class TaskDockerContainer(TaskContainer):
         try:
             # run container as a transient docker swarm service, letting docker handle the resource
             # scheduling (waiting until requested # of CPUs are available)
-            logger.info(_("docker image", tag=self.image_tag))
-            resources = {}
-            if cpu:
-                # the cpu unit expected by swarm is "NanoCPUs"
-                resources["cpu_limit"] = cpu * 1_000_000_000
-                resources["cpu_reservation"] = cpu * 1_000_000_000
-            if memory:
-                resources["mem_reservation"] = memory
-            if resources:
-                logger.debug(_("docker resources", **resources))
-                resources = docker.types.Resources(**resources)
-            else:
-                resources = None
-            user = None
-            if self.as_me:
-                user = f"{os.geteuid()}:{os.getegid()}"
-                logger.info(_("docker user", uid_gid=user))
-                if os.geteuid() == 0:
-                    logger.warning(
-                        "container command will run explicitly as root (as_me=True), since you are root"
-                    )
-            if os.getegid() == 0:
-                logger.warning(
-                    "container command will run as a root/wheel group member, since this is your primary group (gid=0)"
-                )
             svc = client.services.create(
                 self.image_tag,
                 command=[
@@ -342,9 +304,7 @@ class TaskDockerContainer(TaskContainer):
                 mounts=mounts,
                 resources=resources,
                 user=user,
-                # add invoking user's group to ensure that command can access the mounted working
-                # directory even if the docker image assumes some arbitrary uid
-                groups=[str(os.getegid())],
+                groups=groups,
                 labels={"miniwdl_run_id": self.run_id},
                 container_labels={"miniwdl_run_id": self.run_id},
             )
@@ -384,6 +344,72 @@ class TaskDockerContainer(TaskContainer):
                 client.close()
             except:
                 logger.exception("failed to close docker-py client")
+
+    def prepare_mounts(self, logger: logging.Logger) -> List[Dict[str, str]]:
+        def touch_mount_point(container_file: str) -> None:
+            # touching each mount point ensures they'll be owned by invoking user:group
+            assert container_file.startswith(self.container_dir + "/")
+            host_file = os.path.join(
+                self.host_dir, os.path.relpath(container_file, self.container_dir)
+            )
+            assert host_file.startswith(self.host_dir + "/")
+            os.makedirs(os.path.dirname(host_file), exist_ok=True)
+            with open(host_file, "x") as outfile:
+                pass
+
+        mounts = []
+        # mount input files and command
+        if self._bind_input_files:
+            for host_path, container_path in self.input_file_map.items():
+                touch_mount_point(container_path)
+                mounts.append(f"{host_path}:{container_path}:{self._bind_input_files}")
+        # TODO: issue warning of input files lacking group rw permission bits
+        mounts.append(
+            f"{os.path.join(self.host_dir, 'command')}:{os.path.join(self.container_dir, 'command')}:ro"
+        )
+        # mount stdout, stderr, and working directory read/write
+        for pipe_file in ["stdout.txt", "stderr.txt"]:
+            touch_mount_point(os.path.join(self.container_dir, pipe_file))
+            mounts.append(
+                f"{os.path.join(self.host_dir, pipe_file)}:{os.path.join(self.container_dir, pipe_file)}:rw"
+            )
+        mounts.append(
+            f"{os.path.join(self.host_dir, 'work')}:{os.path.join(self.container_dir, 'work')}:rw"
+        )
+        logger.debug(_("docker mounts", mounts=mounts))
+        return mounts
+
+    def misc_config(
+        self, logger: logging.Logger, cpu: int, memory: int
+    ) -> Tuple[Optional[Dict[str, str]], Optional[str], List[str]]:
+        resources = {}
+        if cpu:
+            # the cpu unit expected by swarm is "NanoCPUs"
+            resources["cpu_limit"] = cpu * 1_000_000_000
+            resources["cpu_reservation"] = cpu * 1_000_000_000
+        if memory:
+            resources["mem_reservation"] = memory
+        if resources:
+            logger.debug(_("docker resources", **resources))
+            resources = docker.types.Resources(**resources)
+        else:
+            resources = None
+        user = None
+        if self.as_me:
+            user = f"{os.geteuid()}:{os.getegid()}"
+            logger.info(_("docker user", uid_gid=user))
+            if os.geteuid() == 0:
+                logger.warning(
+                    "container command will run explicitly as root, since you are root and set --as-me"
+                )
+        # add invoking user's group to ensure that command can access the mounted working
+        # directory even if the docker image assumes some arbitrary uid
+        groups = [str(os.getegid())]
+        if groups == ["0"]:
+            logger.warning(
+                "container command will run as a root/wheel group member, since this is your primary group (gid=0)"
+            )
+        return resources, user, groups
 
     def poll_service(
         self, logger: logging.Logger, svc: docker.models.services.Service
@@ -425,23 +451,12 @@ class TaskDockerContainer(TaskContainer):
 
         return None
 
-    def touch_mount_point(self, container_file: str) -> None:
-        """
-        Touch a mount point to ensure it'll be owned by invoking user:group
-        """
-        assert container_file.startswith(self.container_dir + "/")
-        host_file = os.path.join(self.host_dir, os.path.relpath(container_file, self.container_dir))
-        assert host_file.startswith(self.host_dir + "/")
-        os.makedirs(os.path.dirname(host_file), exist_ok=True, mode=dir_mode())
-        with open(host_file, "x") as outfile:
-            pass
-        os.chmod(host_file, file_mode())
-
     def chown(self, logger: logging.Logger, client: docker.DockerClient) -> None:
         """
         After task completion, chown all files in the working directory to the invoking user:group,
-        instead of leaving them root-owned. We do this in a funny way via Docker; see GitHub issue
-        #271 for discussion of alternatives and their problems.
+        instead of leaving them frequently owned by root or some other arbitrary user id (image-
+        dependent). We do this in a funny way via Docker; see GitHub issue #271 for discussion of
+        alternatives and their problems.
         """
         if not self.as_me and (os.geteuid() or os.getegid()):
             script = f"""
@@ -541,11 +556,15 @@ def run_local_task(
         # evaluate output declarations
         outputs = _eval_task_outputs(logger, task, container_env, container)
 
-        write_values_json(outputs, os.path.join(run_dir, "outputs.json"), namespace=task.name)
-
+        # write and link outputs
         from .. import values_to_json
 
         make_output_links(values_to_json(outputs, namespace=task.name), run_dir)  # pyre-fixme
+        write_values_json(outputs, os.path.join(run_dir, "outputs.json"), namespace=task.name)
+
+        # make sure everything will be accessible to downstream tasks
+        chmod_R_plus(container.host_dir, file_bits=0o660, dir_bits=0o770)
+
         logger.notice("done")  # pyre-fixme
         return (run_dir, outputs)
     except Exception as exn:
@@ -875,11 +894,11 @@ def make_output_links(outputs_json: Dict[str, Any], run_dir: str) -> None:
             isinstance(v, str)
             and v.startswith(run_dir + "/")
             and os.path.isfile(v)
-            and os.path.realpath(v).startswith(os.path.realpath(run_dir) + "/")
+            and path_really_within(v, run_dir)
         ):
-            os.makedirs(dn, exist_ok=False, mode=dir_mode())
+            os.makedirs(dn, exist_ok=False)
             os.symlink(v, os.path.join(dn, os.path.basename(v)))
-        elif isinstance(v, list) and len(v):
+        elif isinstance(v, list) and v:
             d = int(math.ceil(math.log10(len(v))))  # how many digits needed
             for i, elt in enumerate(v):
                 traverse(elt, os.path.join(dn, str(i).rjust(d, "0")))
@@ -897,7 +916,7 @@ def make_output_links(outputs_json: Dict[str, Any], run_dir: str) -> None:
                 traverse(list(v.values()), dn)
 
     dn0 = os.path.join(run_dir, "output_links")
-    os.makedirs(dn0, exist_ok=False, mode=dir_mode())
+    os.makedirs(dn0, exist_ok=False)
     traverse(outputs_json, dn0)
 
 

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -322,7 +322,13 @@ class TaskDockerContainer(TaskContainer):
                 user = f"{os.geteuid()}:{os.getegid()}"
                 logger.info(_("docker user", uid_gid=user))
                 if os.geteuid() == 0:
-                    logger.warning("container command will run explicitly as root (as_me=True)")
+                    logger.warning(
+                        "container command will run explicitly as root (as_me=True), since you are root"
+                    )
+            if os.getegid() == 0:
+                logger.warning(
+                    "container command will run as a root/wheel group member, since this is your primary group (gid=0)"
+                )
             svc = client.services.create(
                 self.image_tag,
                 command=[
@@ -338,7 +344,7 @@ class TaskDockerContainer(TaskContainer):
                 user=user,
                 # add invoking user's group to ensure that command can access the mounted working
                 # directory even if the docker image assumes some arbitrary uid
-                groups=[str(os.getegid())] if os.getegid() else None,
+                groups=[str(os.getegid())],
                 labels={"miniwdl_run_id": self.run_id},
                 container_labels={"miniwdl_run_id": self.run_id},
             )

--- a/tests/getting_started.t
+++ b/tests/getting_started.t
@@ -1,0 +1,32 @@
+#!/bin/bash
+# bash-tap tests mirroring the miniwdl "Getting Started" tutorial
+# https://miniwdl.readthedocs.io/en/latest/getting_started.html
+# Warning: consumes about 32GB of disk space and peaks at >10GB of memory
+set -eo pipefail
+
+cd "$(dirname $0)/.."
+SOURCE_DIR="$(pwd)"
+
+export PYTHONPATH="$SOURCE_DIR:$PYTHONPATH"
+miniwdl="python3 -m WDL"
+
+$miniwdl run_self_test
+
+DN=$(mktemp -d --tmpdir miniwdl_runner_tests_XXXXXX)
+cd $DN
+echo "$DN"
+
+git clone --depth 1 https://github.com/HumanCellAtlas/skylab.git
+
+BASH_TAP_ROOT="$SOURCE_DIR/tests/bash-tap"
+source $SOURCE_DIR/tests/bash-tap/bash-tap-bootstrap
+plan tests 1
+set +e
+
+$miniwdl run --copy-input-files --path skylab/library/tasks --verbose  \
+    skylab/pipelines/snap-atac/snap-atac.wdl                           \
+    input_fastq1=gs://hca-dcp-sc-pipelines-test-data/smallDatasets/snap-atac/readnames_preattached/test_500k.R1.fastq.gz  \
+    input_fastq2=gs://hca-dcp-sc-pipelines-test-data/smallDatasets/snap-atac/readnames_preattached/test_500k.R2.fastq.gz  \
+    input_reference=gs://hca-dcp-sc-pipelines-test-data/alignmentReferences/snapATAC_BWA/hg38/hg38.tar \
+    genome_name=hg38
+is "$?" "0" "snap-atac"

--- a/tests/test_4taskrun.py
+++ b/tests/test_4taskrun.py
@@ -832,7 +832,7 @@ class TestTaskRunner(unittest.TestCase):
                 Int count = read_int(stdout())
             }
         }
-        """, {"file": "https://google.com/robots.txt"})
+        """, {"file": "https://google.com/robots.txt"}, as_me=True)
 
     def test_workdir_ownership(self):
         # verify that everything within working directory is owned by the invoking user


### PR DESCRIPTION
If a docker image has been baked with a USER directive to drop privileges to some arbitrary uid (a good security practice), then it may have trouble accessing the mounted working directory, which is owned by the user who invoked miniwdl. To support this we

1. add the invoking user's group to the container (a feature of Docker)
2. ensure everything miniwdl provisions in the working directory has group read/write permission

Incidentally add a gs:// downloader and a test script mirroring the "Getting Started" tutorial, adding which provoked the permissions change.