### PR TITLE
Fix parser comments cache

### DIFF
--- a/WDL/_parser.py
+++ b/WDL/_parser.py
@@ -16,21 +16,26 @@ _lark_lock = threading.Lock()
 
 def parse(grammar: str, txt: str, start: str) -> Tuple[lark.Tree, List[lark.Token]]:
     with _lark_lock:
-        # clearing the buffer in case a previous execution failed
-        _lark_comments_buffer.clear()
-        if (grammar, start) not in _lark_cache:
-            _lark_cache[(grammar, start)] = lark.Lark(
-                grammar,
-                start=start,
-                parser="lalr",
-                maybe_placeholders=False,
-                propagate_positions=True,
-                lexer_callbacks={"COMMENT": _lark_comments_buffer.append},
+        assert not _lark_comments_buffer
+        try:
+            if (grammar, start) not in _lark_cache:
+                _lark_cache[(grammar, start)] = lark.Lark(
+                    grammar,
+                    start=start,
+                    parser="lalr",
+                    maybe_placeholders=False,
+                    propagate_positions=True,
+                    lexer_callbacks={"COMMENT": _lark_comments_buffer.append},
+                )
+            tree = _lark_cache[(grammar, start)].parse(
+                txt + ("\n" if not txt.endswith("\n") else "")
             )
-        tree = _lark_cache[(grammar, start)].parse(txt + ("\n" if not txt.endswith("\n") else ""))
-        comments = _lark_comments_buffer.copy()
-        _lark_comments_buffer.clear()
-        return (tree, comments)
+            comments = _lark_comments_buffer.copy()
+            return (tree, comments)
+        finally:
+            # Wipe temp state (success or fail). It receives the side-effects of lark's
+            # lexer_callbacks, which we have to bind before memoizing the parser object.
+            _lark_comments_buffer.clear()
 
 
 def to_int(x):

--- a/WDL/_parser.py
+++ b/WDL/_parser.py
@@ -16,6 +16,8 @@ _lark_lock = threading.Lock()
 
 def parse(grammar: str, txt: str, start: str) -> Tuple[lark.Tree, List[lark.Token]]:
     with _lark_lock:
+        # clearing the buffer in case a previous execution failed
+        _lark_comments_buffer.clear()
         if (grammar, start) not in _lark_cache:
             _lark_cache[(grammar, start)] = lark.Lark(
                 grammar,

--- a/tests/test_1doc.py
+++ b/tests/test_1doc.py
@@ -1,5 +1,4 @@
-import unittest, inspect, tempfile, os, pickle
-from typing import Optional
+import unittest, tempfile, os, pickle
 from .context import WDL
 
 class TestTasks(unittest.TestCase):

--- a/tests/test_1doc.py
+++ b/tests/test_1doc.py
@@ -1551,6 +1551,26 @@ task count_lines {
         """
         WDL.parse_document(doc).typecheck()
 
+    def test_issue548_comments_buffer(self):
+        # bug where the comments cache was not emptied after a SyntaxError
+        bad_doc = r"""
+        version development
+        
+        # comment 1
+        # comment 2
+        workflow a {
+        """
+        good_doc = r"""
+        version development
+
+        workflow a {}
+        """
+        # Previous to the fix, the comments in the bad doc were preserved, causing an
+        # assertion error when parsing the good doc.
+        with self.assertRaises(WDL.Error.SyntaxError):
+            WDL.parse_document(bad_doc)
+        WDL.parse_document(good_doc).typecheck()
+
 class TestCycleDetection(unittest.TestCase):
     def test_task(self):
         doc = r"""


### PR DESCRIPTION
<!---  Thank you for contributing to miniwdl! Please see the CONTRIBUTING.md guidelines and observe the PR checklist below. --->

### Motivation

Closes #548 

### Approach

Clearing the comments cache before running the parser. An alternative could be to wrap the parser call in a try/except, and clear the buffer there. Happy to amend it, or if anyone would like, feel free to edit/squash the commits here :+1: 

Took a little longer than expected to remember how to run a single `unittest` test :grimacing: , so note for future self (as I'll forget again): `python setup.py test -s tests.test_1doc.TestDoc.test_issue548_comments_buffer`

### Checklist

<!--- You're welcome to open a draft PR to request guidance on testing or Pyre/Pylint problems. --->
- [x] Add appropriate test(s) to the automatic suite
- [x] Use `make pretty` to reformat the code with [black](https://github.com/python/black)
- [x] Use `make check` to statically check the code using [Pyre](https://pyre-check.org/) and [Pylint](https://www.pylint.org/)
- [x] Send PR from a dedicated branch without unrelated edits
- [x] Ensure compatibility with this project's MIT license
