### PR TITLE
Map refinements

### DIFF
--- a/WDL/Expr.py
+++ b/WDL/Expr.py
@@ -609,10 +609,15 @@ class Map(Base):
     ) -> Value.Base:
         ""
         assert isinstance(self.type, Type.Map)
+        keystrs = set()
         eitems = []
         for k, v in self.items:
-            eitems.append((k.eval(env, stdlib), v.eval(env, stdlib)))
-        # TODO: complain of duplicate keys
+            ek = k.eval(env, stdlib)
+            sk = str(ek)
+            if sk in keystrs:
+                raise Error.EvalError(self, "duplicate keys in Map literal")
+            eitems.append((ek, v.eval(env, stdlib)))
+            keystrs.add(sk)
         return Value.Map(self.type.item_type, eitems)
 
     @property

--- a/WDL/Value.py
+++ b/WDL/Value.py
@@ -241,6 +241,8 @@ class Array(Base):
             return Array(
                 desired_type, [v.coerce(desired_type.item_type) for v in self.value], self.expr
             )
+        if isinstance(desired_type, Type.String):
+            return String(json.dumps(self.json))
         return super().coerce(desired_type)
 
 
@@ -265,6 +267,9 @@ class Map(Base):
     def json(self) -> Any:
         ""
         ans = {}
+        if not self.type.item_type[0].coerces(Type.String()):
+            msg = f"cannot JSON-serialize {str(self.type)} keys"
+            raise (Error.EvalError(self.expr, msg) if self.expr else Error.RuntimeError(msg))
         for k, v in self.value:
             kstr = k.coerce(Type.String()).value
             if kstr not in ans:

--- a/WDL/Value.py
+++ b/WDL/Value.py
@@ -268,7 +268,7 @@ class Map(Base):
         ""
         ans = {}
         if not self.type.item_type[0].coerces(Type.String()):
-            msg = f"cannot JSON-serialize {str(self.type)} keys"
+            msg = f"cannot write {str(self.type)} to JSON"
             raise (Error.EvalError(self.expr, msg) if self.expr else Error.RuntimeError(msg))
         for k, v in self.value:
             kstr = k.coerce(Type.String()).value

--- a/WDL/Value.py
+++ b/WDL/Value.py
@@ -266,7 +266,6 @@ class Map(Base):
         ""
         ans = {}
         for k, v in self.value:
-            assert k.type.coerces(Type.String())
             kstr = k.coerce(Type.String()).value
             if kstr not in ans:
                 ans[kstr] = v.json
@@ -455,13 +454,13 @@ def from_json(type: Type.Base, value: Any) -> Base:
         )
     if (
         isinstance(type, Type.Map)
-        and type.item_type[0] == Type.String()
+        and Type.String().coerces(type.item_type[0])
         and isinstance(value, dict)
     ):
         items = []
         for k, v in value.items():
             assert isinstance(k, str)
-            items.append((from_json(type.item_type[0], k), from_json(type.item_type[1], v)))
+            items.append((String(k).coerce(type.item_type[0]), from_json(type.item_type[1], v)))
         return Map(type.item_type, items)
     if (
         isinstance(type, Type.StructInstance)

--- a/WDL/_grammar.py
+++ b/WDL/_grammar.py
@@ -148,7 +148,7 @@ STRING_INNER1: ("\\'"|/[^']/)
 ESCAPED_STRING1: "'" STRING_INNER1* "'"
 string_literal: ESCAPED_STRING | ESCAPED_STRING1
 
-?map_key: literal | string
+?map_key: expr_core
 map_kv: map_key ":" expr
 
 // expression core (everything but infix)
@@ -413,7 +413,7 @@ optional_nonempty: "+?"
           | expr_core "." CNAME -> get_name
           | "object" "{" [object_kv ("," object_kv)* ","?] "}" -> obj
 
-?map_key: literal | string
+?map_key: expr_core
 map_kv: map_key ":" expr
 
 object_kv:  CNAME ":" expr

--- a/tests/test_0eval.py
+++ b/tests/test_0eval.py
@@ -343,6 +343,8 @@ class TestEval(unittest.TestCase):
             ("{[1]: true, [1]: false}", "", WDL.Error.EvalError),
             ("{(false, false): 0, (false, true): 1}", "", WDL.Type.Map((WDL.Type.Pair(WDL.Type.Boolean(), WDL.Type.Boolean()), WDL.Type.Int()))),
         )
+        with self.assertRaisesRegex(WDL.Error.EvalError, "to JSON"):
+            WDL.parse_expr("{(false, false): 0, (false, true): 1}").infer_type(WDL.Env.Bindings()).eval(WDL.Env.Bindings()).json
 
     def test_errors(self):
         self._test_tuples(

--- a/tests/test_1doc.py
+++ b/tests/test_1doc.py
@@ -515,6 +515,26 @@ class TestTypes(unittest.TestCase):
             """)
             doc.typecheck()
 
+    def test_map_io(self):
+        with self.assertRaisesRegex(WDL.Error.ValidationError, "keys cannot"):
+            WDL.parse_document("""
+            workflow w {
+                input {
+                    Map[Pair[Int,Int],String] m
+                }
+            }
+            """).typecheck()
+
+        with self.assertRaisesRegex(WDL.Error.ValidationError, "keys cannot"):
+            WDL.parse_document("""
+            task t {
+                command {}
+                output {
+                    Map[Pair[Int,Int],String] m = read_json("bogus")
+                }
+            }
+            """).typecheck()
+
 class TestDoc(unittest.TestCase):
     def test_count_foo(self):
         doc = r"""#foo

--- a/tests/test_5stdlib.py
+++ b/tests/test_5stdlib.py
@@ -937,6 +937,7 @@ class TestStdLib(unittest.TestCase):
                 Array[Int] k2 = keys(m2)
                 Array[Int] k3 = keys(m3)
                 Array[Boolean] k4 = keys({})
+                Array[Pair[Int,Boolean]] k5 = keys({(1,false): "foo", (3,true): "bar"})
             }
         }
         """)
@@ -944,6 +945,7 @@ class TestStdLib(unittest.TestCase):
         self.assertEqual(outputs["k2"], [1,-1])
         self.assertEqual(outputs["k3"], [])
         self.assertEqual(outputs["k4"], [])
+        self.assertEqual(outputs["k5"], [{"left": 1, "right": False}, {"left": 3, "right": True}])
 
         with self.assertRaises(WDL.Error.StaticTypeMismatch):
             self._test_task(R"""


### PR DESCRIPTION
- detect duplicate keys in map literals
- allow map literals with compound keys
- forbid use of compound-key maps in inputs/outputs (due to lack of JSON codec)