### PR TITLE
macOS compatibility improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,11 +7,12 @@ Feedback and contributions to miniwdl are welcome, via issues and pull requests 
 
 To set up your local development environment,
 
-1. `git clone --recursive` this repository or your fork thereof
-2. Install dependencies as illustrated in the [Dockerfile](https://github.com/chanzuckerberg/miniwdl/blob/master/Dockerfile) (OS packages + PyPI packages listed in `requirements.txt` and `requirements.dev.txt`)
+1. `git clone --recursive` this repository or your fork thereof, and `cd` into it
+2. Install dependencies as illustrated in the [Dockerfile](https://github.com/chanzuckerberg/miniwdl/blob/master/Dockerfile) (OS packages + `pip3 install -r` both `requirements.txt` and `requirements.dev.txt`)
 3. Invoking user must have [permission to control Docker](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user)
+4. Try `python3 -m WDL run_self_test` to test the configuration.
 
-To invoke the `miniwdl` command-line interface from your working repository, e.g. `python3 -m WDL check ...` or `python3 -m WDL run ...`. Another possibility is to `pip3 install .` to install the `miniwdl` entry point with the current code revision (but leaving it installed!).
+Generally, `python3 -m WDL ...` invokes the equivalent of the `miniwdl ...` entry point for the local source tree. Another option is to `pip3 install .` to install the `miniwdl` entry point with the current code revision.
 
 The Makefile has a few typical flows:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,15 +2,17 @@
 
 Feedback and contributions to miniwdl are welcome, via issues and pull requests on this repository.
 
+* [Online documentation](https://miniwdl.readthedocs.io/en/latest/) includes several "codelab" tutorials to start with
 * The [Project board](https://github.com/chanzuckerberg/miniwdl/projects/1) shows our current prioritization of [issues](https://github.com/chanzuckerberg/miniwdl/issues)
-* [Starter issues](https://github.com/chanzuckerberg/miniwdl/issues?q=is%3Aopen+is%3Aissue+label%3Astarter) are good potential entry points for new contributors
+* [Starter issues](https://github.com/chanzuckerberg/miniwdl/issues?q=is%3Aopen+is%3Aissue+label%3Astarter) are suitable entry points for new contributors
+* [Pull request template](https://github.com/chanzuckerberg/miniwdl/blob/master/.github/pull_request_template.md) includes a preparation checklist
 
-To set up your local development environment,
+To set up your Linux development environment,
 
 1. `git clone --recursive` this repository or your fork thereof, and `cd` into it
-2. Install dependencies as illustrated in the [Dockerfile](https://github.com/chanzuckerberg/miniwdl/blob/master/Dockerfile) (OS packages + `pip3 install -r` both `requirements.txt` and `requirements.dev.txt`)
+2. Install dependencies as illustrated in the [Dockerfile](https://github.com/chanzuckerberg/miniwdl/blob/master/Dockerfile) (OS packages + `pip3 install --user -r` both `requirements.txt` and `requirements.dev.txt`)
 3. Invoking user must have [permission to control Docker](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user)
-4. Try `python3 -m WDL run_self_test` to test the configuration.
+4. Try `python3 -m WDL run_self_test` to test the configuration
 
 Generally, `python3 -m WDL ...` invokes the equivalent of the `miniwdl ...` entry point for the local source tree. Another option is to `pip3 install .` to install the `miniwdl` entry point with the current code revision.
 
@@ -23,7 +25,7 @@ The Makefile has a few typical flows:
 
 To quickly run only a relevant subset of the tests, you can e.g. `python3 -m unittest -f tests/test_5stdlib.py` or `python3 -m unittest -f tests.test_5stdlib.TestStdLib.test_glob`.
 
-Miniwdl's [online documentation](https://miniwdl.readthedocs.io/en/latest/) includes several codelab tutorials to start with. The [pull request template](https://github.com/chanzuckerberg/miniwdl/blob/master/.github/pull_request_template.md) includes a checklist for preparing your PR. Thank you!
+**macOS:** isn't preferred for miniwdl development due to some [compatibility problems](https://github.com/chanzuckerberg/miniwdl/issues/145) with test suite; but certainly simple changes can be prototyped under macOS.
 
 ## Security
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ The Makefile has a few typical flows:
 
 To quickly run only a relevant subset of the tests, you can e.g. `python3 -m unittest -f tests/test_5stdlib.py` or `python3 -m unittest -f tests.test_5stdlib.TestStdLib.test_glob`.
 
-**macOS:** isn't preferred for miniwdl development due to some [compatibility problems](https://github.com/chanzuckerberg/miniwdl/issues/145) with test suite; but certainly simple changes can be prototyped under macOS.
+**macOS:** isn't preferred for miniwdl development due to some [test suite incompatibilities](https://github.com/chanzuckerberg/miniwdl/issues/145); but at least simple changes can be prototyped under macOS.
 
 ## Security
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 SHELL := /bin/bash
-PYTHON_PKG_BASE?=$(HOME)/.local
 export TMPDIR = /tmp
 
 test: check_check check unit_tests integration_tests
@@ -36,7 +35,7 @@ ci_unit_tests: unit_tests
 check:
 	pyre \
 		--search-path stubs \
-		--typeshed ${PYTHON_PKG_BASE}/lib/pyre_check/typeshed \
+		--typeshed `python3 -c 'import site; print(site.getuserbase())'`/lib/pyre_check/typeshed \
 		--show-parse-errors check
 	pylint -j `python3 -c 'import multiprocessing as mp; print(mp.cpu_count())'` --errors-only WDL
 

--- a/WDL/_util.py
+++ b/WDL/_util.py
@@ -305,40 +305,36 @@ def PygtailLogger(
 
 
 @export
-def ensure_swarm(logger: logging.Logger) -> None:
-    client = docker.from_env()
-    try:
-        state = "(unknown)"
-        while True:
-            info = client.info()
-            if "Swarm" in info and "LocalNodeState" in info["Swarm"]:
-                state = info["Swarm"]["LocalNodeState"]
+def ensure_swarm(logger: logging.Logger, client: docker.DockerClient) -> None:
+    state = "(unknown)"
+    while True:
+        info = client.info()
+        if "Swarm" in info and "LocalNodeState" in info["Swarm"]:
+            state = info["Swarm"]["LocalNodeState"]
 
-            # https://github.com/moby/moby/blob/e7b5f7dbe98c559b20c0c8c20c0b31a6b197d717/api/types/swarm/swarm.go#L185
-            if state == "inactive":
-                logger.warning(
-                    "docker swarm is inactive on this host; performing `docker swarm init --advertise-addr 127.0.0.1 --listen-addr 127.0.0.1`"
-                )
-                client.swarm.init(advertise_addr="127.0.0.1", listen_addr="127.0.0.1")
-            elif state == "active":
-                break
-            else:
-                logger.notice(  # pyre-fixme
-                    StructuredLogMessage("waiting for docker swarm to become active", state=state)
-                )
-                sleep(2)
-
-        miniwdl_services = [
-            d
-            for d in [s.attrs for s in client.services.list()]
-            if "Spec" in d and "Labels" in d["Spec"] and "miniwdl_run_id" in d["Spec"]["Labels"]
-        ]
-        if miniwdl_services:
+        # https://github.com/moby/moby/blob/e7b5f7dbe98c559b20c0c8c20c0b31a6b197d717/api/types/swarm/swarm.go#L185
+        if state == "inactive":
             logger.warning(
-                "docker swarm lists existing miniwdl-related services. This is normal if other miniwdl processes are running concurrently; otherwise, stale state could interfere with this run. To reset it, `docker swarm leave --force`"
+                "docker swarm is inactive on this host; performing `docker swarm init --advertise-addr 127.0.0.1 --listen-addr 127.0.0.1`"
             )
-    finally:
-        client.close()
+            client.swarm.init(advertise_addr="127.0.0.1", listen_addr="127.0.0.1")
+        elif state == "active":
+            break
+        else:
+            logger.notice(  # pyre-fixme
+                StructuredLogMessage("waiting for docker swarm to become active", state=state)
+            )
+            sleep(2)
+
+    miniwdl_services = [
+        d
+        for d in [s.attrs for s in client.services.list()]
+        if "Spec" in d and "Labels" in d["Spec"] and "miniwdl_run_id" in d["Spec"]["Labels"]
+    ]
+    if miniwdl_services:
+        logger.warning(
+            "docker swarm lists existing miniwdl-related services. This is normal if other miniwdl processes are running concurrently; otherwise, stale state could interfere with this run. To reset it, `docker swarm leave --force`"
+        )
 
 
 _terminating: Optional[bool] = None
@@ -547,49 +543,37 @@ class AtomicCounter:
             return self._value
 
 
-_docker_cpu_mem: Optional[Tuple[int, int]] = None
-_docker_cpu_mem_lock: threading.Lock = threading.Lock()
-
-
 @export
-def docker_host_resources(logger: logging.Logger) -> Tuple[int, int]:
+def docker_host_resources(logger: logging.Logger, client: docker.DockerClient) -> Tuple[int, int]:
     """
     Detect maximum CPUs & memory (bytes) available to Docker containers on the local host
 
     This may differ from multiprocessing.cpu_count() and psutil.virtual_memory().total; in
     particular on Mac, where Docker containers run in a virtual machine with limited resources.
     """
-    with _docker_cpu_mem_lock:
-        global _docker_cpu_mem
-        if _docker_cpu_mem:
-            return _docker_cpu_mem
-
-        logger.debug("detecting host resources available for Docker containers")
-        client = docker.from_env()
-        detector = None
-        try:
-            detector = client.containers.run(
-                "alpine:3",
-                name=f"wdl-detector-{os.getpid()}",
-                command=["/bin/ash", "-c", "nproc && free -b | awk '/^Mem:/{print $2}'"],
-                detach=True,
+    detector = None
+    try:
+        detector = client.containers.run(
+            "alpine:3",
+            name=f"wdl-detector-{os.getpid()}",
+            command=["/bin/ash", "-c", "nproc && free -b | awk '/^Mem:/{print $2}'"],
+            detach=True,
+        )
+        status = detector.wait()
+        assert isinstance(status, dict) and status.get("StatusCode", -1) == 0, str(status)
+        stdout = detector.logs(stdout=True)
+        logger.debug(StructuredLogMessage("docker resource detection", stdout=str(stdout)))
+        stdout = stdout.decode("utf-8").strip().split("\n")
+        assert len(stdout) == 2
+        ans = (int(stdout[0]), int(stdout[1]))
+        logger.info(
+            StructuredLogMessage(
+                "detected host resources available for Docker containers",
+                cpu=ans[0],
+                mem_bytes=ans[1],
             )
-            status = detector.wait()
-            assert isinstance(status, dict) and status.get("StatusCode", -1) == 0, str(status)
-            stdout = detector.logs(stdout=True)
-            logger.debug(StructuredLogMessage("detector output", stdout=str(stdout)))
-            stdout = stdout.decode("utf-8").strip().split("\n")
-            assert len(stdout) == 2
-            ans = (int(stdout[0]), int(stdout[1]))
-            logger.info(
-                StructuredLogMessage(
-                    "detected host resources available for Docker containers",
-                    cpu=ans[0],
-                    mem_bytes=ans[1],
-                )
-            )
-            _docker_cpu_mem = ans
-            return ans
-        finally:
-            if detector:
-                detector.remove()
+        )
+        return ans
+    finally:
+        if detector:
+            detector.remove()

--- a/WDL/_util.py
+++ b/WDL/_util.py
@@ -577,7 +577,7 @@ def docker_host_resources(logger: logging.Logger) -> Tuple[int, int]:
             status = detector.wait()
             assert isinstance(status, dict) and status.get("StatusCode", -1) == 0, str(status)
             stdout = detector.logs(stdout=True)
-            logger.debug(StructuredLogMessage("detector output", stdout=stdout))
+            logger.debug(StructuredLogMessage("detector output", stdout=str(stdout)))
             stdout = stdout.decode("utf-8").strip().split("\n")
             assert len(stdout) == 2
             ans = (int(stdout[0]), int(stdout[1]))

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -31,7 +31,6 @@ from .._util import (
     path_really_within,
     LoggingFileHandler,
     AtomicCounter,
-    docker_host_resources,
 )
 from .._util import StructuredLogMessage as _
 from .download import able as downloadable, run as download
@@ -799,7 +798,7 @@ def _eval_task_runtime(
         )
         if cpu != cpu_value:
             logger.warning(
-                _("runtime.cpu adjusted to host maximum", original=cpu_value, adjusted=cpu)
+                _("runtime.cpu adjusted to host limit", original=cpu_value, adjusted=cpu)
             )
         ans["cpu"] = cpu
 
@@ -816,7 +815,7 @@ def _eval_task_runtime(
         if runtime_memory_max > 0 and memory_bytes > runtime_memory_max:
             logger.warning(
                 _(
-                    "runtime.memory adjusted to host maximum",
+                    "runtime.memory adjusted to host limit",
                     original=memory_bytes,
                     adjusted=runtime_memory_max,
                 )

--- a/WDL/runtime/workflow.py
+++ b/WDL/runtime/workflow.py
@@ -710,7 +710,9 @@ def _workflow_main_loop(
     call_futures = {}
     try:
         # download input files, if needed
-        posix_inputs = _download_input_files(logger, logger_id, run_dir, inputs, thread_pools[0])
+        posix_inputs = _download_input_files(
+            logger, logger_id, run_dir, inputs, thread_pools[0], **task_args
+        )
 
         # run workflow state machine to completion
         state = StateMachine(".".join(logger_id), run_dir, workflow, posix_inputs)
@@ -785,6 +787,7 @@ def _download_input_files(
     run_dir: str,
     inputs: Env.Bindings[Value.Base],
     thread_pool: futures.ThreadPoolExecutor,
+    **task_args,  # pyre-ignore
 ) -> Env.Bindings[Value.Base]:
     """
     Find all File values in the inputs (including any nested within compound values) that need
@@ -806,6 +809,7 @@ def _download_input_files(
                     v.value,
                     run_dir=os.path.join(run_dir, "download", str(len(ops)), "."),
                     logger_prefix=logger_prefix + [f"download{len(ops)}"],
+                    **task_args,
                 )
                 ops[future] = v.value
         for ch in v.children:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -7,7 +7,7 @@ the bioinformatics-focused [Workflow Description Language (WDL)](http://openwdl.
 
 Requirements:
 
-1. Linux or Mac OS X
+1. Linux or [macOS (limited support)](https://github.com/chanzuckerberg/miniwdl/issues/145)
 2. Python 3.6 or higher
 3. [Docker Engine](https://docs.docker.com/install/) 17 or higher
 4. Unix user must have [permission to control Docker](https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,5 @@ docker>=3.4.0
 argcomplete
 pygtail>=0.11.0
 coloredlogs
-psutil
 importlib-metadata
 regex

--- a/stubs/docker/__init__.py
+++ b/stubs/docker/__init__.py
@@ -15,6 +15,9 @@ class Container:
     def remove(self, force: bool = False) -> None:
         ...
 
+    def logs(self, stdout: bool = False) -> bytes:
+        ...
+
 class Containers:
     def run(self, image_tag: str, **kwargs) -> Container:
         ...

--- a/tests/test_4taskrun.py
+++ b/tests/test_4taskrun.py
@@ -15,7 +15,7 @@ class TestTaskRunner(unittest.TestCase):
         self._dir = tempfile.mkdtemp(prefix="miniwdl_test_taskrun_")
 
     def _test_task(self, wdl:str, inputs = None, expected_exception: Exception = None, **kwargs):
-        WDL._util.ensure_swarm(logging.getLogger("test_task"))
+        WDL._util.ensure_swarm(logging.getLogger("test_task"), docker.from_env())
         try:
             doc = WDL.parse_document(wdl)
             assert len(doc.tasks) == 1

--- a/tests/test_4taskrun.py
+++ b/tests/test_4taskrun.py
@@ -10,12 +10,15 @@ from testfixtures import log_capture
 
 class TestTaskRunner(unittest.TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        cls._host_limits = WDL._util.initialize_local_docker(logging.getLogger(cls.__name__))
+
     def setUp(self):
         logging.basicConfig(level=logging.DEBUG, format='%(name)s %(levelname)s %(message)s')
         self._dir = tempfile.mkdtemp(prefix="miniwdl_test_taskrun_")
 
     def _test_task(self, wdl:str, inputs = None, expected_exception: Exception = None, **kwargs):
-        WDL._util.ensure_swarm(logging.getLogger("test_task"), docker.from_env())
         try:
             doc = WDL.parse_document(wdl)
             assert len(doc.tasks) == 1
@@ -23,7 +26,9 @@ class TestTaskRunner(unittest.TestCase):
             assert len(doc.tasks[0].required_inputs.subtract(doc.tasks[0].available_inputs)) == 0
             if isinstance(inputs, dict):
                 inputs = WDL.values_from_json(inputs, doc.tasks[0].available_inputs, doc.tasks[0].required_inputs)
-            rundir, outputs = WDL.runtime.run_local_task(doc.tasks[0], (inputs or WDL.Env.Bindings()), run_dir=self._dir, **kwargs)
+            kwargs2 = dict(**self._host_limits)
+            kwargs2.update(kwargs)
+            rundir, outputs = WDL.runtime.run_local_task(doc.tasks[0], (inputs or WDL.Env.Bindings()), run_dir=self._dir, **kwargs2)
         except WDL.runtime.RunFailed as exn:
             if expected_exception:
                 self.assertIsInstance(exn.__context__, expected_exception)

--- a/tests/test_5stdlib.py
+++ b/tests/test_5stdlib.py
@@ -3,16 +3,20 @@ import logging
 import tempfile
 import os
 import json
+import docker
 from .context import WDL
 
 class TestStdLib(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls._host_limits = WDL._util.initialize_local_docker(logging.getLogger(cls.__name__))
 
     def setUp(self):
         logging.basicConfig(level=logging.DEBUG, format='%(name)s %(levelname)s %(message)s')
         self._dir = tempfile.mkdtemp(prefix="miniwdl_test_stdlib_")
 
     def _test_task(self, wdl:str, inputs = None, expected_exception: Exception = None):
-        WDL._util.ensure_swarm(logging.getLogger("test_task"), docker.from_env())
         try:
             doc = WDL.parse_document(wdl)
             assert len(doc.tasks) == 1
@@ -20,7 +24,7 @@ class TestStdLib(unittest.TestCase):
             assert len(doc.tasks[0].required_inputs.subtract(doc.tasks[0].available_inputs)) == 0
             if isinstance(inputs, dict):
                 inputs = WDL.values_from_json(inputs, doc.tasks[0].available_inputs, doc.tasks[0].required_inputs)
-            rundir, outputs = WDL.runtime.run(doc.tasks[0], (inputs or WDL.Env.Bindings()), run_dir=self._dir, max_tasks=1)
+            rundir, outputs = WDL.runtime.run(doc.tasks[0], (inputs or WDL.Env.Bindings()), run_dir=self._dir, max_tasks=1, **self._host_limits)
         except WDL.runtime.RunFailed as exn:
             if expected_exception:
                 self.assertIsInstance(exn.__context__, expected_exception)

--- a/tests/test_5stdlib.py
+++ b/tests/test_5stdlib.py
@@ -12,7 +12,7 @@ class TestStdLib(unittest.TestCase):
         self._dir = tempfile.mkdtemp(prefix="miniwdl_test_stdlib_")
 
     def _test_task(self, wdl:str, inputs = None, expected_exception: Exception = None):
-        WDL._util.ensure_swarm(logging.getLogger("test_task"))
+        WDL._util.ensure_swarm(logging.getLogger("test_task"), docker.from_env())
         try:
             doc = WDL.parse_document(wdl)
             assert len(doc.tasks) == 1

--- a/tests/test_6workflowrun.py
+++ b/tests/test_6workflowrun.py
@@ -16,7 +16,7 @@ class TestWorkflowRunner(unittest.TestCase):
         sys.setrecursionlimit(180)  # set artificially low in unit tests to detect excessive recursion (issue #239)
         logger = logging.getLogger("test_workflow")
         WDL._util.install_coloredlogs(logger)
-        WDL._util.ensure_swarm(logger)
+        WDL._util.ensure_swarm(logger, docker.from_env())
         try:
             with tempfile.NamedTemporaryFile(dir=self._dir, suffix=".wdl", delete=False) as outfile:
                 outfile.write(wdl.encode("utf-8"))

--- a/tests/test_6workflowrun.py
+++ b/tests/test_6workflowrun.py
@@ -4,9 +4,14 @@ import tempfile
 import os
 import time
 import sys
+import docker
 from .context import WDL
 
 class TestWorkflowRunner(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls._host_limits = WDL._util.initialize_local_docker(logging.getLogger(cls.__name__))
 
     def setUp(self):
         logging.basicConfig(level=logging.DEBUG, format='%(name)s %(levelname)s %(message)s')
@@ -16,7 +21,6 @@ class TestWorkflowRunner(unittest.TestCase):
         sys.setrecursionlimit(180)  # set artificially low in unit tests to detect excessive recursion (issue #239)
         logger = logging.getLogger("test_workflow")
         WDL._util.install_coloredlogs(logger)
-        WDL._util.ensure_swarm(logger, docker.from_env())
         try:
             with tempfile.NamedTemporaryFile(dir=self._dir, suffix=".wdl", delete=False) as outfile:
                 outfile.write(wdl.encode("utf-8"))
@@ -25,7 +29,7 @@ class TestWorkflowRunner(unittest.TestCase):
             assert len(doc.workflow.required_inputs.subtract(doc.workflow.available_inputs)) == 0
             if isinstance(inputs, dict):
                 inputs = WDL.values_from_json(inputs, doc.workflow.available_inputs, doc.workflow.required_inputs)
-            rundir, outputs = WDL.runtime.run(doc.workflow, (inputs or WDL.Env.Bindings()), run_dir=self._dir, _test_pickle=True)
+            rundir, outputs = WDL.runtime.run(doc.workflow, (inputs or WDL.Env.Bindings()), run_dir=self._dir, _test_pickle=True, **self._host_limits)
         except WDL.runtime.RunFailed as exn:
             while isinstance(exn, WDL.runtime.RunFailed):
                 exn = exn.__context__

--- a/tests/test_7runner.py
+++ b/tests/test_7runner.py
@@ -27,7 +27,7 @@ class RunnerTestCase(unittest.TestCase):
         logging.basicConfig(level=logging.DEBUG, format='%(name)s %(levelname)s %(message)s')
         logger = logging.getLogger("test_workflow")
         WDL._util.install_coloredlogs(logger)
-        WDL._util.ensure_swarm(logger)
+        WDL._util.ensure_swarm(logger, docker.from_env())
         try:
             with tempfile.NamedTemporaryFile(dir=self._dir, suffix=".wdl", delete=False) as outfile:
                 outfile.write(wdl.encode("utf-8"))


### PR DESCRIPTION
- default `--runtime-cpu-max` and `--runtime-memory-max` to the resources available in Docker for Mac's virtual machine, rather than the entire host
- `miniwdl run_self_test` failure displays hint on overriding `TMPDIR` (#324)
- documentation

There are still some problems, particularly with the full test suite, tracking in #145