### PR TITLE
add --env & config option to set values in all task environments

### DIFF
--- a/WDL/CLI.py
+++ b/WDL/CLI.py
@@ -685,7 +685,7 @@ def runner(
         cfg.log_all()
         if cfg["task_runtime"].get_dict("env"):
             logger.warning(
-                "--env is a non-standard side channel; tasks relying on it are probably not portable"
+                "--env is a non-standard side channel; relying on it is probably not portable"
             )
 
         # check root

--- a/WDL/CLI.py
+++ b/WDL/CLI.py
@@ -540,6 +540,12 @@ def fill_run_subparser(subparsers):
     group.add_argument("--runtime-cpu-max", metavar="N", type=int, default=None, help=SUPPRESS)
     group.add_argument("--runtime-memory-max", metavar="N", type=str, default=None, help=SUPPRESS)
     group.add_argument(
+        "--runtime-passthru-envvars",
+        nargs="+",
+        type=str,
+        help="""List of environment variables to pass through from miniwdl's environment to task environment""",
+    )
+    group.add_argument(
         "--runtime-defaults",
         metavar="JSON",
         type=str,
@@ -583,6 +589,7 @@ def runner(
     cfg=None,
     runtime_cpu_max=None,
     runtime_memory_max=None,
+    runtime_passthru_envvars=[],
     runtime_defaults=None,
     max_tasks=None,
     copy_input_files=False,
@@ -661,6 +668,8 @@ def runner(
                     cfg_overrides["task_runtime"]["defaults"] = infile.read()
         if runtime_cpu_max is not None:
             cfg_overrides["task_runtime"]["cpu_max"] = runtime_cpu_max
+        if runtime_passthru_envvars:
+            cfg_overrides["task_runtime"]["passthru_envvars"] = runtime_passthru_envvars
         if runtime_memory_max is not None:
             runtime_memory_max = (
                 -1 if runtime_memory_max.strip() == "-1" else parse_byte_size(runtime_memory_max)

--- a/WDL/CLI.py
+++ b/WDL/CLI.py
@@ -1119,13 +1119,7 @@ def runner_env_override(cfg, args):
             raise Error.InputError("invalid --env argument: " + item)
         name = item[: sep if sep >= 0 else len(item)]
         value = None
-        if sep == -1:
-            if name not in os.environ:
-                raise Error.InputError(
-                    f"environment variable {name} isn't defined to pass through;"
-                    f' check name or try --env "{name}=${name}" to tolerate'
-                )
-        else:
+        if sep != -1:
             value = item[sep + 1 :]
         env_override[name] = value
     return env_override

--- a/WDL/CLI.py
+++ b/WDL/CLI.py
@@ -540,12 +540,6 @@ def fill_run_subparser(subparsers):
     group.add_argument("--runtime-cpu-max", metavar="N", type=int, default=None, help=SUPPRESS)
     group.add_argument("--runtime-memory-max", metavar="N", type=str, default=None, help=SUPPRESS)
     group.add_argument(
-        "--runtime-passthru-envvars",
-        nargs="+",
-        type=str,
-        help="""List of environment variables to pass through from miniwdl's environment to task environment""",
-    )
-    group.add_argument(
         "--runtime-defaults",
         metavar="JSON",
         type=str,
@@ -556,6 +550,14 @@ def fill_run_subparser(subparsers):
         "--no-cache",
         action="store_true",
         help="override any configuration enabling cache lookup for call outputs & downloaded files",
+    )
+    group.add_argument(
+        "--env",
+        action="append",
+        metavar="VARNAME[=VALUE]",
+        type=str,
+        help="Environment variable to pass through to [or set outright in]"
+        " all task environments (portability warning: non-standard side channel)",
     )
     group.add_argument(
         "--copy-input-files",
@@ -589,7 +591,7 @@ def runner(
     cfg=None,
     runtime_cpu_max=None,
     runtime_memory_max=None,
-    runtime_passthru_envvars=[],
+    env=[],
     runtime_defaults=None,
     max_tasks=None,
     copy_input_files=False,
@@ -668,8 +670,8 @@ def runner(
                     cfg_overrides["task_runtime"]["defaults"] = infile.read()
         if runtime_cpu_max is not None:
             cfg_overrides["task_runtime"]["cpu_max"] = runtime_cpu_max
-        if runtime_passthru_envvars:
-            cfg_overrides["task_runtime"]["passthru_envvars"] = runtime_passthru_envvars
+        if env:
+            cfg_overrides["task_runtime"]["env"] = runner_env_override(cfg, env)
         if runtime_memory_max is not None:
             runtime_memory_max = (
                 -1 if runtime_memory_max.strip() == "-1" else parse_byte_size(runtime_memory_max)
@@ -681,6 +683,10 @@ def runner(
 
         cfg.override(cfg_overrides)
         cfg.log_all()
+        if cfg["task_runtime"].get_dict("env"):
+            logger.warning(
+                "--env is a non-standard side channel; tasks relying on it are probably not portable"
+            )
 
         # check root
         if not path_really_within((run_dir or os.getcwd()), cfg["file_io"]["root"]):
@@ -1103,6 +1109,26 @@ def runner_input_help(target):
         ans.append(bold(f"  {str(b.value)} {b.name}"))
     for line in ans:
         print(line, file=sys.stderr)
+
+
+def runner_env_override(cfg, args):
+    env_override = cfg["task_runtime"].get_dict("env")
+    for item in args:
+        sep = item.find("=")
+        if sep == 0:
+            raise Error.InputError("invalid --env argument: " + item)
+        name = item[: sep if sep >= 0 else len(item)]
+        value = None
+        if sep == -1:
+            if name not in os.environ:
+                raise Error.InputError(
+                    f"environment variable {name} isn't defined to pass through;"
+                    f' check name or try --env "{name}=${name}" to tolerate'
+                )
+        else:
+            value = item[sep + 1 :]
+        env_override[name] = value
+    return env_override
 
 
 def is_constant_expr(expr):

--- a/WDL/runtime/config_templates/default.cfg
+++ b/WDL/runtime/config_templates/default.cfg
@@ -97,11 +97,11 @@ as_user = false
 placeholder_regex = (.|\n)*
 # Set environment variable(s) in all task environments. The JSON object is keyed by environment
 # variable name. If an entry here is set to null, then miniwdl passes through the variable from its
-# own environment (where it must be defined). Any other value is used as a string.
+# own environment (if there defined). Any other value is used as a string.
 # --env (New in v1.2.2)
-# Warning: this is a non-standard side channel and tasks relying on it are probably not portable to
-# other WDL engines and/or compute platforms. Explicit WDL task inputs should usually be used
-# instead, except in a few cases like auth tokens for platform-specific tasks.
+# Warning: this is a non-standard side channel and relying on it is probably not portable to other
+# WDL engines and/or compute platforms. Explicit WDL task inputs are usually better, except for a
+# few cases like auth tokens for platform-specific tasks.
 env = {}
 
 

--- a/WDL/runtime/config_templates/default.cfg
+++ b/WDL/runtime/config_templates/default.cfg
@@ -96,6 +96,11 @@ as_user = false
 # preferable to validate inputs before invoking miniwdl, if possible.)
 placeholder_regex = (.|\n)*
 
+# Environment variables that should be passed through from miniwdl's runtime env to task runtime env.
+# Use sparingly! This is primarily useful for passing in any env vars set by your compute platform
+# that are required by your application.
+passthru_envvars = []
+
 
 [download_cache]
 # When File or Directory inputs are given URIs to be downloaded, store the downloaded copy in a

--- a/WDL/runtime/config_templates/default.cfg
+++ b/WDL/runtime/config_templates/default.cfg
@@ -95,11 +95,14 @@ as_user = false
 # line of defense against code injection into task command scripts. (As this is a blunt tool, it's
 # preferable to validate inputs before invoking miniwdl, if possible.)
 placeholder_regex = (.|\n)*
-
-# Environment variables that should be passed through from miniwdl's runtime env to task runtime env.
-# Use sparingly! This is primarily useful for passing in any env vars set by your compute platform
-# that are required by your application.
-passthru_envvars = []
+# Set environment variable(s) in all task environments. The JSON object is keyed by environment
+# variable name. If an entry here is set to null, then miniwdl passes through the variable from its
+# own environment (where it must be defined). Any other value is used as a string.
+# --env (New in v1.2.2)
+# Warning: this is a non-standard side channel and tasks relying on it are probably not portable to
+# other WDL engines and/or compute platforms. Explicit WDL task inputs should usually be used
+# instead, except in a few cases like auth tokens for platform-specific tasks.
+env = {}
 
 
 [download_cache]

--- a/WDL/runtime/config_templates/default.cfg
+++ b/WDL/runtime/config_templates/default.cfg
@@ -96,8 +96,8 @@ as_user = false
 # preferable to validate inputs before invoking miniwdl, if possible.)
 placeholder_regex = (.|\n)*
 # Set environment variable(s) in all task environments. The JSON object is keyed by environment
-# variable name. If an entry here is set to null, then miniwdl passes through the variable from its
-# own environment (if there defined). Any other value is used as a string.
+# variable name. If a variable is set to null here, then miniwdl passes through the variable from
+# its own environment (if there defined). Any other value is used as a string.
 # --env (New in v1.2.2)
 # Warning: this is a non-standard side channel and relying on it is probably not portable to other
 # WDL engines and/or compute platforms. Explicit WDL task inputs are usually better, except for a

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -549,8 +549,8 @@ def _eval_task_runtime(
         )
     if env_vars_override:
         # usually don't dump values into log, as they may often be auth tokens
-        logger.notice(_("overriding environment variables", names=list(env_vars_override.keys())))
-        logger.debug(_("overriding environment variables", **env_vars_override))
+        logger.notice(_("overriding environment variables (portability warning)", names=list(env_vars_override.keys())))
+        logger.debug(_("overriding environment variables (portability warning)", **env_vars_override))
         ans["env"] = env_vars_override
 
     unused_keys = list(

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -534,15 +534,19 @@ def _eval_task_runtime(
         logger.info(_("effective runtime", **ans))
 
     env_vars_override = {}
+    env_vars_skipped = []
     for ev_name, ev_value in cfg["task_runtime"].get_dict("env").items():
         if ev_value is None:
             try:
-                ev_value = os.environ[ev_name]
+                env_vars_override[ev_name] = os.environ[ev_name]
             except KeyError:
-                raise Error.InputError(
-                    f"configuration passes through environment variable {ev_name} which isn't defined"
-                ) from None
-        env_vars_override[ev_name] = str(ev_value)
+                env_vars_skipped.append(ev_name)
+        else:
+            env_vars_override[ev_name] = str(ev_value)
+    if env_vars_skipped:
+        logger.warning(
+            _("skipping pass-through of undefined environment variable(s)", names=env_vars_skipped)
+        )
     if env_vars_override:
         # usually don't dump values into log, as they may often be auth tokens
         logger.notice(_("overriding environment variables", names=list(env_vars_override.keys())))

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -530,6 +530,17 @@ def _eval_task_runtime(
                 task.runtime["returnCodes"], "invalid setting of runtime.returnCodes"
             )
 
+    if cfg["task_runtime"].get_list("passthru_envvars"):
+        logger.warning("passthru_envvars is an experimental extension, subject to change")
+        envvars = cfg["task_runtime"].get_list("passthru_envvars")
+        if "environment" not in ans:
+            ans["environment"] = {}
+        for varname in envvars:
+            try:
+                ans["environment"][varname] = os.environ[varname]
+            except KeyError:
+                pass  # Don't break if this env var isn't set
+
     if ans:
         logger.info(_("effective runtime", **ans))
     unused_keys = list(

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -549,8 +549,15 @@ def _eval_task_runtime(
         )
     if env_vars_override:
         # usually don't dump values into log, as they may often be auth tokens
-        logger.notice(_("overriding environment variables (portability warning)", names=list(env_vars_override.keys())))
-        logger.debug(_("overriding environment variables (portability warning)", **env_vars_override))
+        logger.notice(
+            _(
+                "overriding environment variables (portability warning)",
+                names=list(env_vars_override.keys()),
+            )
+        )
+        logger.debug(
+            _("overriding environment variables (portability warning)", **env_vars_override)
+        )
         ans["env"] = env_vars_override
 
     unused_keys = list(

--- a/WDL/runtime/task_container.py
+++ b/WDL/runtime/task_container.py
@@ -568,9 +568,7 @@ class SwarmContainer(TaskContainer):
                 "groups": groups,
                 "labels": {"miniwdl_run_id": self.run_id},
                 "container_labels": {"miniwdl_run_id": self.run_id},
-                "env": [
-                    f"{k}={v}" for (k, v) in self.runtime_values.get("environment", {}).items()
-                ],
+                "env": [f"{k}={v}" for (k, v) in self.runtime_values.get("env", {}).items()],
             }
             kwargs.update(self.create_service_kwargs or {})
             logger.debug(_("docker create service kwargs", **kwargs))

--- a/WDL/runtime/task_container.py
+++ b/WDL/runtime/task_container.py
@@ -568,6 +568,9 @@ class SwarmContainer(TaskContainer):
                 "groups": groups,
                 "labels": {"miniwdl_run_id": self.run_id},
                 "container_labels": {"miniwdl_run_id": self.run_id},
+                "env": [
+                    f"{k}={v}" for (k, v) in self.runtime_values.get("environment", {}).items()
+                ],
             }
             kwargs.update(self.create_service_kwargs or {})
             logger.debug(_("docker create service kwargs", **kwargs))

--- a/tests/runner.t
+++ b/tests/runner.t
@@ -11,7 +11,7 @@ source tests/bash-tap/bash-tap-bootstrap
 export PYTHONPATH="$SOURCE_DIR:$PYTHONPATH"
 miniwdl="python3 -m WDL"
 
-plan tests 81
+plan tests 80
 
 $miniwdl run_self_test
 is "$?" "0" "run_self_test"
@@ -458,7 +458,7 @@ version development
 task t {
     input {}
     command <<<
-        echo "${XXX}/${YYY}/${ZZZ}"
+        echo "${WWW}/${XXX}/${YYY}/${ZZZ}"
     >>>
     output {
         String out = read_string(stdout())
@@ -468,8 +468,6 @@ task t {
     }
 }
 EOF
-$miniwdl run env.wdl --env XXX --env YYY= --env "ZZZ=brown fox"
-is "$?" "1" "--env passed-through variable must be defined"
-XXX=quick $miniwdl run env.wdl --env XXX --env YYY= --env "ZZZ=brown fox" -o env_out.json
+XXX=quick YYY=not $miniwdl run env.wdl --env WWW --env XXX --env YYY= --env "ZZZ=brown fox" -o env_out.json
 is "$?" "0" "--env succeeds"
-is "$(jq -r '.outputs["t.out"]' env_out.json)" "quick//brown fox" "--env correct"
+is "$(jq -r '.outputs["t.out"]' env_out.json)" "/quick//brown fox" "--env correct"

--- a/tests/runner.t
+++ b/tests/runner.t
@@ -11,7 +11,7 @@ source tests/bash-tap/bash-tap-bootstrap
 export PYTHONPATH="$SOURCE_DIR:$PYTHONPATH"
 miniwdl="python3 -m WDL"
 
-plan tests 78
+plan tests 81
 
 $miniwdl run_self_test
 is "$?" "0" "run_self_test"
@@ -451,3 +451,25 @@ $miniwdl run inside/inside.wdl
 is "$?" "0" "outside import allowed"
 $miniwdl run inside/inside.wdl --no-outside-imports
 is "$?" "2" "outside import denied"
+
+# test --env
+cat << 'EOF' > env.wdl
+version development
+task t {
+    input {}
+    command <<<
+        echo "${XXX}/${YYY}/${ZZZ}"
+    >>>
+    output {
+        String out = read_string(stdout())
+    }
+    runtime {
+        docker: "ubuntu:20.04"
+    }
+}
+EOF
+$miniwdl run env.wdl --env XXX --env YYY= --env "ZZZ=brown fox"
+is "$?" "1" "--env passed-through variable must be defined"
+XXX=quick $miniwdl run env.wdl --env XXX --env YYY= --env "ZZZ=brown fox" -o env_out.json
+is "$?" "0" "--env succeeds"
+is "$(jq -r '.outputs["t.out"]' env_out.json)" "quick//brown fox" "--env correct"

--- a/tests/test_7runner.py
+++ b/tests/test_7runner.py
@@ -10,6 +10,7 @@ import docker
 import platform
 from testfixtures import log_capture
 from .context import WDL
+from unittest.mock import patch
 
 class RunnerTestCase(unittest.TestCase):
     """
@@ -984,3 +985,42 @@ class TestImplicitlyOptionalInputWithDefault(RunnerTestCase):
         self.assertEqual(outp["results"], ["AliceBas", "Bas"])
         outp = self._run(caller, {"a": "Alyssa"})
         self.assertEqual(outp["results"], ["Alyssa", None])
+
+
+class TestPassthruEnv(RunnerTestCase):
+    def test1(self):
+        wdl = """
+        version development
+        task t {
+            input {
+                String k1
+            }
+            command <<<
+                echo ~{k1}
+                echo "$TEST_ENV_VAR"
+                echo "$NOT_PASSED_IN_VAR"
+            >>>
+            output {
+                String out = read_string(stdout())
+            }
+            runtime {
+                docker: "ubuntu:20.04"
+            }
+        }
+        """
+        cfg = WDL.runtime.config.Loader(logging.getLogger(self.id()), [])
+        cfg.override({"task_runtime": {"passthru_envvars": ["TEST_ENV_VAR"]}})
+        with open(os.path.join(self._dir, "Alice"), mode="w") as outfile:
+            print("Alice", file=outfile)
+        env = {
+            "TEST_ENV_VAR": "passthru_test_success",
+            "NOT_PASSED_IN_VAR": "this shouldn't be passed in",
+        }
+        with patch.dict("os.environ", env):
+            out = self._run(wdl, {"k1": "stringvalue"}, cfg=cfg)
+        self.assertEqual(
+            out["out"],
+            """stringvalue
+passthru_test_success
+""",
+        )

--- a/tests/test_7runner.py
+++ b/tests/test_7runner.py
@@ -998,6 +998,7 @@ class TestPassthruEnv(RunnerTestCase):
             command <<<
                 echo ~{k1}
                 echo "$TEST_ENV_VAR"
+                echo "$SET_ENV_VAR"
                 echo "$NOT_PASSED_IN_VAR"
             >>>
             output {
@@ -1009,9 +1010,10 @@ class TestPassthruEnv(RunnerTestCase):
         }
         """
         cfg = WDL.runtime.config.Loader(logging.getLogger(self.id()), [])
-        cfg.override({"task_runtime": {"passthru_envvars": ["TEST_ENV_VAR"]}})
+        cfg.override({"task_runtime": {"env": {"TEST_ENV_VAR": None, "SET_ENV_VAR": "set123"}}})
         with open(os.path.join(self._dir, "Alice"), mode="w") as outfile:
             print("Alice", file=outfile)
+        self._run(wdl, {"k1": "stringvalue"}, cfg=cfg, expected_exception=WDL.Error.InputError)
         env = {
             "TEST_ENV_VAR": "passthru_test_success",
             "NOT_PASSED_IN_VAR": "this shouldn't be passed in",
@@ -1022,5 +1024,6 @@ class TestPassthruEnv(RunnerTestCase):
             out["out"],
             """stringvalue
 passthru_test_success
+set123
 """,
         )

--- a/tests/test_7runner.py
+++ b/tests/test_7runner.py
@@ -1013,7 +1013,12 @@ class TestPassthruEnv(RunnerTestCase):
         cfg.override({"task_runtime": {"env": {"TEST_ENV_VAR": None, "SET_ENV_VAR": "set123"}}})
         with open(os.path.join(self._dir, "Alice"), mode="w") as outfile:
             print("Alice", file=outfile)
-        self._run(wdl, {"k1": "stringvalue"}, cfg=cfg, expected_exception=WDL.Error.InputError)
+        out = self._run(wdl, {"k1": "stringvalue"}, cfg=cfg)
+        self.assertEqual(out["out"], """stringvalue
+
+set123
+""",
+        )
         env = {
             "TEST_ENV_VAR": "passthru_test_success",
             "NOT_PASSED_IN_VAR": "this shouldn't be passed in",


### PR DESCRIPTION
@jgadling building on your much-appreciated #516, I extended it to work just like [`docker run --env`](https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file):

* `--env X` to pass through environment variable `X`, skipping if `X` is undefined
* `--env X=foo` to set `X` outright
* supply `--env` multiple times with different variables

Let me know if you have any concerns with this variation on it!

While hacking on this, I remembered how miniwdl [passes AWS credentials to its internal S3 downloader](https://github.com/chanzuckerberg/miniwdl/blob/6963147e3324ef738f899d6f78ab914e2d3bbd06/WDL/runtime/download.py#L308-L332): it *generates a temporary script file* defining the necessary environment variables, then [sources that script](https://github.com/chanzuckerberg/miniwdl/blob/6963147e3324ef738f899d6f78ab914e2d3bbd06/WDL/runtime/download.py#L272) at the start of a task that needs it. The advantages of this approach are (i) it's concise yet explicit that the task needs this information supplied and (ii) miniwdl is careful never to dump *file contents* into its log in case they contain sensitive information. Just another concept to consider, however, I also support this passthrough feature.