### PR TITLE
Enable flake8 linter

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length=120
-ignore=W503,E265,E722,E741,F401,F841
+ignore=W503,E203,E265,E722,E741,F401,F841
 exclude=WDL/_grammar.py

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length=120
+ignore=W503,E265,E722,E741,F401,F841
+exclude=WDL/_grammar.py

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ check:
 		--show-parse-errors check
 	# no-member disabled due to https://github.com/PyCQA/pylint/issues/3137
 	pylint -j `python3 -c 'import multiprocessing as mp; print(mp.cpu_count())'` --errors-only WDL -d no-member
+	flake8 WDL
 
 check_check:
 	# regression test against pyre doing nothing (issue #100)

--- a/WDL/CLI.py
+++ b/WDL/CLI.py
@@ -530,8 +530,8 @@ def runner(
         if os.geteuid() == 0:
             logger.warning(
                 (
-                    "running as root; non-root users should be able to `miniwdl run` as long as they're in the `docker` "
-                    "group"
+                    "running as root; non-root users should be able to `miniwdl run` "
+                    "as long as they're in the `docker` group"
                 )
             )
 

--- a/WDL/CLI.py
+++ b/WDL/CLI.py
@@ -17,9 +17,30 @@ from argparse import ArgumentParser, Action, SUPPRESS, RawDescriptionHelpFormatt
 from contextlib import ExitStack
 import importlib_metadata
 from ruamel.yaml import YAML
-from . import (load, runtime, Error, Lint, Value, Type, Expr, Document, Workflow, Task, Env, Decl, Call, Scatter,
-               Conditional, SourcePosition, parse_document, copy_source, values_from_json, values_to_json,
-               read_source_default, ReadSourceResult)
+from . import (
+    load,
+    runtime,
+    Error,
+    Lint,
+    Value,
+    Type,
+    Expr,
+    Document,
+    Workflow,
+    Task,
+    Env,
+    Decl,
+    Call,
+    Scatter,
+    Conditional,
+    SourcePosition,
+    parse_document,
+    copy_source,
+    values_from_json,
+    values_to_json,
+    read_source_default,
+    ReadSourceResult,
+)
 from ._util import (
     VERBOSE_LEVEL,
     NOTICE_LEVEL,
@@ -121,8 +142,10 @@ def fill_common(subparser, path=True):
         "--no-quant-check",
         dest="check_quant",
         action="store_false",
-        help=("relax static typechecking of optional types, and permit coercion of T to Array[T] (discouraged; for "
-              "backwards compatibility with older WDL)"),
+        help=(
+            "relax static typechecking of optional types, and permit coercion of T to Array[T] (discouraged; for "
+            "backwards compatibility with older WDL)"
+        ),
     )
     if path:
         group.add_argument(
@@ -392,8 +415,10 @@ def fill_run_subparser(subparsers):
         "--dir",
         metavar="DIR",
         dest="run_dir",
-        help=("directory under which to create a timestamp-named subdirectory for this run (defaults to current "
-              " working directory); supply '.' or 'some/dir/.' to instead run in this directory exactly"),
+        help=(
+            "directory under which to create a timestamp-named subdirectory for this run (defaults to current "
+            " working directory); supply '.' or 'some/dir/.' to instead run in this directory exactly"
+        ),
     )
     group.add_argument(
         "--error-json",
@@ -419,8 +444,10 @@ def fill_run_subparser(subparsers):
         metavar="FILE",
         type=str,
         default=None,
-        help=("configuration file to load (in preference to file named by MINIWDL_CFG environment, or "
-              "XDG_CONFIG_{HOME,DIRS}/miniwdl.cfg)"),
+        help=(
+            "configuration file to load (in preference to file named by MINIWDL_CFG environment, or "
+            "XDG_CONFIG_{HOME,DIRS}/miniwdl.cfg)"
+        ),
     )
     group.add_argument("-@", metavar="N", dest="max_tasks", type=int, default=None, help=SUPPRESS)
     group.add_argument("--runtime-cpu-max", metavar="N", type=int, default=None, help=SUPPRESS)
@@ -445,8 +472,10 @@ def fill_run_subparser(subparsers):
     group.add_argument(
         "--as-me",
         action="store_true",
-        help=("run all containers as the invoking user uid:gid (more secure, but potentially blocks task commands e.g. "
-              "apt-get)"),
+        help=(
+            "run all containers as the invoking user uid:gid (more secure, but potentially blocks task commands e.g. "
+            "apt-get)"
+        ),
     )
     # TODO:
     # way to specify None for an optional value (that has a default)
@@ -500,8 +529,10 @@ def runner(
 
         if os.geteuid() == 0:
             logger.warning(
-                ("running as root; non-root users should be able to `miniwdl run` as long as they're in the `docker` "
-                 "group")
+                (
+                    "running as root; non-root users should be able to `miniwdl run` as long as they're in the `docker` "
+                    "group"
+                )
             )
 
         # load configuration & apply command-line overrides
@@ -977,8 +1008,10 @@ def fill_run_self_test_subparser(subparsers):
         metavar="FILE",
         type=str,
         default=None,
-        help=("configuration file to load (in preference to file named by MINIWDL_CFG environment, "
-              "or XDG_CONFIG_{HOME,DIRS}/miniwdl.cfg)"),
+        help=(
+            "configuration file to load (in preference to file named by MINIWDL_CFG environment, "
+            "or XDG_CONFIG_{HOME,DIRS}/miniwdl.cfg)"
+        ),
     )
     run_parser.add_argument("--log-json", action="store_true", help="write all logs in JSON")
     run_parser.add_argument(
@@ -1122,8 +1155,10 @@ def fill_localize_subparser(subparsers):
         metavar="FILE",
         type=str,
         default=None,
-        help=("configuration file to load (in preference to file named by MINIWDL_CFG environment, "
-              "or XDG_CONFIG_{HOME,DIRS}/miniwdl.cfg)"),
+        help=(
+            "configuration file to load (in preference to file named by MINIWDL_CFG environment, "
+            "or XDG_CONFIG_{HOME,DIRS}/miniwdl.cfg)"
+        ),
     )
     return localize_parser
 
@@ -1198,7 +1233,7 @@ def localize(
         if not cache_cfg.get_bool("put"):
             logger.error(
                 'configuration section "download_cache", option "put" (env MINIWDL__DOWNLOAD_CACHE__PUT) must be true '
-                'for this operation to be effective'
+                "for this operation to be effective"
             )
             sys.exit(2)
 

--- a/WDL/Env.py
+++ b/WDL/Env.py
@@ -214,7 +214,7 @@ class Bindings(Generic[T]):
 
         def enter(b: Binding[T]) -> Optional[Binding[T]]:
             if b.name.startswith(namespace):
-                return Binding(b.name[len(namespace) :], b.value, b.info)
+                return Binding(b.name[len(namespace):], b.value, b.info)
             return None
 
         return self.map(enter)

--- a/WDL/Env.py
+++ b/WDL/Env.py
@@ -214,7 +214,7 @@ class Bindings(Generic[T]):
 
         def enter(b: Binding[T]) -> Optional[Binding[T]]:
             if b.name.startswith(namespace):
-                return Binding(b.name[len(namespace):], b.value, b.info)
+                return Binding(b.name[len(namespace) :], b.value, b.info)
             return None
 
         return self.map(enter)

--- a/WDL/Error.py
+++ b/WDL/Error.py
@@ -2,28 +2,9 @@
 from typing import List, Optional, NamedTuple, Union, Iterable, TypeVar, Generator, Callable, Any
 from functools import total_ordering
 from contextlib import contextmanager
+
+from ._error_util import SourcePosition
 from . import Type
-
-
-class SourcePosition(
-    NamedTuple(
-        "SourcePosition",
-        [
-            ("uri", str),
-            ("abspath", str),
-            ("line", int),
-            ("column", int),
-            ("end_line", int),
-            ("end_column", int),
-        ],
-    )
-):
-    """
-    Source position attached to AST nodes and exceptions; NamedTuple of ``uri`` the filename/URI
-    passed to :func:`WDL.load` or a WDL import statement, which may be relative; ``abspath`` the
-    absolute filename/URI; and one-based int positions ``line`` ``end_line`` ``column``
-    ``end_column``
-    """
 
 
 class SyntaxError(Exception):
@@ -106,7 +87,10 @@ class SourceNode:
 
 
 class ValidationError(Exception):
-    """Base class for a WDL validation error (when the document loads and parses, but fails typechecking or other static validity tests)"""
+    """
+    Base class for a WDL validation error (when the document loads and parses, but fails typechecking or other static
+    validity tests)
+    """
 
     pos: SourcePosition
     """:type: SourcePosition"""
@@ -203,7 +187,8 @@ class UncallableWorkflow(ValidationError):
     def __init__(self, node: SourceNode, name: str) -> None:
         super().__init__(
             node,
-            "Cannot call workflow {} because its calls don't supply all required inputs, or it lacks an output section".format(
+            ("Cannot call workflow {} because its calls don't supply all required inputs, "
+             "or it lacks an output section").format(
                 name
             ),
         )

--- a/WDL/Error.py
+++ b/WDL/Error.py
@@ -187,10 +187,10 @@ class UncallableWorkflow(ValidationError):
     def __init__(self, node: SourceNode, name: str) -> None:
         super().__init__(
             node,
-            ("Cannot call workflow {} because its calls don't supply all required inputs, "
-             "or it lacks an output section").format(
-                name
-            ),
+            (
+                "Cannot call workflow {} because its calls don't supply all required inputs, "
+                "or it lacks an output section"
+            ).format(name),
         )
 
 

--- a/WDL/Expr.py
+++ b/WDL/Expr.py
@@ -14,7 +14,7 @@ given a suitable ``WDL.Env.Bindings[Value.Base]``.
 from abc import ABC, abstractmethod
 from typing import List, Optional, Dict, Tuple, Union, Iterable
 from .Error import SourcePosition, SourceNode
-from . import Type, Value, Env, Error, StdLib
+from . import Type, Value, Env, Error, StdLib, Tree
 
 
 class Base(SourceNode, ABC):
@@ -55,7 +55,10 @@ class Base(SourceNode, ABC):
         invoked exactly once prior to use of other methods.
 
         :param stdlib: a context-specific standard function library for typechecking
-        :param check_quant: when ``False``, disables static validation of the optional (?) type quantifier when `typecheck()` is called on this expression, so for example type ``T?`` can satisfy an expected type ``T``. Applies recursively to the type inference and checking of any sub-expressions.
+        :param check_quant:
+            when ``False``, disables static validation of the optional (?) type quantifier when `typecheck()` is called
+            on this expression, so for example type ``T?`` can satisfy an expected type ``T``. Applies recursively to
+            the type inference and checking of any sub-expressions.
         :raise WDL.Error.StaticTypeMismatch: when the expression fails to type-check
         :return: `self`
         """
@@ -258,8 +261,8 @@ class Placeholder(Base):
                     self.expr.type,
                     "array command placeholder must have 'sep'",
                 )
-            # if sum(1 for t in [Type.Int, Type.Float, Type.Boolean, Type.String, Type.File] if isinstance(self.expr.type.item_type, t)) == 0:
-            #    raise Error.StaticTypeMismatch(self, Type.Array(Type.Any()), self.expr.type, "cannot use array of complex types for command placeholder")
+            # if sum(1 for t in [Type.Int, Type.Float, Type.Boolean, Type.String, Type.File] if isinstance(self.expr.type.item_type, t)) == 0:  # noqa
+            #    raise Error.StaticTypeMismatch(self, Type.Array(Type.Any()), self.expr.type, "cannot use array of complex types for command placeholder")  # noqa
         elif "sep" in self.options:
             raise Error.StaticTypeMismatch(
                 self,
@@ -685,7 +688,7 @@ class Ident(Base):
     Name, possibly including a dot-separated namespace
     """
 
-    referee: "Union[None, WDL.Tree.Decl, WDL.Tree.Call, WDL.Tree.Scatter, WDL.Tree.Gather]"
+    referee: "Union[None, Tree.Decl, Tree.Call, Tree.Scatter, Tree.Gather]"
     """
     After typechecking within a task or workflow, stores the AST node to which the identifier
     refers: a ``WDL.Tree.Decl`` for value references; a ``WDL.Tree.Call`` for call outputs; a

--- a/WDL/Lint.py
+++ b/WDL/Lint.py
@@ -839,7 +839,8 @@ class CommandShellCheck(Linter):
             else:
                 self.add(
                     obj,
-                    "shellcheck failed on the task command; update shellcheck version or use --no-shellcheck to suppress this warning",
+                    "shellcheck failed on the task command; update shellcheck version or use --no-shellcheck "
+                    "to suppress this warning",
                     obj.command.pos,
                 )
 
@@ -867,7 +868,8 @@ class CommandShellCheck(Linter):
             except Exception:
                 self.add(
                     obj,
-                    "error parsing shellcheck output JSON; update shellcheck version or use --no-shellcheck to suppress this warning",
+                    "error parsing shellcheck output JSON; update shellcheck version or use --no-shellcheck "
+                    "to suppress this warning",
                     obj.command.pos,
                 )
 

--- a/WDL/Lint.py
+++ b/WDL/Lint.py
@@ -658,8 +658,9 @@ class ForwardReference(Linter):
             referee = obj.referee
             if isinstance(referee, Tree.Gather):
                 referee = referee.final_referee
-            if referee.pos.line > obj.pos.line or (
-                referee.pos.line == obj.pos.line and referee.pos.column > obj.pos.column
+            if referee.pos.line > obj.pos.line or (  # pyre-ignore
+                referee.pos.line == obj.pos.line  # pyre-ignore
+                and referee.pos.column > obj.pos.column  # pyre-ignore
             ):
                 if isinstance(referee, Tree.Decl):
                     msg = "reference to {} precedes its declaration".format(obj.name)

--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -74,7 +74,8 @@ class StructTypeDef(SourceNode):
         """
         :type: str
 
-        A string canonically describing the member names and their types, excluding the struct type name; useful to unify aliased struct types.
+        A string canonically describing the member names and their types, excluding the struct type name; useful to
+        unify aliased struct types.
         """
         return Type._struct_type_id(self.members)
 
@@ -1023,7 +1024,7 @@ class Workflow(SourceNode):
                 errors.try1(
                     lambda decl=decl: decl.typecheck(self._type_env, check_quant=check_quant)
                 )
-            if errors.try1(lambda: _typecheck_workflow_body(doc, check_quant)) == False:
+            if errors.try1(lambda: _typecheck_workflow_body(doc, check_quant)) is False:
                 self.complete_calls = False
             # 4. convert deprecated output_idents, if any, to output declarations
             if self._output_idents:
@@ -1555,7 +1556,7 @@ def _typecheck_workflow_body(
                             ),
                         )
                     )
-                    == False
+                    is False
                 ):
                     complete_calls = False
             elif isinstance(child, WorkflowSection):
@@ -1566,7 +1567,7 @@ def _typecheck_workflow_body(
                             lambda child=child: _typecheck_workflow_body(doc, check_quant, child),
                         )
                     )
-                    == False
+                    is False
                 ):
                     complete_calls = False
             else:

--- a/WDL/Type.py
+++ b/WDL/Type.py
@@ -42,6 +42,8 @@ import copy
 from abc import ABC
 from typing import Optional, Tuple, Dict, Iterable, Set, List
 
+from ._error_util import SourcePosition
+
 
 class Base(ABC):
     """The abstract base class for WDL types
@@ -58,7 +60,7 @@ class Base(ABC):
 
     # pos is set on Type objects instantiated by the WDL syntax parser (mainly in Decl). Other Type
     # objects are instantiated in other ways (e.g. Value describing itself), so will not have pos.
-    pos: "Optional[WDL.Error.SourcePosition]" = None
+    pos: "Optional[SourcePosition]" = None
 
     def coerces(self, rhs: "Base", check_quant: bool = True) -> bool:
         """
@@ -117,7 +119,8 @@ class Base(ABC):
 
 class Any(Base):
     """
-    A symbolic type which coerces to any other type; used to represent e.g. the item type of an empty array literal, or the result of read_json().
+    A symbolic type which coerces to any other type; used to represent e.g. the item type of an empty array literal, or
+    the result of read_json().
     """
 
     def __init__(self, optional: bool = False) -> None:
@@ -410,7 +413,8 @@ class StructInstance(Base):
         """
         :type: str
 
-        A string canonically describing the member names and their types, excluding the struct type name; useful to unify aliased struct types.
+        A string canonically describing the member names and their types, excluding the struct type name; useful to
+        unify aliased struct types.
         """
         assert isinstance(self.members, dict)
         return _struct_type_id(self.members)

--- a/WDL/Value.py
+++ b/WDL/Value.py
@@ -11,7 +11,7 @@ import json
 import copy
 from abc import ABC
 from typing import Any, List, Optional, Tuple, Dict, Iterable, Union, Callable
-from . import Error, Type, Env
+from . import Error, Type, Env, Expr
 
 
 class Base(ABC):
@@ -23,7 +23,7 @@ class Base(ABC):
     value: Any
     """The "raw" Python value"""
 
-    expr: "Optional[WDL.Expr.Base]"
+    expr: "Optional[Expr.Base]"
     """
     Reference to the WDL expression that generated this value, if it originated
     from ``WDL.Expr.eval``
@@ -100,7 +100,8 @@ class Base(ABC):
 
     @property
     def json(self) -> Any:
-        """Return a value representation which can be serialized to JSON using ``json.dumps`` (str, int, float, list, dict, or null)"""
+        """Return a value representation which can be serialized to JSON using ``json.dumps`` """
+        """(str, int, float, list, dict, or null)"""
         return self.value
 
     @property

--- a/WDL/__init__.py
+++ b/WDL/__init__.py
@@ -43,20 +43,29 @@ def load(
     import_max_depth: int = 10,
 ) -> Document:
     """
-    Parse a WDL document given filename/URI, recursively descend into imported documents, then typecheck the tasks and workflow.
+    Parse a WDL document given filename/URI, recursively descend into imported documents, then typecheck the tasks and
+    workflow.
 
     :param path: local filesystem directories to search for imports, in addition to the current working directory
 
-    :param check_quant: set to ``False`` to relax static typechecking of the optional (?) and nonempty (+) type quantifiers. This is discouraged, but may be useful for older WDL workflows which assume less-rigorous static validation of these annotations.
+    :param check_quant:
+        set to ``False`` to relax static typechecking of the optional (?) and nonempty (+) type quantifiers. This is
+        discouraged, but may be useful for older WDL workflows which assume less-rigorous static validation of these
+        annotations.
 
-    :param read_source: async routine to read the WDL source code from filename/URI; see :func:`read_source_default` below for details
+    :param read_source:
+        async routine to read the WDL source code from filename/URI; see :func:`read_source_default` below for details
 
-    :param import_max_depth: to prevent recursive import infinite loops, fail when there are too many import nesting levels (default 10)
+    :param import_max_depth:
+        to prevent recursive import infinite loops, fail when there are too many import nesting levels (default 10)
 
     :raises WDL.Error.SyntaxError: when the document is syntactically invalid under the WDL grammar
-    :raises WDL.Error.ValidationError: when the document is syntactically OK, but fails typechecking or other static validity checks
-    :raises WDL.Error.MultipleValidationErrors: when multiple validation errors are detected in one pass, listed in the ``exceptions`` attribute
-    :raises WDL.Error.ImportError: when an imported sub-document can't be loaded; the ``__cause__`` attribute has the specific error
+    :raises WDL.Error.ValidationError:
+        when the document is syntactically OK, but fails typechecking or other static validity checks
+    :raises WDL.Error.MultipleValidationErrors:
+        when multiple validation errors are detected in one pass, listed in the ``exceptions`` attribute
+    :raises WDL.Error.ImportError:
+        when an imported sub-document can't be loaded; the ``__cause__`` attribute has the specific error
     """
     doc = Tree._load(
         uri,
@@ -169,7 +178,7 @@ def copy_source(doc: Document, dir: str) -> str:
     ans = None
     for a_doc in docs:
         assert a_doc.pos.abspath.startswith(lcp)
-        rp = a_doc.pos.abspath[len(lcp) :].lstrip("/")
+        rp = a_doc.pos.abspath[len(lcp):].lstrip("/")
         fn = os.path.join(dir, rp)
         os.makedirs(os.path.dirname(fn), exist_ok=True)
         _util.write_atomic(a_doc.source_text, fn, end="")
@@ -186,7 +195,9 @@ def parse_document(txt: str, version: Optional[str] = None, uri: str = "") -> Do
     Parse WDL document text into an abstract syntax tree. Doesn't descend into
     imported documents nor typecheck the AST.
 
-    :param version: Override the WDL language version, such as "1.0" or "draft-2". (By default, detects from the "version" string at the beginning of the document, per the WDL spec.)
+    :param version:
+        Override the WDL language version, such as "1.0" or "draft-2". (By default, detects from the "version" string
+        at the beginning of the document, per the WDL spec.)
 
     :param uri: filename/URI for error reporting (not otherwise used)
     """
@@ -230,7 +241,7 @@ def values_from_json(
         if not key.startswith("#"):  # ignore "comments"
             key2 = key
             if namespace and key.startswith(namespace):
-                key2 = key[len(namespace) :]
+                key2 = key[len(namespace):]
             if key2 not in available:
                 # attempt to simplify <call>.<subworkflow>.<input>
                 key2parts = key2.split(".")

--- a/WDL/__init__.py
+++ b/WDL/__init__.py
@@ -178,7 +178,7 @@ def copy_source(doc: Document, dir: str) -> str:
     ans = None
     for a_doc in docs:
         assert a_doc.pos.abspath.startswith(lcp)
-        rp = a_doc.pos.abspath[len(lcp):].lstrip("/")
+        rp = a_doc.pos.abspath[len(lcp) :].lstrip("/")
         fn = os.path.join(dir, rp)
         os.makedirs(os.path.dirname(fn), exist_ok=True)
         _util.write_atomic(a_doc.source_text, fn, end="")
@@ -241,7 +241,7 @@ def values_from_json(
         if not key.startswith("#"):  # ignore "comments"
             key2 = key
             if namespace and key.startswith(namespace):
-                key2 = key[len(namespace):]
+                key2 = key[len(namespace) :]
             if key2 not in available:
                 # attempt to simplify <call>.<subworkflow>.<input>
                 key2parts = key2.split(".")

--- a/WDL/_error_util.py
+++ b/WDL/_error_util.py
@@ -1,0 +1,22 @@
+from typing import NamedTuple
+
+
+class SourcePosition(
+    NamedTuple(
+        "SourcePosition",
+        [
+            ("uri", str),
+            ("abspath", str),
+            ("line", int),
+            ("column", int),
+            ("end_line", int),
+            ("end_column", int),
+        ],
+    )
+):
+    """
+    Source position attached to AST nodes and exceptions; NamedTuple of ``uri`` the filename/URI
+    passed to :func:`WDL.load` or a WDL import statement, which may be relative; ``abspath`` the
+    absolute filename/URI; and one-based int positions ``line`` ``end_line`` ``column``
+    ``end_column``
+    """

--- a/WDL/_parser.py
+++ b/WDL/_parser.py
@@ -330,7 +330,7 @@ class _DocTransformer(_ExprTransformer, _TypeTransformer):
     def runtime_section(self, items, meta):
         d = dict()
         for k, v in items:
-            # TODO: restore duplicate check, cf. https://github.com/gatk-workflows/five-dollar-genome-analysis-pipeline/blob/89f11befc13abae97ab8fb1b457731f390c8728d/tasks_pipelines/qc.wdl#L288
+            # TODO: restore duplicate check, cf. https://github.com/gatk-workflows/five-dollar-genome-analysis-pipeline/blob/89f11befc13abae97ab8fb1b457731f390c8728d/tasks_pipelines/qc.wdl#L288  # noqa
             # if k in d:
             #    raise Error.MultipleDefinitions(self._sp(meta), "duplicate keys in runtime section")
             d[k] = v
@@ -493,14 +493,15 @@ class _DocTransformer(_ExprTransformer, _TypeTransformer):
             # infer namespace from filename/URI
             namespace = uri
             try:
-                namespace = namespace[namespace.rindex("/") + 1 :]
+                namespace = namespace[namespace.rindex("/") + 1:]
             except ValueError:
                 pass
             namespace = namespace.split("?")[0].split(".")[0]
         if not regex.fullmatch("[a-zA-Z][a-zA-Z0-9_]*", namespace) or namespace in self._keywords:
             raise Error.SyntaxError(
                 pos,
-                """declare an import namespace that follows WDL name rules and isn't a language keyword (import "filename" as some_namespace)""",
+                """declare an import namespace that follows WDL name rules and isn't a language keyword """
+                """(import "filename" as some_namespace)""",
                 self._version,
                 self._declared_version,
             )

--- a/WDL/_parser.py
+++ b/WDL/_parser.py
@@ -493,7 +493,7 @@ class _DocTransformer(_ExprTransformer, _TypeTransformer):
             # infer namespace from filename/URI
             namespace = uri
             try:
-                namespace = namespace[namespace.rindex("/") + 1:]
+                namespace = namespace[namespace.rindex("/") + 1 :]
             except ValueError:
                 pass
             namespace = namespace.split("?")[0].split(".")[0]

--- a/WDL/_util.py
+++ b/WDL/_util.py
@@ -40,8 +40,6 @@ import docker
 
 __all__: List[str] = []
 
-from . import Type
-
 
 def export(obj) -> str:  # pyre-ignore
     __all__.append(obj.__name__)
@@ -179,7 +177,8 @@ def write_atomic(contents: str, filename: str, end: str = "\n") -> None:
 
 @export
 def write_values_json(
-    values_env: "Env.Bindings[Value.Base]", filename: str, namespace: str = ""
+        values_env: "Env.Bindings[Value.Base]",  # noqa
+        filename: str, namespace: str = ""
 ) -> None:
     from . import values_to_json
 
@@ -550,7 +549,7 @@ def parse_byte_size(s: str) -> int:
     for i in range(len(s)):
         if s[i].isdigit() or s[i] == ".":
             N = float(s[: i + 1])
-            unit = s[i + 1 :].lstrip()
+            unit = s[i + 1:].lstrip()
         else:
             break
     if N and unit:

--- a/WDL/_util.py
+++ b/WDL/_util.py
@@ -177,8 +177,7 @@ def write_atomic(contents: str, filename: str, end: str = "\n") -> None:
 
 @export
 def write_values_json(
-        values_env: "Env.Bindings[Value.Base]",  # noqa
-        filename: str, namespace: str = ""
+    values_env: "Env.Bindings[Value.Base]", filename: str, namespace: str = ""  # noqa
 ) -> None:
     from . import values_to_json
 
@@ -549,7 +548,7 @@ def parse_byte_size(s: str) -> int:
     for i in range(len(s)):
         if s[i].isdigit() or s[i] == ".":
             N = float(s[: i + 1])
-            unit = s[i + 1:].lstrip()
+            unit = s[i + 1 :].lstrip()
         else:
             break
     if N and unit:

--- a/WDL/runtime/__init__.py
+++ b/WDL/runtime/__init__.py
@@ -11,7 +11,7 @@ from . import config
 from . import task
 from . import workflow
 from . import _statusbar
-from .error import *
+from .error import RunFailed, CommandFailed, Terminated, OutputError, DownloadFailed, error_json
 from .task import run_local_task, link_outputs
 from .workflow import run_local_workflow
 

--- a/WDL/runtime/cache.py
+++ b/WDL/runtime/cache.py
@@ -79,10 +79,10 @@ class CallCache(AbstractContextManager):
             with open(file_path, "rb") as file_reader:
                 contents = file_reader.read()
         except FileNotFoundError:
-            self._logger.info(_(f"call cache miss", cache_path=file_path))
+            self._logger.info(_("call cache miss", cache_path=file_path))
             return None
         contents = json.loads(contents)
-        self._logger.notice(_(f"call cache hit", cache_path=file_path))  # pyre-fixme
+        self._logger.notice(_("call cache hit", cache_path=file_path))  # pyre-fixme
         return values_from_json(contents, output_types)  # pyre-fixme
 
     def put(self, task_key: str, input_digest: str, outputs: Env.Bindings[Value.Base],) -> None:
@@ -102,7 +102,7 @@ class CallCache(AbstractContextManager):
                 json.dumps(values_to_json(outputs, namespace=""), indent=2),  # pyre-ignore
                 filename,
             )
-            self._logger.info(_(f"call cache insert", cache_path=filename))
+            self._logger.info(_("call cache insert", cache_path=filename))
 
     # specialized caching logic for file downloads (not sensitive to the downloader task details,
     # and looked up in URI-derived folder structure instead of sqlite db)
@@ -256,9 +256,9 @@ def _excerpt(doc: Tree.Document, pos: Error.SourcePosition) -> List[str]:
     TODO (?): delete comments from the source lines
     """
     if pos.end_line == pos.line:
-        return [doc.source_lines[pos.line - 1][(pos.column - 1) : pos.end_column]]
+        return [doc.source_lines[pos.line - 1][(pos.column - 1): pos.end_column]]
     return (
-        [doc.source_lines[pos.line - 1][(pos.column - 1) :]]
-        + doc.source_lines[pos.line : (pos.end_line - 1)]
+        [doc.source_lines[pos.line - 1][(pos.column - 1):]]
+        + doc.source_lines[pos.line: (pos.end_line - 1)]
         + [doc.source_lines[pos.end_line - 1][: pos.end_column]]
     )

--- a/WDL/runtime/cache.py
+++ b/WDL/runtime/cache.py
@@ -256,9 +256,9 @@ def _excerpt(doc: Tree.Document, pos: Error.SourcePosition) -> List[str]:
     TODO (?): delete comments from the source lines
     """
     if pos.end_line == pos.line:
-        return [doc.source_lines[pos.line - 1][(pos.column - 1): pos.end_column]]
+        return [doc.source_lines[pos.line - 1][(pos.column - 1) : pos.end_column]]
     return (
-        [doc.source_lines[pos.line - 1][(pos.column - 1):]]
-        + doc.source_lines[pos.line: (pos.end_line - 1)]
+        [doc.source_lines[pos.line - 1][(pos.column - 1) :]]
+        + doc.source_lines[pos.line : (pos.end_line - 1)]
         + [doc.source_lines[pos.end_line - 1][: pos.end_column]]
     )

--- a/WDL/runtime/download.py
+++ b/WDL/runtime/download.py
@@ -76,7 +76,8 @@ def run(cfg: config.Loader, logger: logging.Logger, uri: str, **kwargs) -> str:
     useful in particular.
     """
 
-    from . import run_local_task, RunFailed, DownloadFailed, Terminated, error_json
+    from .error import RunFailed, DownloadFailed, Terminated, error_json
+    from .task import run_local_task
     from .. import parse_document, values_from_json, values_to_json, Walker
 
     gen = _downloader(cfg, uri)
@@ -208,9 +209,10 @@ def awscli_downloader(
             inputs["aws_credentials"] = aws_credentials_file.name
             logger.getChild("awscli_downloader").info("loaded host AWS credentials")
         else:
-            logger.getChild("awscli_downloader").info(
-                "no AWS credentials available via host awscli/boto3; if needed, configure them and set [download_awscli] host_credentials=true. (On EC2: awscli might still assume role from instance metadata service.)"
-            )
+            logger.getChild("awscli_downloader").info("no AWS credentials available via host awscli/boto3; if needed, "
+                                                      "configure them and set [download_awscli] host_credentials=true. "
+                                                      "(On EC2: awscli might still assume role from instance metadata "
+                                                      "service.)")
 
         wdl = r"""
         task aws_s3_cp {

--- a/WDL/runtime/download.py
+++ b/WDL/runtime/download.py
@@ -209,10 +209,12 @@ def awscli_downloader(
             inputs["aws_credentials"] = aws_credentials_file.name
             logger.getChild("awscli_downloader").info("loaded host AWS credentials")
         else:
-            logger.getChild("awscli_downloader").info("no AWS credentials available via host awscli/boto3; if needed, "
-                                                      "configure them and set [download_awscli] host_credentials=true. "
-                                                      "(On EC2: awscli might still assume role from instance metadata "
-                                                      "service.)")
+            logger.getChild("awscli_downloader").info(
+                "no AWS credentials available via host awscli/boto3; if needed, "
+                "configure them and set [download_awscli] host_credentials=true. "
+                "(On EC2: awscli might still assume role from instance metadata "
+                "service.)"
+            )
 
         wdl = r"""
         task aws_s3_cp {

--- a/WDL/runtime/error.py
+++ b/WDL/runtime/error.py
@@ -82,7 +82,8 @@ class RunFailed(_RuntimeError):
 
     def __init__(self, exe: Union[_Task, _Workflow], run_id: str, run_dir: str) -> None:
         super().__init__(
-            f"{'task' if  isinstance(exe, _Task) else 'workflow'} {exe.name} ({exe.pos.uri} Ln {exe.pos.line} Col {exe.pos.column}) failed"
+            f"{'task' if isinstance(exe, _Task) else 'workflow'} {exe.name} "
+            f"({exe.pos.uri} Ln {exe.pos.line} Col {exe.pos.column}) failed"
         )
         self.exe = exe
         self.run_id = run_id

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -12,7 +12,7 @@ import glob
 import threading
 import shutil
 import re
-from typing import Tuple, List, Dict, Optional, Callable, Set, Any
+from typing import Tuple, List, Dict, Optional, Callable, Iterable, Set, Any, Union
 from contextlib import ExitStack
 
 from .. import Error, Type, Env, Value, StdLib, Tree, _util
@@ -31,9 +31,7 @@ from .._util import StructuredLogMessage as _
 from . import config, _statusbar
 from .download import able as downloadable, run_cached as download
 from .cache import CallCache
-from .error import *
-from .task_container import TaskContainer
-from .task_container import new as new_task_container
+from .error import OutputError, Interrupted, Terminated, CommandFailed, RunFailed, error_json
 
 
 def run_local_task(
@@ -735,7 +733,7 @@ class OutputStdLib(_StdLib):
                 dstrip = lib.container.host_dir
                 dstrip += "" if dstrip.endswith("/") else "/"
                 assert hf.startswith(dstrip)
-                container_files.append(os.path.join(lib.container.container_dir, hf[len(dstrip) :]))
+                container_files.append(os.path.join(lib.container.container_dir, hf[len(dstrip):]))
             return Value.Array(Type.File(), [Value.File(fn) for fn in container_files])
 
         setattr(

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -733,7 +733,7 @@ class OutputStdLib(_StdLib):
                 dstrip = lib.container.host_dir
                 dstrip += "" if dstrip.endswith("/") else "/"
                 assert hf.startswith(dstrip)
-                container_files.append(os.path.join(lib.container.container_dir, hf[len(dstrip):]))
+                container_files.append(os.path.join(lib.container.container_dir, hf[len(dstrip) :]))
             return Value.Array(Type.File(), [Value.File(fn) for fn in container_files])
 
         setattr(

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -32,6 +32,7 @@ from . import config, _statusbar
 from .download import able as downloadable, run_cached as download
 from .cache import CallCache
 from .error import OutputError, Interrupted, Terminated, CommandFailed, RunFailed, error_json
+from .task_container import TaskContainer, new as new_task_container
 
 
 def run_local_task(

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -19,3 +19,4 @@ pytest-xdist
 recommonmark
 sphinx-argparse
 boto3
+flake8


### PR DESCRIPTION
### Motivation
Enable flake8 linter

- [x] Add appropriate test(s) to the automatic suite
- [x] Use `make pretty` to reformat the code with [black](https://github.com/python/black)
- [x] Use `make check` to statically check the code using [Pyre](https://pyre-check.org/) and [Pylint](https://www.pylint.org/)
- [x] Send PR from a dedicated branch without unrelated edits
- [x] Ensure compatibility with this project's MIT license
