### PR TITLE
WDL 2.0 struct literals

### DIFF
--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -136,7 +136,7 @@ class WorkflowNode(SourceNode, ABC):
 
     @abstractmethod
     def add_to_type_env(
-        self, struct_typedefs: Env.Bindings[StructTypeDef], type_env: Env.Bindings[Type.Base]
+        self, struct_types: Env.Bindings[Dict[str, Type.Base]], type_env: Env.Bindings[Type.Base]
     ) -> Env.Bindings[Type.Base]:
         # typechecking helper -- add this node to the type environment; for sections, this includes
         # everything in the section body as visible outside of the section.
@@ -198,7 +198,7 @@ class Decl(WorkflowNode):
 
     def add_to_type_env(
         self,
-        struct_typedefs: Env.Bindings[StructTypeDef],
+        struct_types: Env.Bindings[Dict[str, Type.Base]],
         type_env: Env.Bindings[Type.Base],
         collision_ok: bool = False,
     ) -> Env.Bindings[Type.Base]:
@@ -209,7 +209,7 @@ class Decl(WorkflowNode):
                 raise Error.MultipleDefinitions(self, "Multiple declarations of " + self.name)
             if type_env.has_namespace(self.name):
                 raise Error.MultipleDefinitions(self, "Value/call name collision on " + self.name)
-        _resolve_struct_typedefs(self.pos, self.type, struct_typedefs)
+        _resolve_struct_types(self.pos, self.type, struct_types)
         if isinstance(self.type, Type.StructInstance):
             return _add_struct_instance_to_type_env(self.name, self.type, type_env, ctx=self)
         return type_env.bind(self.name, self.type, self)
@@ -218,12 +218,15 @@ class Decl(WorkflowNode):
         self,
         type_env: Env.Bindings[Type.Base],
         stdlib: StdLib.Base,
+        struct_types: Env.Bindings[Dict[str, Type.Base]],
         check_quant: bool = True,
     ) -> None:
         # Infer the expression's type and ensure it checks against the declared
         # type. One time use!
         if self.expr:
-            self.expr.infer_type(type_env, stdlib, check_quant=check_quant).typecheck(self.type)
+            self.expr.infer_type(
+                type_env, stdlib, check_quant=check_quant, struct_types=struct_types
+            ).typecheck(self.type)
 
     def _workflow_node_dependencies(self) -> Iterable[str]:
         yield from _expr_workflow_node_dependencies(self.expr)
@@ -356,10 +359,10 @@ class Task(SourceNode):
 
     def typecheck(
         self,
-        struct_typedefs: Optional[Env.Bindings[StructTypeDef]] = None,
+        struct_types: Optional[Env.Bindings[Dict[str, Type.Base]]] = None,
         check_quant: bool = True,
     ) -> None:
-        struct_typedefs = struct_typedefs or Env.Bindings()
+        struct_types = struct_types or Env.Bindings()
         # warm-up check: if input{} section exists then all postinput decls
         # must be bound
         if self.inputs is not None:
@@ -376,18 +379,22 @@ class Task(SourceNode):
         # in their right-hand side expressions.
         type_env = Env.Bindings()
         for decl in (self.inputs or []) + self.postinputs:
-            type_env = decl.add_to_type_env(struct_typedefs, type_env)
+            type_env = decl.add_to_type_env(struct_types, type_env)
 
         with Error.multi_context() as errors:
             stdlib = StdLib.Base(self.effective_wdl_version)
             # Pass through input & postinput declarations again, typecheck their
             # right-hand side expressions against the type environment.
             for decl in (self.inputs or []) + self.postinputs:
-                errors.try1(lambda: decl.typecheck(type_env, stdlib, check_quant=check_quant))
+                errors.try1(
+                    lambda: decl.typecheck(
+                        type_env, stdlib, check_quant=check_quant, struct_types=struct_types
+                    )
+                )
             # Typecheck the command (string)
             errors.try1(
                 lambda: self.command.infer_type(
-                    type_env, stdlib, check_quant=check_quant
+                    type_env, stdlib, check_quant=check_quant, struct_types=struct_types
                 ).typecheck(Type.String())
             )
             for b in self.available_inputs:
@@ -396,13 +403,13 @@ class Task(SourceNode):
             for _, runtime_expr in self.runtime.items():
                 errors.try1(
                     lambda runtime_expr=runtime_expr: runtime_expr.infer_type(
-                        type_env, stdlib, check_quant=check_quant
+                        type_env, stdlib, check_quant=check_quant, struct_types=struct_types
                     ).typecheck(Type.String())
                 )
             # Add output declarations to type environment
             for decl in self.outputs:
                 type_env2 = errors.try1(
-                    lambda decl=decl: decl.add_to_type_env(struct_typedefs, type_env)
+                    lambda decl=decl: decl.add_to_type_env(struct_types, type_env)
                 )
                 if type_env2:
                     type_env = type_env2
@@ -410,7 +417,9 @@ class Task(SourceNode):
             # Typecheck the output expressions
             stdlib = StdLib.TaskOutputs(self.effective_wdl_version)
             for decl in self.outputs:
-                errors.try1(lambda: decl.typecheck(type_env, stdlib, check_quant=check_quant))
+                errors.try1(
+                    lambda: decl.typecheck(type_env, stdlib, struct_types, check_quant=check_quant)
+                )
                 errors.try1(lambda: _check_serializable_map_keys(decl.type, decl.name, decl))
 
         # check for cyclic dependencies among decls
@@ -512,7 +521,7 @@ class Call(WorkflowNode):
         assert isinstance(self.callee, (Task, Workflow))
 
     def add_to_type_env(
-        self, struct_typedefs: Env.Bindings[StructTypeDef], type_env: Env.Bindings[Type.Base]
+        self, struct_types: Env.Bindings[Dict[str, Type.Base]], type_env: Env.Bindings[Type.Base]
     ) -> Env.Bindings[Type.Base]:
         # Add the call's outputs to the type environment under the appropriate
         # namespace, after checking for namespace collisions.
@@ -532,7 +541,11 @@ class Call(WorkflowNode):
         )
 
     def typecheck_input(
-        self, type_env: Env.Bindings[Type.Base], stdlib: StdLib.Base, check_quant: bool
+        self,
+        struct_types: Env.Bindings[Dict[str, Type.Base]],
+        type_env: Env.Bindings[Type.Base],
+        stdlib: StdLib.Base,
+        check_quant: bool,
     ) -> bool:
         # Check the input expressions against the callee's inputs. One-time use.
         # Returns True if the call supplies all required inputs, False otherwise.
@@ -557,7 +570,7 @@ class Call(WorkflowNode):
                     decl = self.callee.available_inputs[name]
                     errors.try1(
                         lambda expr=expr, decl=decl: expr.infer_type(
-                            type_env, stdlib, check_quant=check_quant
+                            type_env, stdlib, check_quant=check_quant, struct_types=struct_types
                         ).typecheck(decl.type)
                     )
                 except KeyError:
@@ -651,7 +664,7 @@ class Gather(WorkflowNode):
         self.referee = referee
 
     def add_to_type_env(
-        self, struct_typedefs: Env.Bindings[StructTypeDef], type_env: Env.Bindings[Type.Base]
+        self, struct_types: Env.Bindings[Dict[str, Type.Base]], type_env: Env.Bindings[Type.Base]
     ) -> Env.Bindings[Type.Base]:
         raise NotImplementedError()
 
@@ -772,7 +785,7 @@ class Scatter(WorkflowSection):
         yield from super().children
 
     def add_to_type_env(
-        self, struct_typedefs: Env.Bindings[StructTypeDef], type_env: Env.Bindings[Type.Base]
+        self, struct_types: Env.Bindings[Dict[str, Type.Base]], type_env: Env.Bindings[Type.Base]
     ) -> Env.Bindings[Type.Base]:
         # Add declarations and call outputs in this section as they'll be
         # available outside of the section (i.e. a declaration of type T is
@@ -780,7 +793,7 @@ class Scatter(WorkflowSection):
 
         inner_type_env = Env.Bindings()
         for elt in self.body:
-            inner_type_env = elt.add_to_type_env(struct_typedefs, inner_type_env)
+            inner_type_env = elt.add_to_type_env(struct_types, inner_type_env)
         # Subtlety: if the scatter array is statically nonempty, then so too
         # are the arrayized values.
         nonempty = isinstance(self.expr._type, Type.Array) and self.expr._type.nonempty
@@ -841,7 +854,7 @@ class Conditional(WorkflowSection):
         yield from super().children
 
     def add_to_type_env(
-        self, struct_typedefs: Env.Bindings[StructTypeDef], type_env: Env.Bindings[Type.Base]
+        self, struct_types: Env.Bindings[Dict[str, Type.Base]], type_env: Env.Bindings[Type.Base]
     ) -> Env.Bindings[Type.Base]:
         # Add declarations and call outputs in this section as they'll be
         # available outside of the section (i.e. a declaration of type T is
@@ -849,7 +862,7 @@ class Conditional(WorkflowSection):
 
         inner_type_env = Env.Bindings()
         for elt in self.body:
-            inner_type_env = elt.add_to_type_env(struct_typedefs, inner_type_env)
+            inner_type_env = elt.add_to_type_env(struct_types, inner_type_env)
 
         # optional-ize each inner type binding and add gather nodes
         def optionalize(binding: Env.Binding[Type.Base]) -> Env.Binding[Type.Base]:
@@ -1064,7 +1077,10 @@ class Workflow(SourceNode):
             for decl in self.inputs or []:
                 errors.try1(
                     lambda decl=decl: decl.typecheck(
-                        self._type_env, stdlib, check_quant=check_quant
+                        self._type_env,
+                        stdlib,
+                        check_quant=check_quant,
+                        struct_types=doc._struct_types,
                     )
                 )
             if errors.try1(lambda: _typecheck_workflow_body(doc, stdlib, check_quant)) is False:
@@ -1097,13 +1113,16 @@ class Workflow(SourceNode):
                     # 2. we still want to typecheck the output expression againsnt the 'old' type
                     #    environment
                     output_type_env2 = output.add_to_type_env(
-                        doc.struct_typedefs,
+                        doc._struct_types,
                         output_type_env,
                         collision_ok=getattr(output, "_rewritten_ident", False),
                     )
                     errors.try1(
                         lambda output=output: output.typecheck(
-                            output_type_env, stdlib, check_quant=check_quant
+                            output_type_env,
+                            stdlib,
+                            check_quant=check_quant,
+                            struct_types=doc._struct_types,
                         )
                     )
                     output_type_env = output_type_env2
@@ -1258,6 +1277,10 @@ class Document(SourceNode):
     Imported documents"""
     struct_typedefs: Env.Bindings[StructTypeDef]
     """:type: Env.Bindings[WDL.Tree.StructTypeDef]"""
+
+    _struct_types: Env.Bindings[Dict[str, Type.Base]]
+    # simpler mapping of struct names to their members, used for typechecking ops
+
     tasks: List[Task]
     """:type: List[WDL.Tree.Task]"""
     workflow: Optional[Workflow]
@@ -1279,6 +1302,7 @@ class Document(SourceNode):
         self.struct_typedefs = Env.Bindings()
         for name, struct_typedef in struct_typedefs.items():
             self.struct_typedefs = self.struct_typedefs.bind(name, struct_typedef)
+        self._struct_types = Env.Bindings()
         self.tasks = tasks
         self.workflow = workflow
         self.source_text = source_text
@@ -1321,7 +1345,11 @@ class Document(SourceNode):
                 )
             names.add(imp.namespace)
         _import_structs(self)
-        _initialize_struct_typedefs(self.struct_typedefs)
+        for struct_binding in self.struct_typedefs:
+            self._struct_types = self._struct_types.bind(
+                struct_binding.name, struct_binding.value.members
+            )
+        _initialize_struct_typedefs(self.struct_typedefs, self._struct_types)
         names = set()
         # typecheck each task
         with Error.multi_context() as errors:
@@ -1332,7 +1360,7 @@ class Document(SourceNode):
                     )
                 names.add(task.name)
                 errors.try1(
-                    lambda task=task: task.typecheck(self.struct_typedefs, check_quant=check_quant)
+                    lambda task=task: task.typecheck(self._struct_types, check_quant=check_quant)
                 )
         # typecheck the workflow
         if self.workflow:
@@ -1529,10 +1557,12 @@ def _build_workflow_type_env(
     if isinstance(self, Workflow):
         # start with workflow inputs
         for decl in self.inputs or []:
-            type_env = decl.add_to_type_env(doc.struct_typedefs, type_env)
+            type_env = decl.add_to_type_env(doc._struct_types, type_env)
     elif isinstance(self, Scatter):
         # typecheck scatter array
-        self.expr.infer_type(type_env, stdlib, check_quant=check_quant)
+        self.expr.infer_type(
+            type_env, stdlib, check_quant=check_quant, struct_types=doc._struct_types
+        )
         if not isinstance(self.expr.type, Type.Array):
             raise Error.NotAnArray(self.expr)
         if isinstance(self.expr.type.item_type, Type.Any):
@@ -1549,7 +1579,9 @@ def _build_workflow_type_env(
         type_env = type_env.bind(self.variable, self.expr.type.item_type, self)
     elif isinstance(self, Conditional):
         # typecheck the condition
-        self.expr.infer_type(type_env, stdlib, check_quant=check_quant)
+        self.expr.infer_type(
+            type_env, stdlib, check_quant=check_quant, struct_types=doc._struct_types
+        )
         if not self.expr.type.coerces(Type.Boolean()):
             raise Error.StaticTypeMismatch(self.expr, Type.Boolean(), self.expr.type)
     else:
@@ -1564,7 +1596,7 @@ def _build_workflow_type_env(
             for sibling in self.body:
                 if sibling is not child:
                     child_outer_type_env = sibling.add_to_type_env(
-                        doc.struct_typedefs, child_outer_type_env
+                        doc._struct_types, child_outer_type_env
                     )
             _build_workflow_type_env(doc, stdlib, check_quant, child, child_outer_type_env)
         elif isinstance(child, Decl) and not child.type.optional and not child.expr:
@@ -1585,7 +1617,7 @@ def _build_workflow_type_env(
 
     # finally, populate self._type_env with all our children
     for child in self.body:
-        type_env = child.add_to_type_env(doc.struct_typedefs, type_env)
+        type_env = child.add_to_type_env(doc._struct_types, type_env)
     self._type_env = type_env
 
 
@@ -1607,7 +1639,10 @@ def _typecheck_workflow_body(
                     _translate_struct_mismatch(
                         doc,
                         lambda child=child: child.typecheck(
-                            self._type_env, stdlib, check_quant=check_quant
+                            self._type_env,
+                            stdlib,
+                            check_quant=check_quant,
+                            struct_types=doc._struct_types,
                         ),
                     )
                 )
@@ -1617,7 +1652,7 @@ def _typecheck_workflow_body(
                         _translate_struct_mismatch(
                             doc,
                             lambda child=child: child.typecheck_input(
-                                self._type_env, stdlib, check_quant=check_quant
+                                doc._struct_types, self._type_env, stdlib, check_quant=check_quant
                             ),
                         )
                     )
@@ -1811,46 +1846,49 @@ def _import_structs(doc: Document):
                 doc.struct_typedefs = doc.struct_typedefs.bind(name, st2)
 
 
-def _resolve_struct_typedef(
-    pos: Error.SourcePosition, ty: Type.StructInstance, struct_typedefs: Env.Bindings[StructTypeDef]
+def _resolve_struct_type(
+    pos: Error.SourcePosition,
+    ty: Type.StructInstance,
+    struct_types: Env.Bindings[Dict[str, Type.Base]],
 ):
     # On construction, WDL.Type.StructInstance is not yet resolved to the
     # struct type definition. Here, given the Env.Bindings[StructTypeDef] computed
     # on document construction, we populate 'members' with the dict of member
     # types and names.
     try:
-        struct_typedef = struct_typedefs[ty.type_name]
+        ty.members = struct_types[ty.type_name]
     except KeyError:
         raise Error.InvalidType(pos, "Unknown type " + ty.type_name) from None
-    ty.members = struct_typedef.members
 
 
-def _resolve_struct_typedefs(
+def _resolve_struct_types(
     pos: Error.SourcePosition,
     ty: Type.Base,
-    struct_typedefs: Env.Bindings[StructTypeDef],
+    struct_types: Env.Bindings[Dict[str, Type.Base]],
     members_dict_ids: Optional[List[int]] = None,
 ):
     members_dict_ids = members_dict_ids or []
     # resolve all StructInstance within a potentially compound type
     if isinstance(ty, Type.StructInstance):
-        _resolve_struct_typedef(pos, ty, struct_typedefs)
+        _resolve_struct_type(pos, ty, struct_types)
         if id(ty.members) in members_dict_ids:
             # circular struct types!
             raise StopIteration
         members_dict_ids = [id(ty.members)] + (members_dict_ids or [])
     for p in ty.parameters:
-        _resolve_struct_typedefs(pos, p, struct_typedefs, members_dict_ids=members_dict_ids)
+        _resolve_struct_types(pos, p, struct_types, members_dict_ids=members_dict_ids)
 
 
-def _initialize_struct_typedefs(struct_typedefs: Env.Bindings[StructTypeDef]):
+def _initialize_struct_typedefs(
+    struct_typedefs: Env.Bindings[StructTypeDef], struct_types: Env.Bindings[Dict[str, Type.Base]]
+):
     # bootstrap struct typechecking: resolve all StructInstance members of the
     # struct types; also detect & error circular struct definitions
     for b in struct_typedefs:
         assert isinstance(b, Env.Binding)
         for member_ty in b.value.members.values():
             try:
-                _resolve_struct_typedefs(b.value.pos, member_ty, struct_typedefs)
+                _resolve_struct_types(b.value.pos, member_ty, struct_types)
             except StopIteration:
                 raise Error.CircularDependencies(b.value) from None
 

--- a/WDL/_grammar.py
+++ b/WDL/_grammar.py
@@ -409,9 +409,10 @@ optional_nonempty: "+?"
 
           | CNAME "(" [expr ("," expr)*] ")" -> apply
 
+          | CNAME "{" [object_kv ("," object_kv)* ","?] "}" -> obj
+
           | CNAME -> left_name
           | expr_core "." CNAME -> get_name
-          | "object" "{" [object_kv ("," object_kv)* ","?] "}" -> obj
 
 ?map_key: expr_core
 map_kv: map_key ":" expr

--- a/WDL/_parser.py
+++ b/WDL/_parser.py
@@ -210,6 +210,11 @@ class _DocTransformer(_ExprTransformer):
         self._check_keyword(self._sp(meta), ans[0])
         return ans
 
+    def obj(self, items, meta):
+        if isinstance(items[0], str) and items[0] != "object":
+            self._check_keyword(self._sp(meta), items[0])
+        return super().obj(items, meta)
+
     def left_name(self, items, meta) -> Expr.Base:
         ans = super().left_name(items, meta)
         self._check_keyword(ans.pos, items[0])

--- a/WDL/_parser.py
+++ b/WDL/_parser.py
@@ -207,7 +207,7 @@ class _DocTransformer(_ExprTransformer):
 
     def object_kv(self, items, meta):
         ans = super().object_kv(items, meta)
-        self._check_keyword(ans.pos, ans[0])
+        self._check_keyword(self._sp(meta), ans[0])
         return ans
 
     def left_name(self, items, meta) -> Expr.Base:

--- a/WDL/_parser.py
+++ b/WDL/_parser.py
@@ -210,8 +210,8 @@ class _DocTransformer(_ExprTransformer):
         self._check_keyword(self._sp(meta), ans[0])
         return ans
 
-    def obj(self, items, meta):
-        if isinstance(items[0], str) and items[0] != "object":
+    def obj(self, items, meta) -> Expr.Base:
+        if items and isinstance(items[0], str) and items[0] != "object":
             self._check_keyword(self._sp(meta), items[0])
         return super().obj(items, meta)
 

--- a/WDL/runtime/workflow.py
+++ b/WDL/runtime/workflow.py
@@ -96,7 +96,7 @@ class WorkflowOutputs(Tree.WorkflowNode):
         yield from self.output_node_ids
 
     def add_to_type_env(
-        self, struct_typedefs: Env.Bindings[Tree.StructTypeDef], type_env: Env.Bindings[Type.Base]
+        self, struct_types: Env.Bindings[Dict[str, Type.Base]], type_env: Env.Bindings[Type.Base]
     ) -> Env.Bindings[Type.Base]:
         raise NotImplementedError()
 

--- a/tests/test_2calls.py
+++ b/tests/test_2calls.py
@@ -617,7 +617,22 @@ class TestCalls(unittest.TestCase):
                 }
             }
         """)
-        with self.assertRaises(WDL.Error.NoSuchMember):
+        with self.assertRaises(WDL.Error.StaticTypeMismatch):
+            doc.typecheck()
+
+        doc = WDL.parse_document(defs + """
+            workflow w {
+                Car c = Car {
+                    make: "Toyota",
+                    model: "Camry",
+                    odometer: 139000,
+                    owner: Person {
+                        name: "Mario"
+                    }
+                }
+            }
+        """)
+        with self.assertRaises(WDL.Error.StaticTypeMismatch):
             doc.typecheck()
 
         doc = WDL.parse_document(defs + """
@@ -634,19 +649,4 @@ class TestCalls(unittest.TestCase):
             }
         """)
         with self.assertRaises(WDL.Error.InvalidType):
-            doc.typecheck()
-
-        doc = WDL.parse_document(defs + """
-            workflow w {
-                Car c = Car {
-                    make: "Toyota",
-                    model: "Camry",
-                    odometer: 139000,
-                    owner: Person {
-                        name: "Mario"
-                    }
-                }
-            }
-        """)
-        with self.assertRaises(WDL.Error.StaticTypeMismatch):
             doc.typecheck()

--- a/tests/test_2calls.py
+++ b/tests/test_2calls.py
@@ -537,3 +537,116 @@ class TestCalls(unittest.TestCase):
         self.assertEqual(str(doc.workflow.effective_outputs.resolve("hello.message")), "Array[String]")
         self.assertEqual(str(doc.workflow.effective_outputs.resolve("hello2.message")), "Array[String]?")
         self.assertEqual(str(doc.workflow.effective_outputs.resolve("hello3.message")), "String")
+
+    def test_new_struct_literals(self):
+        txt = r"""
+        version development
+        struct Person {
+            String name
+            Int age
+        }
+        struct Car {
+            String make
+            String model
+            Int odometer
+            Person owner
+        }
+        workflow garage {
+            call drive {
+                input:
+                car = Car {
+                    make: "Toyota",
+                    model: "Camry",
+                    odometer: 139000,
+                    owner: Person {
+                        name: "Mario",
+                        age: 42
+                    }
+                },
+                miles = 3000
+            }
+            output {
+                Car car = Car {
+                    make: drive.car_out.make,
+                    model: drive.car_out.model,
+                    odometer: drive.car_out.odometer,
+                    owner: Person {
+                        name: "Luigi",
+                        age: 39
+                    }
+                }
+            }
+        }
+        task drive {
+            input {
+                Car car
+                Int miles
+            }
+            command {}
+            output {
+                Car car_out = Car {
+                    make: car.make,
+                    model: car.model,
+                    odometer: car.odometer + miles,
+                    owner: car.owner
+                }
+            }
+        }
+        """
+        WDL.parse_document(txt).typecheck
+
+        defs = R"""
+        version development
+        struct Person {
+            String name
+            Int age
+        }
+        struct Car {
+            String make
+            String model
+            Int odometer
+            Person owner
+        }
+        """
+        
+        doc = WDL.parse_document(defs + """
+            workflow w {
+                Person p = Car {
+                    name: "Mario",
+                    age: 42
+                }
+            }
+        """)
+        with self.assertRaises(WDL.Error.NoSuchMember):
+            doc.typecheck()
+
+        doc = WDL.parse_document(defs + """
+            workflow w {
+                Car c = Car {
+                    make: "Toyota",
+                    model: "Camry",
+                    odometer: 139000,
+                    owner: Bogus {
+                        name: "Mario",
+                        age: 42
+                    }
+                }
+            }
+        """)
+        with self.assertRaises(WDL.Error.InvalidType):
+            doc.typecheck()
+
+        doc = WDL.parse_document(defs + """
+            workflow w {
+                Car c = Car {
+                    make: "Toyota",
+                    model: "Camry",
+                    odometer: 139000,
+                    owner: Person {
+                        name: "Mario"
+                    }
+                }
+            }
+        """)
+        with self.assertRaises(WDL.Error.StaticTypeMismatch):
+            doc.typecheck()

--- a/tests/test_7runner.py
+++ b/tests/test_7runner.py
@@ -346,7 +346,7 @@ class TestNoneLiteral(RunnerTestCase):
             output {
                 Boolean b1 = defined(flag1)
                 Boolean b2 = defined(flag2)
-                Car c = object {
+                Car c = Car {
                     make: "One",
                     model: None
                 }


### PR DESCRIPTION
Implements #113 https://github.com/openwdl/wdl/pull/297

New struct literal syntax similar to the old `object` syntax, but improves static typechecking by including the intended struct type name in the literal. So we can typecheck the members before later coercing them to a struct declaration/input. (The `object` syntax still works.)

Some detailed surgery to make declared struct types available to `Expr` typechecking logic, where before they'd only been needed in `Tree`.
