### PR TITLE
rework struct initialization from read_json()

### DIFF
--- a/WDL/StdLib.py
+++ b/WDL/StdLib.py
@@ -444,8 +444,8 @@ class _At(EagerFunction):
                     rhs, lhs.type.item_type[0], rhs.type, "Map key"
                 ) from None
             return lhs.type.item_type[1]
-        if isinstance(lhs.type, Type.Any):
-            # e.g. read_json(): assume lhs is Array[Any] or Map[String,Any]
+        if isinstance(lhs.type, Type.Any) and not lhs.type.optional:
+            # e.g. read_json(): assume lhs is Array[Any] or Struct
             return Type.Any()
         raise Error.NotAnArray(lhs)
 
@@ -465,6 +465,17 @@ class _At(EagerFunction):
             if ans is None:
                 raise Error.OutOfBounds(expr.arguments[1], "Map key not found")
             return ans
+        elif isinstance(lhs, Value.Struct):
+            # allow member access from read_json() (issue #320)
+            key = None
+            if rhs.type.coerces(Type.String()):
+                try:
+                    key = rhs.coerce(Type.String()).value
+                except Error.RuntimeError:
+                    pass
+            if not key or key not in lhs.value:
+                raise Error.OutOfBounds(expr.arguments[1], "struct member not found")
+            return lhs.value[key]
         else:
             lhs = lhs.coerce(Type.Array(Type.Any()))
             rhs = rhs.coerce(Type.Int())

--- a/WDL/StdLib.py
+++ b/WDL/StdLib.py
@@ -5,6 +5,7 @@ import json
 import tempfile
 from typing import List, Tuple, Callable, BinaryIO, Optional
 from abc import ABC, abstractmethod
+from contextlib import suppress
 import regex
 from . import Type, Value, Expr, Env, Error
 from ._util import byte_size_units, chmod_R_plus
@@ -469,11 +470,9 @@ class _At(EagerFunction):
             # allow member access from read_json() (issue #320)
             key = None
             if rhs.type.coerces(Type.String()):
-                try:
+                with suppress(Error.RuntimeError):
                     key = rhs.coerce(Type.String()).value
-                except Error.RuntimeError:
-                    pass
-            if not key or key not in lhs.value:
+            if key is None or key not in lhs.value:
                 raise Error.OutOfBounds(expr.arguments[1], "struct member not found")
             return lhs.value[key]
         else:

--- a/WDL/Type.py
+++ b/WDL/Type.py
@@ -522,9 +522,9 @@ def unify(types: List[Base], check_quant: bool = True, force_string: bool = Fals
     if not types:
         return Any()
 
-    # begin with first type; or if --no-quant-check, the first array type (as we can try to promote
-    # other T to Array[T])
-    t = next((t for t in types if not isinstance(t, Any)), types[0])
+    # begin with first non-String type (as almost everything is coercible to string); or if
+    # --no-quant-check, the first array type (as we can try to promote other T to Array[T])
+    t = next((t for t in types if not isinstance(t, (String, Any))), types[0])
     if not check_quant:
         t = next((a for a in types if isinstance(a, Array) and not isinstance(a.item_type, Any)), t)
     t = t.copy()  # pyre-ignore
@@ -554,13 +554,16 @@ def unify(types: List[Base], check_quant: bool = True, force_string: bool = Fals
             t = Float()
         if isinstance(t, String) and isinstance(t2, File):
             t = File()
+        if isinstance(t, String) and isinstance(t2, Directory):
+            t = Directory()
 
         # String
         if (
             isinstance(t2, String)
-            and not isinstance(t2, File)
-            and not isinstance(t, File)
+            and not isinstance(t2, (File, Directory))
+            and not isinstance(t, (File, Directory))
             and (not check_quant or not isinstance(t, Array))
+            and (not isinstance(t, (Pair, Map)))
         ):
             t = String()
         if not t2.coerces(String(optional=True), check_quant=check_quant):

--- a/WDL/Value.py
+++ b/WDL/Value.py
@@ -328,7 +328,7 @@ class Map(Base):
                 # Runtime typecheck for initializing struct from read_{object,objects,map}
                 # This couldn't have been checked statically because the map keys weren't known.
                 litty = Type.Map(
-                    (self.type.item_type[0], self.type.item_type[1]),
+                    self.type.item_type,
                     self.type.optional,
                     set(kv[0].value for kv in self.value),
                 )
@@ -470,46 +470,19 @@ class Struct(Base):
 
     def coerce(self, desired_type: Optional[Type.Base] = None) -> Base:
         """"""
-
-        def fail(msg):
-            raise Error.EvalError(
-                self.expr,
-                msg,
-            ) if self.expr else Error.RuntimeError(msg)
-
         if isinstance(desired_type, (Type.Object, Type.StructInstance)):
             if not self.type.coerces(desired_type):
-                fail(
+                msg = (
                     "unusable runtime struct initializer"
                     " (member type mismatch, lacking required member, or extra member)"
                 )
+                raise Error.EvalError(
+                    self.expr,
+                    msg,
+                ) if self.expr else Error.RuntimeError(msg)
             return Struct(desired_type, self.value, self.expr)
         if isinstance(desired_type, Type.Map):
-            # runtime coercion e.g. Map[String,String] foo = read_json("foo.txt")
-            assert isinstance(self.type, Type.Object)
-            key_type = desired_type.item_type[0]
-            if not Type.String().coerces(key_type):
-                fail(f"cannot coerce member names to {key_type} map keys")
-            value_type = desired_type.item_type[1]
-            entries = []
-            for k, v in self.value.items():
-                if not (isinstance(v, Null) and value_type.optional):
-                    map_key = None
-                    try:
-                        map_key = String(k).coerce(key_type)
-                    except Error.RuntimeError:
-                        fail(f"cannot coerce member name {k} to {key_type} map key")
-                    map_value = None
-                    if self.type.members[k].coerces(value_type):
-                        with suppress(Error.RuntimeError):
-                            map_value = v.coerce(value_type)
-                    if map_value is None:
-                        fail(
-                            "cannot coerce struct member"
-                            f" {self.type.members[k]} {k} to {value_type} map value"
-                        )
-                    entries.append((map_key, map_value))
-            return Map(desired_type.item_type, entries)
+            return self._coerce_to_map(desired_type)
         if isinstance(desired_type, Type.Any):
             return self
         msg = f"cannot coerce struct to {desired_type}"
@@ -517,6 +490,40 @@ class Struct(Base):
             self.expr,
             msg,
         ) if self.expr else Error.RuntimeError(msg)
+
+    def _coerce_to_map(self, desired_type: Type.Map) -> Map:
+        # runtime coercion e.g. Map[String,String] foo = read_json("foo.txt")
+        assert isinstance(self.type, Type.Object)
+
+        def fail(msg):
+            raise Error.EvalError(
+                self.expr,
+                msg,
+            ) if self.expr else Error.RuntimeError(msg)
+
+        key_type = desired_type.item_type[0]
+        if not Type.String().coerces(key_type):
+            fail(f"cannot coerce member names to {key_type} map keys")
+        value_type = desired_type.item_type[1]
+        entries = []
+        for k, v in self.value.items():
+            if not (isinstance(v, Null) and value_type.optional):
+                map_key = None
+                try:
+                    map_key = String(k).coerce(key_type)
+                except Error.RuntimeError:
+                    fail(f"cannot coerce member name {k} to {key_type} map key")
+                map_value = None
+                if self.type.members[k].coerces(value_type):
+                    with suppress(Error.RuntimeError):
+                        map_value = v.coerce(value_type)
+                if map_value is None:
+                    fail(
+                        "cannot coerce struct member"
+                        f" {self.type.members[k]} {k} to {value_type} map value"
+                    )
+                entries.append((map_key, map_value))
+        return Map(desired_type.item_type, entries)
 
     def __str__(self) -> Any:
         return "{" + ", ".join(f"{k}: {str(v)}" for k, v in self.value.items()) + "}"
@@ -619,13 +626,13 @@ def _infer_from_json(j: Any) -> Base:
         item_type = Type.unify([item.type for item in items])
         return Array(item_type, [item.coerce(item_type) for item in items])
     if isinstance(j, dict):
-        fields = {}
-        field_types = {}
+        members = {}
+        member_types = {}
         for k in j:
             assert isinstance(k, str)
-            fields[k] = _infer_from_json(j[k])
-            field_types[k] = fields[k].type
-        return Struct(Type.Object(field_types), fields)
+            members[k] = _infer_from_json(j[k])
+            member_types[k] = members[k].type
+        return Struct(Type.Object(member_types), members)
     raise Error.InputError(f"couldn't construct value from: {json.dumps(j)}")
 
 

--- a/WDL/Value.py
+++ b/WDL/Value.py
@@ -328,9 +328,7 @@ class Map(Base):
                 # Runtime typecheck for initializing struct from read_{object,objects,map}
                 # This couldn't have been checked statically because the map keys weren't known.
                 litty = Type.Map(
-                    self.type.item_type,
-                    self.type.optional,
-                    set(kv[0].value for kv in self.value),
+                    self.type.item_type, self.type.optional, set(kv[0].value for kv in self.value)
                 )
                 if not litty.coerces(desired_type):
                     msg = (

--- a/tests/test_0eval.py
+++ b/tests/test_0eval.py
@@ -484,7 +484,6 @@ class TestValue(unittest.TestCase):
             (WDL.Type.Array(WDL.Type.String(optional=True)), ["apple", "orange", None]),
             (WDL.Type.Map((WDL.Type.String(), WDL.Type.Int())), {"cats": 42, "dogs": 99}),
             (pty, {"name": "Alyssa", "age": 42, "pets": None}),
-            (pty, {"name": "Alyssa", "age": 42}),
             (pty, {"name": "Alyssa", "age": 42, "pets": {"cats": 42, "dogs": 99}}),
             (WDL.Type.Array(WDL.Type.Pair(WDL.Type.String(), WDL.Type.Int())), [{"left": "a", "right": 0},{"left": "b", "right": 1}]),
 

--- a/tests/test_4taskrun.py
+++ b/tests/test_4taskrun.py
@@ -811,10 +811,11 @@ class TestTaskRunner(unittest.TestCase):
                 String memory
             }
             command <<<
-                cat /sys/fs/cgroup/memory/memory.limit_in_bytes
+                cat /sys/fs/cgroup/memory/memory.limit_in_bytes \
+                    || cat /sys/fs/cgroup/memory.max
             >>>
             output {
-                Int memory_limit_in_bytes = read_int(stdout())
+                String memory_limit_in_bytes = read_string(stdout())
             }
             runtime {
                 cpu: 1
@@ -824,10 +825,11 @@ class TestTaskRunner(unittest.TestCase):
         """
         cfg = WDL.runtime.config.Loader(logging.getLogger(self.id()), [])
         outputs = self._test_task(txt, {"memory": "256MB"}, cfg=cfg)
-        self.assertGreater(outputs["memory_limit_in_bytes"], 300*1024*1024)
+        if outputs["memory_limit_in_bytes"] != "max":
+            self.assertGreater(int(outputs["memory_limit_in_bytes"]), 300*1024*1024)
         cfg.override({"task_runtime": {"memory_limit_multiplier": 0.9}})
         outputs = self._test_task(txt, {"memory": "256MB"}, cfg=cfg)
-        self.assertLess(outputs["memory_limit_in_bytes"], 300*1024*1024)
+        self.assertLess(int(outputs["memory_limit_in_bytes"]), 300*1024*1024)
 
     def test_runtime_returnCodes(self):
         txt = R"""

--- a/tests/test_4taskrun.py
+++ b/tests/test_4taskrun.py
@@ -578,6 +578,23 @@ class TestTaskRunner(unittest.TestCase):
         """)
         self.assertEqual(outputs["car"], {"model": "Mazda", "year": 2017, "mileage": None})
         self.assertEqual(outputs["car2"], {"model": "Toyota", "year": None, "mileage": None})
+        # bad struct init from map
+        self._test_task(R"""
+        version 1.0
+        struct Car {
+            String model
+            Float mileage
+        }
+        task t {
+            command {}
+            output {
+                Car car = {
+                    "model": "Mazda",
+                    "mileage": "bogus"
+                }
+            }
+        }
+        """, expected_exception=WDL.Error.EvalError)
 
     def test_errors(self):
         self._test_task(R"""

--- a/tests/test_5stdlib.py
+++ b/tests/test_5stdlib.py
@@ -854,7 +854,7 @@ class TestStdLib(unittest.TestCase):
             >>>
 
             output {
-                Map[Array[Float],String] data = read_json("data.json")
+                Map[Float,String] data = read_json("data.json")
             }
         }
         """, expected_exception=WDL.Error.EvalError)

--- a/tests/test_5stdlib.py
+++ b/tests/test_5stdlib.py
@@ -1,3 +1,4 @@
+from math import exp
 import unittest
 import logging
 import tempfile
@@ -550,7 +551,7 @@ class TestStdLib(unittest.TestCase):
                 Array[String] my_array = read_json(stdout())
             }
         }
-        """, expected_exception=WDL.Error.InputError)
+        """, expected_exception=WDL.Error.EvalError)
 
         outputs = self._test_task(R"""
         version 1.0

--- a/tests/test_5stdlib.py
+++ b/tests/test_5stdlib.py
@@ -578,6 +578,18 @@ class TestStdLib(unittest.TestCase):
         }
         """, expected_exception=WDL.Error.InputError)
 
+        self._test_task(R"""
+        version 1.0
+        task test {
+            command <<<
+                echo '{"foo":"bar"}'
+            >>>
+            output {
+                String baz = read_json(stdout())["baz"]
+            }
+        }
+        """, expected_exception=WDL.Error.OutOfBounds)
+
     def test_read_map_ints(self):
         outputs = self._test_task(R"""
         version 1.0
@@ -842,7 +854,7 @@ class TestStdLib(unittest.TestCase):
             >>>
 
             output {
-                Map[Float,String] data = read_json("data.json")
+                Map[Array[Float],String] data = read_json("data.json")
             }
         }
         """, expected_exception=WDL.Error.EvalError)

--- a/tests/test_5stdlib.py
+++ b/tests/test_5stdlib.py
@@ -677,7 +677,7 @@ class TestStdLib(unittest.TestCase):
         self.assertEqual(outputs["samplesheet2"], samplesheet2)
 
     def test_issue524(self):
-        # additional struct initialization from read_json() cases motivated by issue #524
+        # additional cases for struct initialization from read_json(), motivated by issue #524
 
         # explicit null value should be acceptable initializer for optional struct field
         outp = self._test_task(R"""


### PR DESCRIPTION
Initializing a struct from unsafe `read_json()`, change the transient intermediate codepath to go through `Object` instead of `Map`, avoiding various problems caused by spurious attempt to unify heterogeneous value types. Improve error messages.

mostly addresses #524 