### PR TITLE
speed up CI by caching docker layers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,38 @@ services:
   - docker
 
 env:
-  - CI_TARGET=unit_tests
-  - CI_TARGET=integration_tests
-  - CI_TARGET=ci_housekeeping
-  - CI_TARGET=skylab_bulk_rna
+  global:
+    - DOCKER_CACHE_TAG=quay.io/mlin/miniwdl_ci:latest
+    - secure: "nxHBaRAUj641OAFDBYGp+VZ5U7txbm8BLanBCQE0SuulFCTz1mYf8+vEHPkhkm0hcQrghnvB27NT/1EwXJQcJTwX/+HF8ealhgogvJKcgiLNLGVLIK2DF/D2hYjbOFAX9yV4hMX6EFNwEVBiH+8OfI5JxXNPzAnDFJpyEHENe8LDEP4IpmGsjgcY8569zDJjT91Rc43YOKMiQDZFWqdN75CQDwP8EOhR7AKOt8kzpuNCR5Ovh1qEfXbvmdK2qnyUAo9ODJD4QF4Zps+HTs8GfTpn9Z6l1J4Nv2ACYEeB8ZTwy/0EBvzuM9QSHvlgCe9EjKoXQWV9qPQ3M1FBYs4dSDLiB2ILatRBbGxPP1QUP+uSFpmvxiWaAuUd6SgANVL880s8aCa5M+3gQ4QoxabcX9vyvdbWd69fJFXbv4XSwtTYrqTxwjhaeQ/oFhSgQISIs09IMDVqqSwTAJ/5hKMnJRdpemQIOEuKC3bvP/CoawxK4v5scGhYoa5tlYijQumQJj71/YgqAXCm3Si8283fBxbxZwch+JRNSWq/msaco6OMqi8dfgA2M/C3ovuFKeat0kdWFUwfzhmd1yUYyE+eorotrV+lb+rXwY7tLRV4BySNvixjOcfUQqKagnbyUHFNKti/obfywAS1xHRAfiNEbKJDGjZdDRjBmTld9DYhwrc="
+
+# Pull docker image layers from the last successful build, in hopes we might reuse the package
+# installation steps when we docker build --cache-from
+before_script:
+  - docker pull $DOCKER_CACHE_TAG || true
 
 script:
   - |
-      set -exo pipefail
-      make docker
+      set -e
+      docker build -t miniwdl --cache-from $DOCKER_CACHE_TAG .
       docker run --env TRAVIS_JOB_ID=${TRAVIS_JOB_ID} --env TRAVIS_BRANCH=${TRAVIS_BRANCH} \
                   --group-add $(stat -c %g /var/run/docker.sock) -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp \
-                  miniwdl bash -c "make $CI_TARGET && coveralls"
+                  miniwdl make $CI_TARGET
 
 jobs:
+  include:
+    - env: CI_TARGET=ci_housekeeping
+      after_success:
+        - |
+            # Push layers back to the registry for the next build(s) to use. From time to time, one
+            # should delete the 'latest' tag via the quay.io website to trigger a refresh.
+            if [ -n "$QUAY_PASSWORD" ]; then  # secure variable won't be available in others' PRs
+              docker tag miniwdl $DOCKER_CACHE_TAG
+              echo "$QUAY_PASSWORD" | docker login -u mlin+miniwdl_ci --password-stdin quay.io
+              docker push $DOCKER_CACHE_TAG
+            fi
+    - env: CI_TARGET=ci_unit_tests
+    - env: CI_TARGET=integration_tests
+    - env: CI_TARGET=skylab_bulk_rna
   allow_failures:
     - env: CI_TARGET=skylab_bulk_rna
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
 
 # don't bother with pip install -r requirements.txt, since we're going to use docker
 install:
+  - whoami
 
 # Pull docker image layers from the last successful build, in hopes we might reuse the package
 # installation steps when we docker build --cache-from

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ env:
     - DOCKER_CACHE_TAG=quay.io/mlin/miniwdl_ci:latest
     - secure: "nxHBaRAUj641OAFDBYGp+VZ5U7txbm8BLanBCQE0SuulFCTz1mYf8+vEHPkhkm0hcQrghnvB27NT/1EwXJQcJTwX/+HF8ealhgogvJKcgiLNLGVLIK2DF/D2hYjbOFAX9yV4hMX6EFNwEVBiH+8OfI5JxXNPzAnDFJpyEHENe8LDEP4IpmGsjgcY8569zDJjT91Rc43YOKMiQDZFWqdN75CQDwP8EOhR7AKOt8kzpuNCR5Ovh1qEfXbvmdK2qnyUAo9ODJD4QF4Zps+HTs8GfTpn9Z6l1J4Nv2ACYEeB8ZTwy/0EBvzuM9QSHvlgCe9EjKoXQWV9qPQ3M1FBYs4dSDLiB2ILatRBbGxPP1QUP+uSFpmvxiWaAuUd6SgANVL880s8aCa5M+3gQ4QoxabcX9vyvdbWd69fJFXbv4XSwtTYrqTxwjhaeQ/oFhSgQISIs09IMDVqqSwTAJ/5hKMnJRdpemQIOEuKC3bvP/CoawxK4v5scGhYoa5tlYijQumQJj71/YgqAXCm3Si8283fBxbxZwch+JRNSWq/msaco6OMqi8dfgA2M/C3ovuFKeat0kdWFUwfzhmd1yUYyE+eorotrV+lb+rXwY7tLRV4BySNvixjOcfUQqKagnbyUHFNKti/obfywAS1xHRAfiNEbKJDGjZdDRjBmTld9DYhwrc="
 
+# don't bother with pip install -r requirements.txt, since we're going to use docker
+install:
+
 # Pull docker image layers from the last successful build, in hopes we might reuse the package
 # installation steps when we docker build --cache-from
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ before_script:
 script:
   - |
       set -e
-      docker build -t miniwdl --cache-from $DOCKER_CACHE_TAG .
+      docker build -t miniwdl_deps --target deps --cache-from $DOCKER_CACHE_TAG .
+      docker build -t miniwdl --cache-from miniwdl_deps .
       docker run --env TRAVIS_JOB_ID=${TRAVIS_JOB_ID} --env TRAVIS_BRANCH=${TRAVIS_BRANCH} \
                   --group-add $(stat -c %g /var/run/docker.sock) -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp \
                   miniwdl make $CI_TARGET
@@ -29,7 +30,7 @@ jobs:
             # Push layers back to the registry for the next build(s) to use. From time to time, one
             # should delete the 'latest' tag via the quay.io website to trigger a refresh.
             if [ -n "$QUAY_PASSWORD" ]; then  # secure variable won't be available in others' PRs
-              docker tag miniwdl $DOCKER_CACHE_TAG
+              docker tag miniwdl_deps $DOCKER_CACHE_TAG
               echo "$QUAY_PASSWORD" | docker login -u mlin+miniwdl_ci --password-stdin quay.io
               docker push $DOCKER_CACHE_TAG
             fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # or append 'bash' to that to enter interactive shell
 
 # start with ubuntu:18.04 plus some apt packages
-FROM ubuntu:18.04
+FROM ubuntu:18.04 as deps
 ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8
 RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -qq install -y \
@@ -22,6 +22,7 @@ COPY requirements.txt requirements.dev.txt /home/wdler/
 RUN bash -o pipefail -c "pip3 install --user -r <(cat /home/wdler/requirements.txt /home/wdler/requirements.dev.txt)"
 
 # add the source tree
+FROM deps as all
 ADD --chown=wdler:wdler . /miniwdl
 WORKDIR /miniwdl
 

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ skylab_bulk_rna:
 
 ci_housekeeping: sopretty check_check check doc
 
+ci_unit_tests: unit_tests
+	coveralls
+
 check:
 	pyre \
 		--search-path stubs \

--- a/WDL/_parser.py
+++ b/WDL/_parser.py
@@ -138,7 +138,7 @@ COMMENT: "#" /[^\r\n]*/ NEWLINE
 ?expr_core: "(" expr ")"
           | literal
           | string
-          | "!" expr -> negate
+          | "!" expr_core -> negate
 
           | "[" [expr ("," expr)*] ","? "]" -> array
           | expr_core "[" expr "]" -> at

--- a/tests/test_0eval.py
+++ b/tests/test_0eval.py
@@ -131,7 +131,10 @@ class TestEval(unittest.TestCase):
             ("!!true", "true"),
             ("!false", "true"),
             ("!false && true", "true"),
-            ("!(false && true)", "true")
+            ("!false && false", "false"),
+            ("!true && false", "false"),
+            ("!(false && false)", "true"),
+            ("!(false && true)", "true"),
         )
 
     def test_arithmetic(self):


### PR DESCRIPTION
Save docker image layers with rarely-changing apt & PyPI package dependencies to a [public docker registry](https://quay.io/repository/mlin/miniwdl_ci?tab=tags), so that they can be reused by subsequent builds. This should be set up to automatically update everything whenever we bump or add package dependencies, but if needed we can evict the cache by deleting the 'latest' tag through the quay.io website.