### PR TITLE
improve user-visibility of captured task stdout

### DIFF
--- a/WDL/runtime/error.py
+++ b/WDL/runtime/error.py
@@ -20,14 +20,26 @@ class CommandFailed(_RuntimeError):
     Path to a file containing the task's standard error
     """
 
-    # pyre-ignore
-    def __init__(self, exit_status: int, stderr_file: str, message: str = "", **kwargs) -> None:
+    stdout_file: str
+    """
+    Path to a file containing the task's standard output
+    """
+
+    def __init__(
+        self,
+        exit_status: int,
+        stderr_file: str,
+        stdout_file: str,
+        message: str = "",
+        **kwargs,  # pyre-ignore
+    ) -> None:
         oom_hint = ", a possible indication that it ran out of memory" if exit_status == 137 else ""
         super().__init__(
             message or f"task command failed with exit status {exit_status}{oom_hint}", **kwargs
         )
         self.exit_status = exit_status
         self.stderr_file = stderr_file
+        self.stdout_file = stdout_file
 
 
 class Terminated(_RuntimeError):
@@ -131,6 +143,7 @@ def error_json(exn: BaseException, cause: Optional[Exception] = None) -> Dict[st
     elif isinstance(exn, CommandFailed):
         info["exit_status"] = getattr(exn, "exit_status")
         info["stderr_file"] = getattr(exn, "stderr_file")
+        info["stdout_file"] = getattr(exn, "stdout_file")
     elif str(exn):
         info["message"] = str(exn)
     if hasattr(exn, "job_id"):

--- a/WDL/runtime/task_container.py
+++ b/WDL/runtime/task_container.py
@@ -223,11 +223,20 @@ class TaskContainer(ABC):
 
                 if not self.success_exit_code(exit_code):
                     raise CommandFailed(
-                        exit_code, self.host_stderr_txt(), more_info=self.failure_info
+                        exit_code,
+                        self.host_stderr_txt(),
+                        self.host_stdout_txt(),
+                        more_info=self.failure_info,
                     ) if not terminating() else Terminated()
 
     @abstractmethod
     def _run(self, logger: logging.Logger, terminating: Callable[[], bool], command: str) -> int:
+        """
+        Implementation-specific: run command in container & return exit status.
+
+        Take care to write informative log messages for any backend-specific errorsd. Miniwdl's
+        outer exception handler will only emit a brief, generic log message about the run failing.
+        """
         # run command in container & return exit status
         raise NotImplementedError()
 


### PR DESCRIPTION
- when task command fails, exception log reports stdout_file as well as stderr_file
- when task command succeeds, with nonempty stdout that isn't used in WDL outputs, note this in the log (and suggest `>&2`)