### PR TITLE
Add py.typed file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,3 +26,6 @@ console_scripts =
 [pbr]
 skip_authors = True
 skip_changelog = True
+
+[options.package_data]
+* = py.typed


### PR DESCRIPTION
### Motivation

Closes #535 

This makes builds with `mypy` to pass without adding `type: ignore` when importing the `WDL` module.

### Approach

As per recommendation in the PEP 561 - <https://www.python.org/dev/peps/pep-0561/#packaging-type-information>

### Checklist

<!--- You're welcome to open a draft PR to request guidance on testing or Pyre/Pylint problems. --->
- [ ] Add appropriate test(s) to the automatic suite
- [x] Use `make pretty` to reformat the code with [black](https://github.com/python/black)
- [x] Use `make check` to statically check the code using [Pyre](https://pyre-check.org/) and [Pylint](https://www.pylint.org/)
- [x] Send PR from a dedicated branch without unrelated edits
- [x] Ensure compatibility with this project's MIT license
