### PR TITLE
exapt squote() to provide secure shell-quoting

### DIFF
--- a/WDL/StdLib.py
+++ b/WDL/StdLib.py
@@ -3,6 +3,7 @@ import math
 import os
 import json
 import tempfile
+import shlex
 from typing import List, Tuple, Callable, BinaryIO, Optional
 from abc import ABC, abstractmethod
 import regex
@@ -140,7 +141,9 @@ class Base:
             self.min = _ArithmeticOperator("min", lambda l, r: min(l, r))
             self.max = _ArithmeticOperator("max", lambda l, r: max(l, r))
             self.quote = _Quote()
-            self.squote = _Quote(squote=True)
+            self.squote = (
+                _Quote(squote=True) if self.wdl_version != "development" else _ShellQuote()
+            )
             self.keys = _Keys()
             self.as_map = _AsMap()
             self.as_pairs = _AsPairs()
@@ -1012,7 +1015,6 @@ class _Suffix(EagerFunction):
 class _Quote(EagerFunction):
     # t array -> string array
     # if input array is nonempty then so is output
-    # Append a suffix to every element within the array
 
     def __init__(self, squote: bool = False) -> None:
         if squote:
@@ -1025,7 +1027,6 @@ class _Quote(EagerFunction):
             raise Error.WrongArity(expr, 1)
         expr.arguments[0].typecheck(Type.Array(Type.String()))
         arg0ty = expr.arguments[0].type
-        nonempty = isinstance(arg0ty, Type.Array) and arg0ty.nonempty
         return Type.Array(
             Type.String(), nonempty=(isinstance(arg0ty, Type.Array) and arg0ty.nonempty)
         )
@@ -1038,6 +1039,39 @@ class _Quote(EagerFunction):
                 for s in arguments[0].value
             ],
         )
+
+
+class _ShellQuote(EagerFunction):
+    # t -> string or t array -> string array
+
+    def infer_type(self, expr: "Expr.Apply") -> Type.Base:
+        if len(expr.arguments) != 1:
+            raise Error.WrongArity(expr, 1)
+        if not isinstance(expr.arguments[0].type, Type.Array):
+            expr.arguments[0].typecheck(Type.String(optional=True))
+            return Type.String()
+        expr.arguments[0].typecheck(Type.Array(Type.String(optional=True), optional=True))
+        arg0ty = expr.arguments[0].type
+        return Type.Array(
+            Type.String(), nonempty=(isinstance(arg0ty, Type.Array) and arg0ty.nonempty)
+        )
+
+    def _call_eager(self, expr: "Expr.Apply", arguments: List[Value.Base]) -> Value.Base:
+        ty = self.infer_type(expr)
+        if isinstance(ty, Type.String):
+            return Value.String(self._shellquote(arguments[0].coerce(Type.String()).value))
+        assert isinstance(ty, Type.Array)
+        return Value.Array(
+            Type.String(),
+            [
+                Value.String(self._shellquote(s.coerce(Type.String()).value))
+                for s in arguments[0].value
+            ],
+        )
+
+    def _shellquote(self, s: str) -> str:
+        q = shlex.quote(s)
+        return q if q != s else ("'" + s + "'")
 
 
 class _Keys(EagerFunction):

--- a/tests/test_5stdlib.py
+++ b/tests/test_5stdlib.py
@@ -1079,23 +1079,23 @@ class TestStdLib(unittest.TestCase):
 
     def test_squote(self):
         outputs = self._test_task(R"""
-        version development
+        version 1.1
         task test_squote {
             command {}
             output {
-                Array[String] arguments = ["foo","bar","baz"]
-                Array[String] quoted_args = squote(arguments) # ["'foo'","'bar'","'baz'"]
+                Array[String] arguments = ["foo","bar","baz'"]
+                Array[String] quoted_args = squote(arguments) # ["'foo'","'bar'","'baz''"]
             }
         }
         """)
-        # Check to make sure each element has be quoted appropriately
+        # Check to make sure each element has been quoted appropriately
         self.assertEqual(outputs, {
-            "arguments": ["foo","bar","baz"],
-            "quoted_args": ["'foo'","'bar'","'baz'"]
+            "arguments": ["foo","bar","baz'"],
+            "quoted_args": ["'foo'","'bar'","'baz''"]
         })
 
         outputs = self._test_task(R"""
-        version development
+        version 1.1
         task test_squote {
             command {}
             output {
@@ -1113,7 +1113,7 @@ class TestStdLib(unittest.TestCase):
 
         # Check invalid type does not work
         outputs = self._test_task(R"""
-        version development
+        version 1.1
         task test_squote {
             command {}
             output {
@@ -1122,6 +1122,39 @@ class TestStdLib(unittest.TestCase):
             }
         }
         """,expected_exception=WDL.Error.StaticTypeMismatch)
+
+    def test_shellquote(self):
+        outputs = self._test_task(R"""
+        version development
+        task test_squote {
+            command {}
+            output {
+                Array[String?] arguments = ["foo","bar","baz'", None]
+                Array[String] quoted_args = squote(arguments)
+            }
+        }
+        """)
+        # Check to make sure each element has been quoted appropriately
+        self.assertEqual(outputs, {
+            "arguments": ["foo","bar","baz'", None],
+            "quoted_args": ["'foo'","'bar'",""" 'baz'"'"'' """.strip(), "''"]
+        })
+
+        outputs = self._test_task(R"""
+        version development
+        task test_squote {
+            command {}
+            output {
+                String quoted = squote(1)
+                String quoted2 = squote("so'wl'chu'")
+            }
+        }
+        """)
+
+        self.assertEqual(outputs, {
+            "quoted": "'1'",
+            "quoted2": """ 'so'"'"'wl'"'"'chu'"'"'' """.strip()
+        })
 
     def test_keys(self):
         outputs = self._test_task(R"""


### PR DESCRIPTION
#493

Applies to `version development` only. The `squote()` function, in addition to prepending and appending single-quote marks, uses Python's [`shlex.quote()`](https://github.com/python/cpython/blob/6f37ebc61e9e0d13bcb1a2ddb7fc9723c04b6372/Lib/shlex.py#L323-L334) to furthermore escape any single-quote marks that may be embedded in the value. It accepts individual string values as well as arrays, with corresponding polymorphic return type.