### PR TITLE
separate task retry logic for interruptions

### DIFF
--- a/WDL/runtime/error.py
+++ b/WDL/runtime/error.py
@@ -42,7 +42,7 @@ class Terminated(_RuntimeError):
 
 class Interrupted(_RuntimeError):
     """
-    Task execution was interrupted by an uncontrollable cause (e.g. worker node went down)
+    Task was interrupted by an exogenous problem (e.g. worker node went down)
     """
 
     pass

--- a/WDL/runtime/error.py
+++ b/WDL/runtime/error.py
@@ -20,23 +20,32 @@ class CommandFailed(_RuntimeError):
     """
 
     def __init__(self, exit_status: int, stderr_file: str, message: str = "") -> None:
-        super().__init__(message or f"task command failed with exit status {exit_status}")
+        oom_hint = ", a possible indication that it ran out of memory" if exit_status == 137 else ""
+        super().__init__(message or f"task command failed with exit status {exit_status}{oom_hint}")
         self.exit_status = exit_status
         self.stderr_file = stderr_file
 
 
 class Terminated(_RuntimeError):
     """
-    Workflow/task was terminated, e.g. by Unix signal
+    Workflow/task was intentionally terminated, e.g. by Unix signal
     """
 
     quiet: bool
     """
-    Termination was a secondary side-effect, so warrants less logging
+    Termination warrants less logging because it was a secondary side-effect of a previous error
     """
 
     def __init__(self, quiet: bool = False) -> None:
         self.quiet = quiet
+
+
+class Interrupted(_RuntimeError):
+    """
+    Task execution was interrupted by an uncontrollable cause (e.g. worker node went down)
+    """
+
+    pass
 
 
 class OutputError(_RuntimeError):

--- a/tests/test_6workflowrun.py
+++ b/tests/test_6workflowrun.py
@@ -1003,6 +1003,7 @@ class TestWorkflowRunner(unittest.TestCase):
             }
             runtime {
                 maxRetries: 99
+                preemptible: 2
             }
         }
         """
@@ -1010,7 +1011,7 @@ class TestWorkflowRunner(unittest.TestCase):
         self.assertGreaterEqual(outputs["finish_time"], outputs["start_time"] + 20)
         self.assertTrue(os.path.isfile(os.path.join(self._rundir, "call-finish", "failed_tries", "0", "work", "iwuzhere")))
         cfg = WDL.runtime.config.Loader(logging.getLogger(self.id()), [])
-        cfg.override({"task_runtime": {"delete_work": "failure"}})
+        cfg.override({"task_runtime": {"delete_work": "failure", "_mock_interruptions": 2}})
         outputs = self._test_workflow(txt, cfg=cfg)
         self.assertGreaterEqual(outputs["finish_time"], outputs["start_time"] + 20)
         self.assertFalse(os.path.isdir(os.path.join(self._rundir, "call-finish", "failed_tries")))


### PR DESCRIPTION
Introduce concept of exogenous task "interruption" (e.g. spot/preemptible instance termination), with a separate retry budget controlled by `runtime.preemptible`. Refine interpretation of docker task states to recognize symptoms of interruption.