### PR TITLE
Add support for attaching tasks to docker networks.

### DIFF
--- a/WDL/runtime/backend/docker_swarm.py
+++ b/WDL/runtime/backend/docker_swarm.py
@@ -210,6 +210,9 @@ class SwarmContainer(TaskContainer):
                 "container_labels": {"miniwdl_run_id": self.run_id},
                 "env": [f"{k}={v}" for (k, v) in self.runtime_values.get("env", {}).items()],
             }
+            network = self.runtime_values.get("docker_network", None)
+            if network:
+                kwargs["networks"] = [network]
             if self.runtime_values.get("privileged", False) is True:
                 logger.warning("runtime.privileged enabled (security & portability warning)")
                 kwargs["cap_add"] = ["ALL"]

--- a/WDL/runtime/backend/docker_swarm.py
+++ b/WDL/runtime/backend/docker_swarm.py
@@ -212,7 +212,16 @@ class SwarmContainer(TaskContainer):
             }
             network = self.runtime_values.get("docker_network", None)
             if network:
-                kwargs["networks"] = [network]
+                if network in self.cfg.get_list("docker_swarm", "allow_networks"):
+                    kwargs["networks"] = [network]
+                else:
+                    logger.warning(
+                        _(
+                            "runtime.docker_network ignored; network name must appear in JSON list from config"
+                            " [docker_swarm] allow_networks / env MINIWDL__DOCKER_SWARM__ALLOW_NETWORKS",
+                            docker_network=network,
+                        )
+                    )
             if self.runtime_values.get("privileged", False) is True:
                 logger.warning("runtime.privileged enabled (security & portability warning)")
                 kwargs["cap_add"] = ["ALL"]

--- a/WDL/runtime/config_templates/default.cfg
+++ b/WDL/runtime/config_templates/default.cfg
@@ -43,6 +43,11 @@ auto_init = true
 polling_period_seconds = 1.5
 # Retry idempotent dockerd requests yielding 5xx status code (after polling_period_seconds)
 server_error_retries = 2
+# Recognize e.g. `docker_network: "host"` in task runtime sections, and associate respective
+# containers with the docker network, if the network name appears in this list -- e.g.
+#   allow_networks = ["host"]
+# (New in v1.5.1)
+allow_networks = []
 
 
 [file_io]

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -484,6 +484,9 @@ def _eval_task_runtime(
             # TODO: ask TaskContainer to choose preferred candidate
             docker_value = docker_value.value[0]
         ans["docker"] = docker_value.coerce(Type.String()).value
+    if "docker_network" in runtime_values:
+        network_value = runtime_values["docker_network"]
+        ans["docker_network"] = network_value.coerce(Type.String()).value
 
     if (
         isinstance(runtime_values.get("privileged", None), Value.Boolean)

--- a/docs/runner_reference.md
+++ b/docs/runner_reference.md
@@ -46,7 +46,7 @@ The default local scheduler observes these task `runtime {}` attributes:
   * The memory reservation informs scheduling, but isn't an enforced limit unless the configuration option `[task_runtime] memory_limit_multiplier` is set
 * `maxRetries` (Int): retry failing tasks up to this many additional attempts (after the first)
 * `returnCodes` (Int/Array[Int]/`"*"`): consider the given non-zero exit code(s) to indicate command success
-* `docker_network` (String): name of a docker network to which to attach container, e.g. "host"
+* `docker_network` (String): name of a docker network to which to attach container, e.g. "host"; the network name must also appear in the configuration option `[docker_swarm] allow_networks` JSON list.
 * `privileged` (Boolean): if true, *and* configuration option `[task_runtime] allow_privileged = true`, then run task containers with privileged capabilities. (Not recommended, for security & portability reasons.)
 
 ## File & Directory URI downloads

--- a/docs/runner_reference.md
+++ b/docs/runner_reference.md
@@ -38,7 +38,6 @@ The miniwdl source repository includes several [example scripts](https://github.
 The default local scheduler observes these task `runtime {}` attributes:
 
 * `docker`/`container` (String): docker image tag used to instantiate container; if omitted, a default image is specified in the miniwdl configuration option `[task_runtime] defaults` (currently `ubuntu:20.04`)
-* `docker_network` (String): The name of a docker network to attach task containers to.
 * `cpu` (Int): container reserves, and is throttled to, this many CPUs
   * Automatically rounds down to all host CPUs, if fewer
   * Multiple tasks can run concurrently on the local host, if CPUs and memory are available to meet their total reservations, and the workflow dependencies allow
@@ -47,6 +46,7 @@ The default local scheduler observes these task `runtime {}` attributes:
   * The memory reservation informs scheduling, but isn't an enforced limit unless the configuration option `[task_runtime] memory_limit_multiplier` is set
 * `maxRetries` (Int): retry failing tasks up to this many additional attempts (after the first)
 * `returnCodes` (Int/Array[Int]/`"*"`): consider the given non-zero exit code(s) to indicate command success
+* `docker_network` (String): name of a docker network to which to attach container, e.g. "host"
 * `privileged` (Boolean): if true, *and* configuration option `[task_runtime] allow_privileged = true`, then run task containers with privileged capabilities. (Not recommended, for security & portability reasons.)
 
 ## File & Directory URI downloads

--- a/docs/runner_reference.md
+++ b/docs/runner_reference.md
@@ -38,6 +38,7 @@ The miniwdl source repository includes several [example scripts](https://github.
 The default local scheduler observes these task `runtime {}` attributes:
 
 * `docker`/`container` (String): docker image tag used to instantiate container; if omitted, a default image is specified in the miniwdl configuration option `[task_runtime] defaults` (currently `ubuntu:20.04`)
+* `docker_network` (String): The name of a docker network to attach task containers to.
 * `cpu` (Int): container reserves, and is throttled to, this many CPUs
   * Automatically rounds down to all host CPUs, if fewer
   * Multiple tasks can run concurrently on the local host, if CPUs and memory are available to meet their total reservations, and the workflow dependencies allow

--- a/tests/test_7runner.py
+++ b/tests/test_7runner.py
@@ -1063,6 +1063,7 @@ set123
 class TestDockerNetwork(RunnerTestCase):
     @classmethod
     def setUpClass(self):
+        super().setUpClass()
         self.subnet = "192.168.99.0/24"
         self.network_name = "miniwdl_test7_net"
         self.client = docker.from_env(version="auto")
@@ -1080,7 +1081,9 @@ class TestDockerNetwork(RunnerTestCase):
 
     @classmethod
     def tearDownClass(self):
+        super().tearDownClass()
         self.network.remove()
+        self.client.close()
 
     def test_network_default(self):
         wdl = """
@@ -1122,3 +1125,21 @@ class TestDockerNetwork(RunnerTestCase):
         """
         out = self._run(wdl, {})
         self.assertEqual(out["out"][:11], "192.168.99.")
+
+    def test_network_host(self):
+        wdl = """
+        version development
+        task t {
+            command <<<
+                hostname -I
+            >>>
+            output {
+                String out = read_string(stdout())
+            }
+            runtime {
+                docker: "ubuntu:20.04"
+                docker_network: "host"
+            }
+        }
+        """
+        self._run(wdl, {})


### PR DESCRIPTION
<!---  Thank you for contributing to miniwdl! Please see the CONTRIBUTING.md guidelines and observe the PR checklist below. --->

### Motivation
We increasingly rely on miniwdl in our batch processing pipelines, and we're currently trying to improve the developer experience for engineers who work on those pipelines. Our local development environments make use of `docker-compose` and docker networks to make the interactions between our microservices resemble our production environment. Since miniwdl doesn't currently have support for docker networks, the tasks it runs don't have access to the services in our local dev environment and can't interact with our local S3 service, database, etc.

### Approach
This is a pretty straightforward addition of a `docker_network` runtime config flag.

### Checklist

<!--- You're welcome to open a draft PR to request guidance on testing or Pyre/Pylint problems. --->
- [x] Add appropriate test(s) to the automatic suite
- [x] Use `make pretty` to reformat the code with [black](https://github.com/python/black)
- [x] Use `make check` to statically check the code using [Pyre](https://pyre-check.org/) and [Pylint](https://www.pylint.org/)
- [x] Send PR from a dedicated branch without unrelated edits
- [x] Ensure compatibility with this project's MIT license
