### PR TITLE
Fix off by one error when resolving file uri.

### DIFF
--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -1232,7 +1232,7 @@ async def resolve_file_import(uri: str, path: List[str], importer: Optional[Docu
         # for now we do nothing with web URIs
         return uri
     if uri.startswith("file:///"):
-        uri = uri[7:]
+        uri = uri[8:]
     if os.path.isabs(uri):
         # given an already-absolute filename, just normalize it
         ans = os.path.abspath(uri)


### PR DESCRIPTION
A file uri has the following format: file://hostname/path
If uri.startswith("file:///") we should therefore remove all 3 slashes to get the path. 'file:///' is 8 characters.

<!---  Thank you for contributing to miniwdl! Please see the CONTRIBUTING.md guidelines and observe the PR checklist below. --->

### Motivation

This bug was found when working on [wdl-packager](https://github.com/biowdl/wdl-packager). It depends on miniwdl for determining the imports.
File imports can not work currently because miniwdl does not strip the last slash. Therefore every path will start with `/` and will be resolved as an absolute path. These are usually not resolvable as file imports should be relative. (Unless you want the WDL file to be completely non-portable.)

I think this is not a big issue, since most people who use the file imports will not use the "file:///" protocol in front of the path anyway. It is [very confusing how many slashes should be in there](https://en.wikipedia.org/wiki/File_URI_scheme). 

The only reason I stumbled across this was because I wanted to test file imports to be spec compliant.


### Checklist

<!--- You're welcome to open a draft PR to request guidance on testing or Pyre/Pylint problems. --->
- [ ] Add appropriate test(s) to the automatic suite
- [ ] Use `make pretty` to reformat the code with [black](https://github.com/python/black)
- [ ] Use `make check` to statically check the code using [Pyre](https://pyre-check.org/) and [Pylint](https://www.pylint.org/)
- [ ] Send PR from a dedicated branch without unrelated edits
- [ ] Ensure compatibility with this project's MIT license
