### PR TITLE
config option to set hard memory limit from task runtime.memory

### DIFF
--- a/WDL/runtime/config.py
+++ b/WDL/runtime/config.py
@@ -48,6 +48,9 @@ class Section:
     def get_int(self, key: str) -> int:
         return self._parent.get_int(self._section, key)
 
+    def get_float(self, key: str) -> float:
+        return self._parent.get_float(self._section, key)
+
     def get_bool(self, key: str) -> bool:
         return self._parent.get_bool(self._section, key)
 
@@ -201,6 +204,9 @@ class Loader:
 
     def get_int(self, section: str, key: str) -> int:
         return self._parse(section, key, "int", int)
+
+    def get_float(self, section: str, key: str) -> float:
+        return self._parse(section, key, "float", float)
 
     def get_bool(self, section: str, key: str) -> bool:
         return self._parse(section, key, "bool", _parse_bool)

--- a/WDL/runtime/config_templates/default.cfg
+++ b/WDL/runtime/config_templates/default.cfg
@@ -45,11 +45,16 @@ output_hardlinks = false
 
 [task_runtime]
 # Effective maximum values of runtime.cpu and runtime.memory (bytes), which evaluated values are
-# rounded down to. 0 = detect host resources, -1 = do not apply a limit.
+# rounded down to. Warning: tasks may deadlock if these are set higher than actual provision-able
+# resources.
+# 0 = detect host resources, -1 = do not apply a limit.
 # --runtime-cpu-max, --runtime-memory-max
-# Warning: tasks may deadlock if these are set higher than actual provision-able resources.
 cpu_max = 0
 memory_max = 0
+# A task's runtime.memory is used as a "reservation" for container scheduling purposes, but isn't
+# enforced unless memory_limit_multiplier is positive, which leads to a hard limit of:
+# memory_limit_multiplier*runtime.memory
+memory_limit_multiplier = 0.0
 # Defaults which each task's runtime{} section will be merged into. --runtime-defaults
 defaults = {
         "docker": "ubuntu:18.04"

--- a/WDL/runtime/config_templates/default.cfg
+++ b/WDL/runtime/config_templates/default.cfg
@@ -43,6 +43,7 @@ copy_input_files = false
 # arising from files with multiple hardlinks! See also [task_runtime] delete_work, below.
 output_hardlinks = false
 
+
 [task_runtime]
 # Effective maximum values of runtime.cpu and runtime.memory (bytes), which evaluated values are
 # rounded down to. Warning: tasks may deadlock if these are set higher than actual provision-able

--- a/WDL/runtime/config_templates/default.cfg
+++ b/WDL/runtime/config_templates/default.cfg
@@ -45,16 +45,16 @@ output_hardlinks = false
 
 
 [task_runtime]
-# Effective maximum values of runtime.cpu and runtime.memory (bytes), which evaluated values are
-# rounded down to. Warning: tasks may deadlock if these are set higher than actual provision-able
-# resources.
+# Effective maximum values of runtime.cpu and runtime.memory (bytes), which evaluated values may be
+# rounded down to in order to "fit" the maximum available host resources. Warning: tasks may
+# deadlock if these are set higher than actual achievable resources.
 # 0 = detect host resources, -1 = do not apply a limit.
 # --runtime-cpu-max, --runtime-memory-max
 cpu_max = 0
 memory_max = 0
-# A task's runtime.memory is used as a "reservation" for container scheduling purposes, but isn't
-# enforced unless memory_limit_multiplier is positive, which leads to a hard limit of:
-# memory_limit_multiplier*runtime.memory
+# A task's runtime.memory is used as a "reservation" to guide container scheduling, but isn't an
+# enforced limit unless memory_limit_multiplier is positive, which sets a hard limit of
+# memory_limit_multiplier*runtime.memory. Recommendation: if activating this, disable host swap.
 memory_limit_multiplier = 0.0
 # Defaults which each task's runtime{} section will be merged into. --runtime-defaults
 defaults = {

--- a/tests/test_4taskrun.py
+++ b/tests/test_4taskrun.py
@@ -796,7 +796,7 @@ class TestTaskRunner(unittest.TestCase):
         cfg = WDL.runtime.config.Loader(logging.getLogger(self.id()), [])
         outputs = self._test_task(txt, {"memory": "256MB"}, cfg=cfg)
         self.assertGreater(outputs["memory_limit_in_bytes"], 300*1024*1024)
-        cfg.override({"task_runtime": {"memory_hard_limit_multiplier": 0.9}})
+        cfg.override({"task_runtime": {"memory_limit_multiplier": 0.9}})
         outputs = self._test_task(txt, {"memory": "256MB"}, cfg=cfg)
         self.assertLess(outputs["memory_limit_in_bytes"], 300*1024*1024)
 


### PR DESCRIPTION
The task runtime.memory is used as a scheduling reservation, but not enforced as a hard limit. Here we add config option [task_runtime] memory_limit_multiplier, which if positive causes a hard limit of memory_limit_multiplier*runtime.memory to be set. One can imagine scenarios where it could be useful to set this either above or below unity.
