### PR TITLE
Support forwarding env vars from miniwdl's env to tasks

### DIFF
--- a/WDL/CLI.py
+++ b/WDL/CLI.py
@@ -540,6 +540,12 @@ def fill_run_subparser(subparsers):
     group.add_argument("--runtime-cpu-max", metavar="N", type=int, default=None, help=SUPPRESS)
     group.add_argument("--runtime-memory-max", metavar="N", type=str, default=None, help=SUPPRESS)
     group.add_argument(
+        "--runtime-passthru-envvars",
+        nargs="+",
+        type=str,
+        help="""List of environment variables to pass through from miniwdl's environment to task environment""",
+    )
+    group.add_argument(
         "--runtime-defaults",
         metavar="JSON",
         type=str,
@@ -583,6 +589,7 @@ def runner(
     cfg=None,
     runtime_cpu_max=None,
     runtime_memory_max=None,
+    runtime_passthru_envvars=[],
     runtime_defaults=None,
     max_tasks=None,
     copy_input_files=False,
@@ -661,6 +668,8 @@ def runner(
                     cfg_overrides["task_runtime"]["defaults"] = infile.read()
         if runtime_cpu_max is not None:
             cfg_overrides["task_runtime"]["cpu_max"] = runtime_cpu_max
+        if runtime_passthru_envvars:
+            cfg_overrides["task_runtime"]["passthru_envvars"] = runtime_passthru_envvars
         if runtime_memory_max is not None:
             runtime_memory_max = (
                 -1 if runtime_memory_max.strip() == "-1" else parse_byte_size(runtime_memory_max)

--- a/WDL/runtime/config_templates/default.cfg
+++ b/WDL/runtime/config_templates/default.cfg
@@ -96,6 +96,11 @@ as_user = false
 # preferable to validate inputs before invoking miniwdl, if possible.)
 placeholder_regex = (.|\n)*
 
+# Environment variables that should be passed through from miniwdl's runtime env to task runtime env.
+# Use sparingly! This is primarily useful for passing in any env vars set by your compute platform
+# that are required by your application.
+passthru_envvars = []
+
 
 [download_cache]
 # When File or Directory inputs are given URIs to be downloaded, store the downloaded copy in a

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -530,6 +530,17 @@ def _eval_task_runtime(
                 task.runtime["returnCodes"], "invalid setting of runtime.returnCodes"
             )
 
+    if cfg["task_runtime"].get_list("passthru_envvars"):
+        logger.warning("passthru_envvars is an experimental extension, subject to change")
+        envvars = cfg["task_runtime"].get_list("passthru_envvars")
+        if "environment" not in ans:
+            ans["environment"] = {}
+        for varname in envvars:
+            try:
+                ans["environment"][varname] = os.environ[varname]
+            except KeyError:
+                pass  # Don't break if this env var isn't set
+
     if ans:
         logger.info(_("effective runtime", **ans))
     unused_keys = list(

--- a/WDL/runtime/task_container.py
+++ b/WDL/runtime/task_container.py
@@ -568,6 +568,9 @@ class SwarmContainer(TaskContainer):
                 "groups": groups,
                 "labels": {"miniwdl_run_id": self.run_id},
                 "container_labels": {"miniwdl_run_id": self.run_id},
+                "env": [
+                    f"{k}={v}" for (k, v) in self.runtime_values.get("environment", {}).items()
+                ],
             }
             kwargs.update(self.create_service_kwargs or {})
             logger.debug(_("docker create service kwargs", **kwargs))

--- a/tests/test_7runner.py
+++ b/tests/test_7runner.py
@@ -10,6 +10,7 @@ import docker
 import platform
 from testfixtures import log_capture
 from .context import WDL
+from unittest.mock import patch
 
 class RunnerTestCase(unittest.TestCase):
     """
@@ -984,3 +985,42 @@ class TestImplicitlyOptionalInputWithDefault(RunnerTestCase):
         self.assertEqual(outp["results"], ["AliceBas", "Bas"])
         outp = self._run(caller, {"a": "Alyssa"})
         self.assertEqual(outp["results"], ["Alyssa", None])
+
+
+class TestPassthruEnv(RunnerTestCase):
+    def test1(self):
+        wdl = """
+        version development
+        task t {
+            input {
+                String k1
+            }
+            command <<<
+                echo ~{k1}
+                echo "$TEST_ENV_VAR"
+                echo "$NOT_PASSED_IN_VAR"
+            >>>
+            output {
+                String out = read_string(stdout())
+            }
+            runtime {
+                docker: "ubuntu:20.04"
+            }
+        }
+        """
+        cfg = WDL.runtime.config.Loader(logging.getLogger(self.id()), [])
+        cfg.override({"task_runtime": {"passthru_envvars": ["TEST_ENV_VAR"]}})
+        with open(os.path.join(self._dir, "Alice"), mode="w") as outfile:
+            print("Alice", file=outfile)
+        env = {
+            "TEST_ENV_VAR": "passthru_test_success",
+            "NOT_PASSED_IN_VAR": "this shouldn't be passed in",
+        }
+        with patch.dict("os.environ", env):
+            out = self._run(wdl, {"k1": "stringvalue"}, cfg=cfg)
+        self.assertEqual(
+            out["out"],
+            """stringvalue
+passthru_test_success
+""",
+        )


### PR DESCRIPTION
<!---  Thank you for contributing to miniwdl! Please see the CONTRIBUTING.md guidelines and observe the PR checklist below. --->

### Motivation
We're running miniwdl as part of our AWS batch pipelines, and some of the tasks in our pipelines need to be able to fetch secrets from AWS Secrets Manager. In order for our tasks to be able to assume the correct role (the role associated with the Batch task), we need the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable forwarded from miniwdl's environment into the task's environment.

Since we have no control over the value of this environment variable, there's no way for us to specify it as an input to miniwdl. Many other compute environments pass important context via env vars to the containers they run, so I suspect this functionality will be useful beyond just AWS Batch.

### Approach
This PR allows users to specify a list of env vars that will be forwarded from miniwdl's execution environment into the environment of all containers launched via miniwdl.

### Checklist

<!--- You're welcome to open a draft PR to request guidance on testing or Pyre/Pylint problems. --->
- [x] Add appropriate test(s) to the automatic suite
- [x] Use `make pretty` to reformat the code with [black](https://github.com/python/black)
- [x] Use `make check` to statically check the code using [Pyre](https://pyre-check.org/) and [Pylint](https://www.pylint.org/)
- [x] Send PR from a dedicated branch without unrelated edits
- [x] Ensure compatibility with this project's MIT license
