### PR TITLE
prototype runtime.autoEnv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@
 #       --rm -it miniwdl
 # or append 'bash' to that to enter interactive shell
 
-# start with ubuntu:18.04 plus some apt packages
-FROM ubuntu:18.04 as deps
+# start with ubuntu:20.04 plus some apt packages
+FROM ubuntu:20.04 as deps
 ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8
 RUN apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -qq install -y \

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -511,6 +511,19 @@ def _eval_task_runtime(
                 task.runtime["returnCodes"], "invalid setting of runtime.returnCodes"
             )
 
+    if runtime_values.get("autoEnv", Value.Null()).value:
+        logger.warning("runtime.autoEnv is an experimental extension, subject to change")
+        auto_env = {}
+        for b in env:
+            assert b.name not in auto_env
+            if isinstance(
+                b.value,
+                (Value.String, Value.Int, Value.Float, Value.File, Value.Directory, Value.Boolean),
+            ):
+                auto_env[b.name] = b.value.coerce(Type.String()).value
+        logger.debug(_("runtime.autoEnv", **auto_env))
+        ans["environment"] = auto_env
+
     if ans:
         logger.info(_("effective runtime", **ans))
     unused_keys = list(

--- a/WDL/runtime/task_container.py
+++ b/WDL/runtime/task_container.py
@@ -559,6 +559,9 @@ class SwarmContainer(TaskContainer):
                 "groups": groups,
                 "labels": {"miniwdl_run_id": self.run_id},
                 "container_labels": {"miniwdl_run_id": self.run_id},
+                "env": [
+                    f"{k}={v}" for (k, v) in self.runtime_values.get("environment", {}).items()
+                ],
             }
             kwargs.update(self.create_service_kwargs or {})
             logger.debug(_("docker create service kwargs", **kwargs))


### PR DESCRIPTION
Experimental feature: if the task runtime section declares `autoEnv: true` then WDL declarations with atomic types are automatically propagated to environment variables in the task container. 

(atomic types: String, File, Directory, Int, Float, Boolean. Compound types can be passed this way via an intermediate String/File using `sep`, `write_lines`, `write_json`, or the like)