### PR TITLE
[WDL 1.1] input overrides for task runtime values

### DIFF
--- a/WDL/Env.py
+++ b/WDL/Env.py
@@ -113,6 +113,16 @@ class Bindings(Generic[T]):
         """
         return self.resolve_binding(name).value
 
+    def get(self, name: str, default: Optional[T] = None) -> Optional[T]:
+        """
+        Look up a bound value by name, returning the default value or ``None`` if there's no such
+        binding.
+        """
+        try:
+            return self.resolve(name)
+        except KeyError:
+            return default
+
     def __getitem__(self, name: str) -> T:
         return self.resolve(name)
 

--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -312,6 +312,11 @@ class Task(SourceNode):
         Each input is at the top level of the Env, with no namespace.
         """
         ans = Env.Bindings()
+
+        if self.effective_wdl_version not in ("draft-2", "1.0"):
+            # synthetic placeholder to expose runtime overrides
+            ans = ans.bind("_runtime", Decl(self.pos, Type.Any(), "_runtime"))
+
         for decl in reversed(self.inputs if self.inputs is not None else self.postinputs):
             ans = ans.bind(decl.name, decl)
         return ans
@@ -329,7 +334,7 @@ class Task(SourceNode):
         for b in reversed(list(self.available_inputs)):
             assert isinstance(b, Env.Binding)
             d: Decl = b.value
-            if d.expr is None and d.type.optional is False:
+            if d.expr is None and d.type.optional is False and not d.name.startswith("_"):
                 ans = Env.Bindings(b, ans)
         return ans
 
@@ -1203,13 +1208,11 @@ class Workflow(SourceNode):
                 # into the decl name with a ., which is a weird corner
                 # case!
                 synthetic_output_name = ".".join(output_ident)
-                try:
-                    ty = self._type_env.resolve(synthetic_output_name)
-                except KeyError:
+                ty = self._type_env.get(synthetic_output_name)
+                if not ty:
                     raise Error.UnknownIdentifier(
                         Expr.Ident(self._output_idents_pos, synthetic_output_name)
                     ) from None
-                assert isinstance(ty, Type.Base)
                 output_ident_decls.append(
                     Decl(
                         self.pos,

--- a/WDL/_grammar.py
+++ b/WDL/_grammar.py
@@ -326,7 +326,7 @@ placeholder: expr
 ?command: "command" (command1 | command2)
 
 // meta/parameter_meta sections (effectively JSON)
-meta_object: "{" [meta_kv (","? meta_kv)*] "}"
+meta_object: "{" [meta_kv (","? meta_kv)*] ","? "}"
 meta_kv: CNAME ":" meta_value
 ?meta_value: literal | string_literal
            | meta_object

--- a/WDL/runtime/workflow.py
+++ b/WDL/runtime/workflow.py
@@ -370,7 +370,14 @@ class StateMachine:
             assert isinstance(job.node.callee, (Tree.Task, Tree.Workflow))
             callee_inputs = job.node.callee.available_inputs
             call_inputs = call_inputs.map(
-                lambda b: Env.Binding(b.name, b.value.coerce(callee_inputs[b.name].type))
+                lambda b: Env.Binding(
+                    b.name,
+                    (
+                        b.value.coerce(callee_inputs[b.name].type)
+                        if b.name in callee_inputs
+                        else b.value
+                    ),
+                )
             )
             # check input files against whitelist
             disallowed_filenames = _fspaths(call_inputs) - self.filename_whitelist

--- a/tests/runner.t
+++ b/tests/runner.t
@@ -11,7 +11,7 @@ source tests/bash-tap/bash-tap-bootstrap
 export PYTHONPATH="$SOURCE_DIR:$PYTHONPATH"
 miniwdl="python3 -m WDL"
 
-plan tests 72
+plan tests 74
 
 $miniwdl run_self_test
 is "$?" "0" "run_self_test"
@@ -210,7 +210,7 @@ is "$?" "0" "failer2000 try3 iwuzhere"
 
 
 cat << 'EOF' > multitask.wdl
-version 1.0
+version development
 workflow multi {
     call first
 }
@@ -227,16 +227,20 @@ task first {
 task second {
     command {
         echo -n two
+        cp /etc/issue issue
     }
     output {
         String msg = read_string(stdout())
+        File issue = "issue"
     }
 }
 EOF
 
-$miniwdl run multitask.wdl --task second
+$miniwdl run multitask.wdl runtime.docker=ubuntu:20.10 --task second
 is "$?" "0" "multitask"
 is "$(jq -r '.["second.msg"]' _LAST/outputs.json)" "two" "multitask stdout & _LAST"
+grep -q 20.10 _LAST/out/issue/issue
+is "$?" "0" "override runtime.docker"
 
 cat << 'EOF' > mv_input_file.wdl
 version 1.0
@@ -269,6 +273,7 @@ workflow w {
     }
     output {
         Int dsz = round(size(t.files))
+        File issue = t.issue
     }
 }
 task t {
@@ -276,11 +281,13 @@ task t {
         Directory d
     }
     command <<<
+        cp /etc/issue issue
         mkdir outdir
         find ~{d} -type f | xargs -i{} cp {} outdir/
     >>>
     output {
         Array[File] files = glob("outdir/*")
+        File issue = "issue"
     }
 }
 EOF
@@ -288,9 +295,11 @@ EOF
 mkdir -p indir/subdir
 echo alice > indir/alice.txt
 echo bob > indir/subdir/bob.txt
-$miniwdl run dir_io.wdl d=indir
+$miniwdl run dir_io.wdl d=indir t.runtime.docker=ubuntu:20.10
 is "$?" "0" "directory input"
 is `jq -r '.["w.dsz"]' _LAST/outputs.json` "10" "use of directory input"
+grep -q 20.10 _LAST/out/issue/issue
+is "$?" "0" "override t.runtime.docker"
 
 cat << 'EOF' > uri_inputs.json
 {


### PR DESCRIPTION
Subset of #456 excluding 'hints' (which didn't make it into WDL 1.1)