### PR TITLE
improvement(lint): consider TES runtime attributes

### DIFF
--- a/WDL/Lint.py
+++ b/WDL/Lint.py
@@ -915,6 +915,7 @@ class UnknownRuntimeKey(Linter):
     # https://github.com/broadinstitute/cromwell/blob/develop/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchRuntimeAttributes.scala
     # https://github.com/openwdl/wdl/pull/315
     # https://github.com/dnanexus/dxWDL/blob/master/doc/ExpertOptions.md
+    # https://cromwell.readthedocs.io/en/develop/backends/TES/
     known_keys = set(
         [
             "bootDiskSizeGb",
@@ -922,8 +923,10 @@ class UnknownRuntimeKey(Linter):
             "continueOnReturnCode",
             "cpu",
             "cpuPlatform",
+            "disk",
             "disks",
             "docker",
+            "dockerWorkingDir",
             "dx_instance_type",
             "gpu",
             "gpuCount",


### PR DESCRIPTION
<!---  Thank you for contributing to miniwdl! Please see the CONTRIBUTING.md guidelines and observe the PR checklist below. --->

### Motivation

`miniwdl check` gives LOTS of warnings about the `disk` runtime attribute. I really dislike that both `disk` and `disks` exists, but for now that's what we are stuck with 🤷‍♂ .

### Approach

Add valid keys to `Lint.py`, link documentation to TES.

### Checklist

- [x] Add appropriate test(s) to the automatic suite
- [x] Use `make pretty` to reformat the code with [black](https://github.com/python/black)
- [x] Use `make check` to statically check the code using [Pyre](https://pyre-check.org/) and [Pylint](https://www.pylint.org/)
- [x] Send PR from a dedicated branch without unrelated edits
- [x] Ensure compatibility with this project's MIT license

As a sidenote, I did run `make check`, which reports many errors not related to this pull request. Not sure what to do with that, I configured my environment as instructed by `CONTRIBUTING.md`.