### PR TITLE
Always create reproducible zips and tars

### DIFF
--- a/WDL/Zip.py
+++ b/WDL/Zip.py
@@ -53,8 +53,10 @@ def build(
         logger.debug("manifest = " + json.dumps(manifest))
 
         # zip the temp directory (into another temp directory)
-        logger.info(f"archiving {dir_to_zip}")
-        os.makedirs(os.path.dirname(archive), exist_ok=True)
+        logger.info(f"Create archive {archive} from directory {dir_to_zip}")
+        dirname = os.path.dirname(archive)
+        if dirname:
+            os.makedirs(dirname, exist_ok=True)
         create_reproducible_archive(dir_to_zip, archive, archive_format)
 
 

--- a/WDL/Zip.py
+++ b/WDL/Zip.py
@@ -260,6 +260,6 @@ def _write_no_mtime_tar(tar_archive: str, src_dest_list: List[Tuple[pathlib.Path
     with tarfile.TarFile(tar_archive, "w") as archive:
         for src, dest in src_dest_list:
             dest_info = tarfile.TarInfo(str(dest))  # Mtime by default at 0
-            dest_info.size = os.stat(dest).st_size
+            dest_info.size = os.stat(src).st_size
             with open(src, "rb") as in_file:
                 archive.addfile(dest_info, in_file)

--- a/tests/test_3corpi.py
+++ b/tests/test_3corpi.py
@@ -644,11 +644,11 @@ class TestZip(unittest.TestCase):
             copy_pipeline_dir = cleanup.enter_context(
                 tempfile.TemporaryDirectory(prefix="miniwdl_reproducible_zip_test")
             )
+            copy_pipeline_dir = os.path.join(copy_pipeline_dir, "contents")
             # Copy file contents, but not file metadata.
             copied_pipeline_dir = shutil.copytree(
                 os.path.dirname(original_wdl),
-                copy_pipeline_dir, copy_function=shutil.copyfile,
-                dirs_exist_ok=True)
+                copy_pipeline_dir, copy_function=shutil.copyfile)
             copied_wdl = os.path.join(copied_pipeline_dir,
                                       "multi-bam-quantify.wdl")
             copied_doc = WDL.load(copied_wdl)

--- a/tests/test_3corpi.py
+++ b/tests/test_3corpi.py
@@ -617,7 +617,13 @@ class TestZip(unittest.TestCase):
             ),
         )
 
-    def test_reproducible(self):
+    def test_reproducible_zip(self):
+        self._reproducible_test("zip")
+
+    def test_reproducible_tar(self):
+        self._reproducible_test("tar")
+
+    def _reproducible_test(self, format):
         original_wdl = "test_corpi/biowdl/expression-quantification/multi-bam-quantify.wdl"
         doc = WDL.load(original_wdl)
         with contextlib.ExitStack() as cleanup:
@@ -625,9 +631,10 @@ class TestZip(unittest.TestCase):
                 tempfile.TemporaryDirectory(prefix="miniwdl_zip_test_"))
             meta = {"foo": "bar"}
             main_wdl = os.path.basename(doc.pos.abspath)
-            zip_fn = os.path.join(testdir, main_wdl + ".zip")
+            zip_fn = os.path.join(testdir, main_wdl + f".{format}")
             WDL.Zip.build(
-                doc, zip_fn, logging.getLogger("miniwdl_zip_test"), meta=meta
+                doc, zip_fn, logging.getLogger("miniwdl_zip_test"), meta=meta,
+                archive_format=format
             )
             zip_contents = pathlib.Path(zip_fn).read_bytes()
             zip_checksum = hashlib.sha1(zip_contents).hexdigest()
@@ -645,10 +652,10 @@ class TestZip(unittest.TestCase):
             copied_wdl = os.path.join(copied_pipeline_dir,
                                       "multi-bam-quantify.wdl")
             copied_doc = WDL.load(copied_wdl)
-            copied_zip_fn = os.path.join(testdir, main_wdl + ".copied.zip")
+            copied_zip_fn = os.path.join(testdir, main_wdl + f".copied.{format}")
             WDL.Zip.build(
                 copied_doc, copied_zip_fn, logging.getLogger("miniwdl_zip_test"),
-                meta=meta
+                meta=meta, archive_format=format
             )
             copied_zip_contents = pathlib.Path(copied_zip_fn).read_bytes()
             copied_zip_checksum = hashlib.sha1(copied_zip_contents).hexdigest()


### PR DESCRIPTION
<!---  Thank you for contributing to miniwdl! Please see the CONTRIBUTING.md guidelines and observe the PR checklist below. --->

### Motivation

See #556 . I think it is best to make reproducible zip/tar packages by default. It should be part of the SPEC.  

### Approach

Since zip and tar packages store files in a certain order, files are sorted by their path in the archive and added in that order. This ensures the order for a given set of files is always the same. 

Since compression can change with different libraries files are stored uncompressed. 

Since modification times can ruin your day for reproducibility, the modification time is set to 0 for tarfiles and to 1980-1-1 00:00 for zipfiles. These are both the lowest possible timestamps.



### Checklist

<!--- You're welcome to open a draft PR to request guidance on testing or Pyre/Pylint problems. --->
- [x] Add appropriate test(s) to the automatic suite
- [x] Use `make pretty` to reformat the code with [black](https://github.com/python/black)
- [ ] Use `make check` to statically check the code using [Pyre](https://pyre-check.org/) and [Pylint](https://www.pylint.org/)
- [x] Send PR from a dedicated branch without unrelated edits
- [x] Ensure compatibility with this project's MIT license
