### PR TITLE
[WDL 2.0] runtime & hints

### DIFF
--- a/WDL/CLI.py
+++ b/WDL/CLI.py
@@ -971,6 +971,7 @@ def runner_input_help(target):
         ans.append(bold(f"  {str(b.value.type)} {b.name}"))
         add_wrapped_parameter_meta(target, b.name, ans)
     optional_inputs = target.available_inputs.subtract(target.required_inputs)
+    optional_inputs = optional_inputs.filter(lambda b: not b.value.name.startswith("_"))
     if target.inputs is None:
         # if the target doesn't have an input{} section (pre WDL 1.0), exclude
         # declarations bound to a non-constant expression (heuristic)

--- a/WDL/Env.py
+++ b/WDL/Env.py
@@ -105,6 +105,16 @@ class Bindings(Generic[T]):
                 return b
         raise KeyError()
 
+    def get(self, name: str, default: Optional[T] = None) -> Optional[T]:
+        """
+        Look up a bound value by name, returning the default value or ``None`` if there's no such
+        binding.
+        """
+        try:
+            return self.resolve_binding(name).value
+        except KeyError:
+            return default
+
     def resolve(self, name: str) -> T:
         """
         Look up a bound value by name. Equivalently, ``env[name]``

--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -316,6 +316,11 @@ class Task(SourceNode):
         Each input is at the top level of the Env, with no namespace.
         """
         ans = Env.Bindings()
+
+        if self.effective_wdl_version not in ["draft-2", "1.0"]:
+            # synthetic placeholder to expose runtime & hints overrides
+            ans = ans.bind("_runtime", Decl(self.pos, Type.Any(), "_runtime"))
+
         for decl in reversed(self.inputs if self.inputs is not None else self.postinputs):
             ans = ans.bind(decl.name, decl)
         return ans
@@ -333,7 +338,7 @@ class Task(SourceNode):
         for b in reversed(list(self.available_inputs)):
             assert isinstance(b, Env.Binding)
             d: Decl = b.value
-            if d.expr is None and d.type.optional is False:
+            if d.expr is None and d.type.optional is False and not d.name.startswith("_"):
                 ans = Env.Bindings(b, ans)
         return ans
 

--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -261,6 +261,10 @@ class Task(SourceNode):
     """:type: Dict[str,WDL.Expr.Base]
 
     ``runtime{}`` section, with keys and corresponding expressions to be evaluated"""
+    hints: Dict[str, Any]
+    """:type: Dict[str, Any]
+
+    ``hints{}`` section as a JSON-like dict"""
     meta: Dict[str, Any]
     """:type: Dict[str,Any]
 
@@ -283,6 +287,7 @@ class Task(SourceNode):
         parameter_meta: Dict[str, Any],
         runtime: Dict[str, Expr.Base],
         meta: Dict[str, Any],
+        hints: Dict[str, Any],
     ) -> None:
         super().__init__(pos)
         self.name = name
@@ -293,6 +298,7 @@ class Task(SourceNode):
         self.parameter_meta = parameter_meta
         self.runtime = runtime
         self.meta = meta
+        self.hints = hints
         self.effective_wdl_version = "1.0"  # overridden by Document.__init__
         # TODO: enforce validity constraints on parameter_meta and runtime
         # TODO: if the input section exists, then all postinputs decls must be

--- a/WDL/__init__.py
+++ b/WDL/__init__.py
@@ -242,17 +242,33 @@ def values_from_json(
             key2 = key
             if namespace and key.startswith(namespace):
                 key2 = key[len(namespace) :]
-            if key2 not in available:
-                # attempt to simplify <call>.<subworkflow>.<input>
-                key2parts = key2.split(".")
-                if len(key2parts) == 3 and key2parts[0] and key2parts[1] and key2parts[2]:
-                    key2 = ".".join([key2parts[0], key2parts[2]])
-            try:
+
+            ty = None
+            if key2 in available:
                 ty = available[key2]
-            except KeyError:
+            else:
+                key2parts = key2.split(".")
+
+                runtime_idx = next(
+                    (i for i, term in enumerate(key2parts) if term in ("runtime", "hints")), -1
+                )
+                if (
+                    runtime_idx >= 0
+                    and len(key2parts) > (runtime_idx + 1)
+                    and ".".join(key2parts[:runtime_idx] + ["_runtime"]) in available
+                ):
+                    # allow arbitrary keys for runtime/hints
+                    ty = Type.Any()
+                elif len(key2parts) == 3 and key2parts[0] and key2parts[1] and key2parts[2]:
+                    # attempt to simplify <call>.<subworkflow>.<input> from old Cromwell JSON
+                    key2 = ".".join([key2parts[0], key2parts[2]])
+                    if key2 in available:
+                        ty = available[key2]
+            if not ty:
                 raise Error.InputError("unknown input/output: " + key) from None
             if isinstance(ty, Tree.Decl):
                 ty = ty.type
+
             assert isinstance(ty, Type.Base)
             try:
                 ans = ans.bind(key2, Value.from_json(ty, values_json[key]))

--- a/WDL/_grammar.py
+++ b/WDL/_grammar.py
@@ -313,6 +313,7 @@ task: "task" CNAME "{" task_section* command task_section* "}"
              | output_decls
              | meta_section
              | runtime_section
+             | hints_section
              | any_decl -> noninput_decl
 
 tasks: task*
@@ -326,7 +327,7 @@ placeholder: expr
 ?command: command1 | command2
 
 // meta/parameter_meta sections (effectively JSON)
-meta_object: "{" [meta_kv (","? meta_kv)*] "}"
+meta_object: "{" [meta_kv (","? meta_kv)*] ","? "}"
 meta_kv: CNAME ":" meta_value
 ?meta_value: literal | string_literal
            | meta_object
@@ -336,6 +337,7 @@ meta_kv: CNAME ":" meta_value
 // task runtime section (key-expression pairs)
 runtime_section: "runtime" "{" [runtime_kv (","? runtime_kv)*] "}"
 runtime_kv: CNAME ":" expr
+hints_section: "hints" meta_object
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // decl
@@ -479,7 +481,7 @@ COMMENT: /[ \t]*/ "#" /[^\r\n]*/
 %ignore COMMENT
 """
 keywords["development"] = set(
-    "Array Directory File Float Int Map None Pair String alias as call command else false if import input left meta object output parameter_meta right runtime scatter struct task then true workflow".split(
+    "Array Directory File Float Int Map None Pair String alias as call command else false hints if import input left meta object output parameter_meta right runtime scatter struct task then true workflow".split(
         " "
     )
 )

--- a/WDL/_parser.py
+++ b/WDL/_parser.py
@@ -363,6 +363,9 @@ class _DocTransformer(_ExprTransformer):
             d[k] = v
         return {"runtime": d}
 
+    def hints_section(self, items, meta):
+        return {"hints": items[0]}
+
     def task(self, items, meta):
         d = {"noninput_decls": []}
         for item in items:
@@ -391,6 +394,7 @@ class _DocTransformer(_ExprTransformer):
             d.get("parameter_meta", {}),
             d.get("runtime", {}),
             d.get("meta", {}),
+            d.get("hints", {}),
         )
 
     def tasks(self, items, meta):

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -429,8 +429,12 @@ def _eval_task_runtime(
     logger.debug(_("runtime values", **dict((key, str(v)) for key, v in runtime_values.items())))
     ans = {}
 
-    if "docker" in runtime_values:
-        ans["docker"] = runtime_values["docker"].coerce(Type.String()).value
+    docker_value = runtime_values.get("docker", runtime_values.get("container"))
+    if docker_value:
+        if isinstance(docker_value, Value.Array) and len(docker_value.value):
+            # TODO: ask TaskContainer to choose preferred candidate
+            docker_value = docker_value.value[0]
+        ans["docker"] = docker_value.coerce(Type.String()).value
 
     host_limits = container.__class__.detect_resource_limits(cfg, logger)
     if "cpu" in runtime_values:

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -167,7 +167,7 @@ def run_local_task(
                 # evaluate runtime fields
                 stdlib = InputStdLib(task.effective_wdl_version, logger, container)
                 container.runtime_values = _eval_task_runtime(
-                    cfg, logger, task, container, container_env, stdlib
+                    cfg, logger, task, posix_inputs, container, container_env, stdlib
                 )
 
                 # interpolate command
@@ -409,6 +409,7 @@ def _eval_task_runtime(
     cfg: config.Loader,
     logger: logging.Logger,
     task: Tree.Task,
+    inputs: Env.Bindings[Value.Base],
     container: TaskContainer,
     env: Env.Bindings[Value.Base],
     stdlib: StdLib.Base,
@@ -421,8 +422,10 @@ def _eval_task_runtime(
             runtime_values[key] = Value.Int(v)
         else:
             raise Error.InputError(f"invalid default runtime setting {key} = {v}")
-    for key, expr in task.runtime.items():
+    for key, expr in task.runtime.items():  # evaluate expressions in source code
         runtime_values[key] = expr.eval(env, stdlib)
+    for b in inputs.enter_namespace("runtime"):
+        runtime_values[b.name] = b.value  # input overrides
     logger.debug(_("runtime values", **dict((key, str(v)) for key, v in runtime_values.items())))
     ans = {}
 

--- a/WDL/runtime/workflow.py
+++ b/WDL/runtime/workflow.py
@@ -371,7 +371,14 @@ class StateMachine:
             assert isinstance(job.node.callee, (Tree.Task, Tree.Workflow))
             callee_inputs = job.node.callee.available_inputs
             call_inputs = call_inputs.map(
-                lambda b: Env.Binding(b.name, b.value.coerce(callee_inputs[b.name].type))
+                lambda b: Env.Binding(
+                    b.name,
+                    (
+                        b.value.coerce(callee_inputs[b.name].type)
+                        if b.name in callee_inputs
+                        else b.value
+                    ),
+                )
             )
             # check input files against whitelist
             disallowed_filenames = _fspaths(call_inputs) - self.filename_whitelist

--- a/tests/test_7runner.py
+++ b/tests/test_7runner.py
@@ -792,6 +792,9 @@ class MiscRegressionTests(RunnerTestCase):
             output {
                 Array[File] files_out = glob("files_out/*")
             }
+            runtime {
+                docker: ["ubuntu:20.04"]
+            }
         }
         """
 


### PR DESCRIPTION
Provisionally implements https://github.com/openwdl/wdl/pull/315

* Add task `hints` section
  * Modeled on meta sections, with nested literals but no expressions
  * Unused for now
* Allow JSON/CLI input overrides for runtime values
* Alias `runtime.container` to `runtime.docker`, and accept arrays (unused for now)