### PR TITLE
abbreviated call input syntax

### DIFF
--- a/WDL/_grammar.py
+++ b/WDL/_grammar.py
@@ -300,7 +300,7 @@ call: "call" namespaced_ident ("after" CNAME)* call_body? -> call
 namespaced_ident: CNAME ("." CNAME)*
 call_inputs: "input" ":" [call_input ("," call_input)*] ","?
 ?call_body: "{" call_inputs? "}"
-call_input: CNAME "=" expr
+call_input: CNAME ["=" expr]
 
 ?workflow_outputs: output_decls
 

--- a/WDL/_parser.py
+++ b/WDL/_parser.py
@@ -401,7 +401,9 @@ class _DocTransformer(_ExprTransformer):
         return [item.value for item in items]
 
     def call_input(self, items, meta):
-        return (items[0].value, items[1])
+        if len(items) > 1:
+            return (items[0].value, items[1])
+        return (items[0].value, Expr.Ident(self._sp(meta), items[0].value))
 
     def call_inputs(self, items, meta):
         d = dict()


### PR DESCRIPTION
Very often multiple tasks share one or more inputs in common (e.g. `reference_genome_fasta` or `docker_image`) and we end up explicitly declaring a workflow input with the same name, then mechanically passing that in the call inputs for each applicable task. The product is numerous `foo=foo, bar=bar` entries in each call input. This change makes this pattern a bit more concise by allowing `foo=foo, bar=bar` to be abbreviated `foo, bar`.