### PR TITLE
add type hints for print_error()

### DIFF
--- a/WDL/CLI.py
+++ b/WDL/CLI.py
@@ -30,7 +30,6 @@ from . import (
     Call,
     Scatter,
     Conditional,
-    SourcePosition,
     parse_document,
     copy_source,
     values_from_json,
@@ -377,7 +376,7 @@ def print_error(exn: Optional[BaseException]) -> None:
             sys.stderr.write(ANSI.BHRED)
         if hasattr(exn, "pos"):
             pos = getattr(exn, "pos", None)
-            if isinstance(pos, SourcePosition):
+            if isinstance(pos, Error.SourcePosition):
                 print(f"({pos.uri} Ln {pos.line} Col {pos.column}) {exn}", file=sys.stderr)
             else:
                 print(str(exn), file=sys.stderr)


### PR DESCRIPTION
### Motivation

Tried to use `print_error()` from a typechecked codebase

```
wdl2cwl/main.py:43:9: error: Call to untyped function "print_error" in typed context  [no-untyped-call]
            WDL.CLI.print_error(exn)
```

<!--- You're welcome to open a draft PR to request guidance on testing or Pyre/Pylint problems. --->
- [ ] Add appropriate test(s) to the automatic suite
- [x] Use `make pretty` to reformat the code with [black](https://github.com/python/black)
- [x] Use `make check` to statically check the code using [Pyre](https://pyre-check.org/) and [Pylint](https://www.pylint.org/)
- [x] Send PR from a dedicated branch without unrelated edits
- [x] Ensure compatibility with this project's MIT license
