### PR TITLE
macOS unit test suite

### DIFF
--- a/WDL/runtime/task_container.py
+++ b/WDL/runtime/task_container.py
@@ -597,11 +597,14 @@ class SwarmContainer(TaskContainer):
             return exit_code
         finally:
             if svc:
-                try:
-                    svc.remove()
-                except:
-                    logger.exception("failed to remove docker service")
-                self.chown(logger, client, exit_code == 0)
+                for attempt in range(3):
+                    try:
+                        svc.remove()
+                        break
+                    except:
+                        logger.exception("failed to remove docker service")
+                        time.sleep(2)
+            self.chown(logger, client, exit_code == 0)
             try:
                 client.close()
             except:

--- a/tests/test_7runner.py
+++ b/tests/test_7runner.py
@@ -7,6 +7,7 @@ import shutil
 import json
 import time
 import docker
+import platform
 from testfixtures import log_capture
 from .context import WDL
 
@@ -160,7 +161,7 @@ class TestDirectoryIO(RunnerTestCase):
 
         assert len(outp["d_out"]) == 2
         assert os.path.islink(outp["d_out"][0])
-        assert os.path.realpath(outp["d_out"][0]) == os.path.join(self._dir, "d")
+        assert os.path.realpath(outp["d_out"][0]) == os.path.realpath(os.path.join(self._dir, "d"))
         assert os.path.isdir(outp["d_out"][1])
         assert os.path.islink(outp["d_out"][1])
         assert os.path.basename(outp["d_out"][1]) == "outdir"
@@ -173,7 +174,7 @@ class TestDirectoryIO(RunnerTestCase):
         outp = self._run(wdl, {"d": os.path.join(self._dir, "d")}, cfg=cfg)
         assert len(outp["d_out"]) == 2
         assert not os.path.islink(outp["d_out"][0])
-        assert os.path.realpath(outp["d_out"][0]) != os.path.join(self._dir, "d")
+        assert os.path.realpath(outp["d_out"][0]) != os.path.realpath(os.path.join(self._dir, "d"))
         assert os.path.isdir(outp["d_out"][1])
         assert not os.path.islink(outp["d_out"][1])
         assert os.path.basename(outp["d_out"][1]) == "outdir"
@@ -712,6 +713,7 @@ class MiscRegressionTests(RunnerTestCase):
         outp = self._run(wdl, {"file": os.path.join(self._dir, "alice.txt")})
         self.assertEqual(outp["t.out"], ["Alice", "Alice"])
 
+    @unittest.skipIf(platform.system() == "Darwin", "FIXME on macOS")
     def test_weird_filenames(self):
         chars = [c for c in (chr(i) for i in range(1,256)) if c not in ('/')]
         filenames = []

--- a/tests/test_7runner.py
+++ b/tests/test_7runner.py
@@ -713,7 +713,6 @@ class MiscRegressionTests(RunnerTestCase):
         outp = self._run(wdl, {"file": os.path.join(self._dir, "alice.txt")})
         self.assertEqual(outp["t.out"], ["Alice", "Alice"])
 
-    @unittest.skipIf(platform.system() == "Darwin", "FIXME on macOS")
     def test_weird_filenames(self):
         chars = [c for c in (chr(i) for i in range(1,256)) if c not in ('/')]
         filenames = []
@@ -722,6 +721,8 @@ class MiscRegressionTests(RunnerTestCase):
                 filenames.append(c)
             filenames.append(c + ''.join(random.choices(chars,k=11)))
         assert filenames == list(sorted(filenames))
+        if platform.system() == "Darwin":  # macOS is case-insensitive
+            filenames = list(set(fn.lower() for fn in filenames))
         filenames.append('ThisIs{{AVeryLongFilename }}abc...}}xzy1234567890!@{{నేనుÆды.test.ext')
 
         inputs = {"files": []}


### PR DESCRIPTION
Tweaks allowing `make unit_tests` to pass on macOS (locally with Docker for Mac, which isn't available in CI)

The integration/CLI tests still need work