### PR TITLE
add gsutil directory downloader

### DIFF
--- a/WDL/runtime/config.py
+++ b/WDL/runtime/config.py
@@ -394,7 +394,12 @@ def default_plugins() -> "Dict[str,List[importlib_metadata.EntryPoint]]":
                 group="miniwdl.plugin.directory_download",
                 name="s3",
                 value="WDL.runtime.download:awscli_directory_downloader",
-            )
+            ),
+            importlib_metadata.EntryPoint(
+                group="miniwdl.plugin.directory_download",
+                name="gs",
+                value="WDL.runtime.download:gsutil_directory_downloader",
+            ),
         ],
         "task": [],
         "workflow": [],

--- a/WDL/runtime/download.py
+++ b/WDL/runtime/download.py
@@ -388,8 +388,6 @@ def gsutil_directory_downloader(
     Built-in downloader plugin for public gs:// URIs; registered by setup.cfg entry_points section
 
     TODO: adopt security credentials from runtime environment
-
-    TODO: add tests, probably at `miniwdl/tests/test_7runner.py:test_directory`
     """
     if uri == "gs://8675309":
         # hook for test coverage of exception handler

--- a/WDL/runtime/download.py
+++ b/WDL/runtime/download.py
@@ -389,9 +389,6 @@ def gsutil_directory_downloader(
 
     TODO: adopt security credentials from runtime environment
     """
-    if uri == "gs://8675309":
-        # hook for test coverage of exception handler
-        raise RuntimeError("don't change your number")
     wdl = r"""
     task gsutil_cp {
         input {
@@ -405,8 +402,6 @@ def gsutil_directory_downloader(
             set -euxo pipefail
             mkdir __out/
             gsutil -q -m cp -r "~{uri}" __out/
-
-            ls -lh "__out/~{dnm}"
         >>>
         output {
             Directory directory = "__out/" + dnm


### PR DESCRIPTION

### Motivation

`Directory` URIs for the `gs://` scheme have not been implemented, though the scheme is available for `s3://` URIs.

### Approach

The command change to allow `gsutil` to download a directory rather than a single file is to add the `-r` flag. To implement this, there is now an additional download task plugin, and a second gsutil function for directory rather than file download.

Testing was added based on the `s3:` test that fetches a 1000genomes structural variants directory. The GCS mirror of the same repo has four files rather than two, so the asserts on file counts were updated.

I needed this for compatibility with a local cromwell install, and it has worked so far in pipeline development.

### Checklist


- [X] Add appropriate test(s) to the automatic suite
- [X] Use `make pretty` to reformat the code with [black](https://github.com/python/black)
- [X] Use `make check` to statically check the code using [Pyre](https://pyre-check.org/) and [Pylint](https://www.pylint.org/)
- [X] Send PR from a dedicated branch without unrelated edits
- [x] Ensure compatibility with this project's MIT license
