### PR TITLE
Permissive dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,8 @@ regex>=v39.0.1
 xdg>=2.0.0
 docker>=3.4.0
 ruamel.yaml>=0.15.37
-argcomplete~=1.11.0
-pygtail~=0.11.0
-coloredlogs~=11.0
-python-json-logger~=0.1.11
-lark-parser==0.9.0
+argcomplete~=1.11
+pygtail~=0.11
+coloredlogs>=11.0
+python-json-logger~=0.1
+lark-parser~=0.9


### PR DESCRIPTION
### Motivation
See #412

### Approach
Use `~=M.m` dependencies instead of `~=M.m.p` where possible. For `coloredlogs`, be even more permissive because this is a common library that is likely to cause dependency issues, and the newer major releases don't seem problematic.

### Checklist

- [x] Add appropriate test(s) to the automatic suite
- [x] Use `make pretty` to reformat the code with [black](https://github.com/python/black)
- [x] Use `make check` to statically check the code using [Pyre](https://pyre-check.org/) and [Pylint](https://www.pylint.org/)
- [x] Send PR from a dedicated branch without unrelated edits
- [x] Ensure compatibility with this project's MIT license
