### PR TITLE
handle docker state corner case triggered by workers going down

### DIFF
--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -481,11 +481,9 @@ class SwarmContainer(TaskContainer):
                 while exit_code is None:
                     time.sleep(random.uniform(1.0, 2.0))  # spread out work over the GIL
                     if terminating():
-                        quiet = (  # suppress log noise if docker task only sat in the queue
-                            self._observed_states.intersection(
-                                {"(UNKNOWN)", "new", "allocated", "pending"}
-                            )
-                            == self._observed_states
+                        quiet = not self._observed_states.difference(
+                            # reduce log noise if the terminated task only sat in docker's queue
+                            {"(UNKNOWN)", "new", "allocated", "pending"}
                         )
                         if not quiet:
                             self.poll_service(logger, svc, verbose=True)

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -1080,7 +1080,6 @@ def _eval_task_runtime(
                 )
             )
             memory_bytes = memory_max
-        ans["memory"] = memory_bytes
         ans["memory_reservation"] = memory_bytes
 
         memory_limit_multiplier = cfg["task_runtime"].get_float("memory_limit_multiplier")
@@ -1094,7 +1093,9 @@ def _eval_task_runtime(
 
     if ans:
         logger.info(_("effective runtime", **ans))
-    unused_keys = list(key for key in runtime_values if key not in ans)
+    unused_keys = list(
+        key for key in runtime_values if key not in ("cpu", "memory") and key not in ans
+    )
     if unused_keys:
         logger.warning(_("ignored runtime settings", keys=unused_keys))
 

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -639,7 +639,7 @@ class SwarmContainer(TaskContainer):
             if status["DesiredState"] != state:
                 loginfo["desired"] = status["DesiredState"]
             logmsg = status.get("Err", status.get("Message", None))
-            if logmsg:
+            if logmsg and logmsg != state:
                 loginfo["message"] = logmsg
             method = logger.notice if state == "running" else logger.info  # pyre-fixme
             method(_(f"docker task {state}", **loginfo))
@@ -1080,6 +1080,7 @@ def _eval_task_runtime(
                 )
             )
             memory_bytes = memory_max
+        ans["memory"] = memory_bytes
         ans["memory_reservation"] = memory_bytes
 
         memory_limit_multiplier = cfg["task_runtime"].get_float("memory_limit_multiplier")


### PR DESCRIPTION
Stress-testing revealed that a task whose assigned worker goes down can end up in one of three distinct modes:

1. state = running, exit code = -1
2. state = shutdown, orphaned, or remove
3. "desired state" = shutdown, orphaned, or remove (with non-terminal state)

The first case is common, while the last two are rare & appear only in stress-testing with artificially-induced worker shutdown :cry: 