### PR TITLE
Use POSIX ERE for sub function

### DIFF
--- a/WDL/StdLib.py
+++ b/WDL/StdLib.py
@@ -67,7 +67,9 @@ class Base:
 
         @static([Type.String(), Type.String(), Type.String()], Type.String())
         def sub(input: Value.String, pattern: Value.String, replace: Value.String) -> Value.String:
-            return Value.String(regex.compile(pattern.value, flags=regex.POSIX).sub(replace.value, input.value))
+            return Value.String(
+                regex.compile(pattern.value, flags=regex.POSIX).sub(replace.value, input.value)
+            )
 
         static([Type.String(), Type.String(optional=True)], Type.String())(basename)
 

--- a/WDL/StdLib.py
+++ b/WDL/StdLib.py
@@ -1,7 +1,7 @@
 # pylint: disable=protected-access,exec-used
 import math
 import os
-import re
+import regex
 import json
 import tempfile
 from typing import List, Tuple, Callable, BinaryIO, Optional
@@ -67,7 +67,7 @@ class Base:
 
         @static([Type.String(), Type.String(), Type.String()], Type.String())
         def sub(input: Value.String, pattern: Value.String, replace: Value.String) -> Value.String:
-            return Value.String(re.compile(pattern.value).sub(replace.value, input.value))
+            return Value.String(regex.compile(pattern.value, flags=regex.POSIX).sub(replace.value, input.value))
 
         static([Type.String(), Type.String(optional=True)], Type.String())(basename)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pygtail>=0.11.0
 coloredlogs
 psutil
 importlib-metadata
+regex

--- a/stubs/regex/__init__.py
+++ b/stubs/regex/__init__.py
@@ -1,0 +1,7 @@
+from typing import Any
+
+POSIX: int
+
+
+def compile(pattern, flags=0, **kwargs) -> Any:
+    ...

--- a/tests/test_5stdlib.py
+++ b/tests/test_5stdlib.py
@@ -220,6 +220,8 @@ class TestStdLib(unittest.TestCase):
                 String chocolove = sub(chocolike, "like", "love") # I love chocolate when it's late
                 String chocoearly = sub(chocolike, "late", "early") # I like chocoearly when it's early
                 String chocolate = sub(chocolike, "late$", "early") # I like chocolate when it's early
+                String chocoearlylate = sub(chocolike, "[^ ]late", "early") # I like chocearly when it's late
+                String choco4 = sub(chocolike, " [[:alpha:]]{4} ", " 4444 ") # I 4444 chocolate 4444 it's late
             }
         }
         """)
@@ -227,7 +229,9 @@ class TestStdLib(unittest.TestCase):
             "chocolike": "I like chocolate when it's late",
             "chocolove": "I love chocolate when it's late",
             "chocoearly": "I like chocoearly when it's early",
-            "chocolate": "I like chocolate when it's early"
+            "chocolate": "I like chocolate when it's early",
+            "chocoearlylate": "I like chocearly when it's late",
+            "choco4": "I 4444 chocolate 4444 it's late"
         })
         outputs = self._test_task(R"""
         task example {


### PR DESCRIPTION
<!---  Thank you for contributing to miniwdl! Please see the CONTRIBUTING.md guidelines and observe the PR checklist below. --->

### Motivation
This PR implements openwdl/wdl#243
<!--- and/or link to related GitHub issue --->

### Approach
Uses the POSIX implementation of the regex package.

### Checklist

<!--- You're welcome to open a draft PR to request guidance on testing or Pyre/Pylint problems. --->
- [x] Add appropriate test(s) to the automatic suite
- [x] Use `make pretty` to reformat the code with [black](https://github.com/python/black)
- [x] Use `make check` to statically check the code using [Pyre](https://pyre-check.org/) and [Pylint](https://www.pylint.org/)
- [x] Send PR from a dedicated branch without unrelated edits
- [x] Ensure compatibility with this project's MIT license
