### PR TITLE
linter suppression comments & strict mode

### DIFF
--- a/test_corpi/contrived/contrived.wdl
+++ b/test_corpi/contrived/contrived.wdl
@@ -2,7 +2,8 @@
 version 1.0
 
 import "empty.wdl" as popular
-import "empty.wdl" as contrived
+import "empty.wdl" as contrived  # !UnusedImport
+# !NameCollision
 
 struct contrived {
 }
@@ -12,7 +13,7 @@ struct popular {
 
 workflow contrived {
     input {
-        String popular = "fox"
+        String popular = "fox" # !NameCollision
         Int? fortytwo = 42
         Float required
     }
@@ -38,6 +39,7 @@ workflow contrived {
 task popular {
     input {
         String popular
+        # Lorem ipsum dolor sit (!NameCollision)
         String? opt
         Float? i
         Array[String]+ y = select_all(["${popular + i}"])


### PR DESCRIPTION
`miniwdl check` lint warnings can be suppressed by a comment containing `!WarningName` on the same line or the following line.

With `--strict`, it exits with nonzero status code if there are any shown lint warnings (in addition to syntax or type errors).