### PR TITLE
Singularity cache

### DIFF
--- a/WDL/runtime/backend/cli_subprocess.py
+++ b/WDL/runtime/backend/cli_subprocess.py
@@ -195,6 +195,9 @@ class SubprocessBase(TaskContainer):
                     logger.info(_(f"{self.cli_name} image already pulled", image=image))
                     return image
 
+            if not invocation:
+                # No action required, image could be cached externally.
+                return image
             logger.info(_(f"begin {self.cli_name} pull", command=" ".join(invocation)))
             try:
                 subprocess.run(

--- a/WDL/runtime/backend/singularity.py
+++ b/WDL/runtime/backend/singularity.py
@@ -67,6 +67,7 @@ class SingularityContainer(SubprocessBase):
         if not os.path.exists(image_path):
             return image_path, self.cli_exe + ["pull", image_path, docker_uri]
         # If path already exists, no need to use a pull invocation.
+        logger.info(_("Singularity SIF found in image cache directory", sif=image_path))
         return image_path, []
 
     def _run_invocation(self, logger: logging.Logger, cleanup: ExitStack, image: str) -> List[str]:

--- a/WDL/runtime/backend/singularity.py
+++ b/WDL/runtime/backend/singularity.py
@@ -17,7 +17,6 @@ class SingularityContainer(SubprocessBase):
     """
 
     image_cache_dir: Optional[str]
-    tempdir: Optional[str]
 
     @classmethod
     def global_init(cls, cfg: config.Loader, logger: logging.Logger) -> None:
@@ -41,13 +40,6 @@ class SingularityContainer(SubprocessBase):
             os.makedirs(cls.image_cache_dir, exist_ok=True)
         else:
             cls.image_cache_dir = None
-
-        tempdir = cfg.get("singularity", "tempdir")
-        if tempdir != "":
-            cls.tempdir = os.path.abspath(tempdir)
-            os.makedirs(cls.tempdir, exist_ok=True)
-        else:
-            cls.tempdir = tempfile.gettempdir()
 
         logger.notice(  # pyre-ignore
             _(
@@ -100,9 +92,7 @@ class SingularityContainer(SubprocessBase):
         # Also create a scratch directory and mount to /tmp and /var/tmp
         # For context why this is needed:
         #   https://github.com/hpcng/singularity/issues/5718
-        tempdir = cleanup.enter_context(
-            tempfile.TemporaryDirectory(prefix="miniwdl_singularity_", dir=self.tempdir)
-        )
+        tempdir = cleanup.enter_context(tempfile.TemporaryDirectory(prefix="miniwdl_singularity_"))
         os.mkdir(os.path.join(tempdir, "tmp"))
         os.mkdir(os.path.join(tempdir, "var_tmp"))
         mounts.append(("/tmp", os.path.join(tempdir, "tmp"), True))

--- a/WDL/runtime/backend/singularity.py
+++ b/WDL/runtime/backend/singularity.py
@@ -15,6 +15,7 @@ class SingularityContainer(SubprocessBase):
     """
     Singularity task runtime based on cli_subprocess.SubprocessBase
     """
+
     image_cache_dir: Optional[str]
 
     @classmethod

--- a/WDL/runtime/backend/singularity.py
+++ b/WDL/runtime/backend/singularity.py
@@ -63,7 +63,7 @@ class SingularityContainer(SubprocessBase):
             tempfile.TemporaryDirectory(prefix="miniwdl_sif_")
         )
         image_name = docker_uri.replace("/", "_").replace(":", "_")
-        image_path = os.path.join(pulldir, image_name)
+        image_path = os.path.join(pulldir, image_name + ".sif")
         if not os.path.exists(image_path):
             return image_path, self.cli_exe + ["pull", image_path, docker_uri]
         # If path already exists, no need to use a pull invocation.

--- a/WDL/runtime/backend/singularity.py
+++ b/WDL/runtime/backend/singularity.py
@@ -40,6 +40,14 @@ class SingularityContainer(SubprocessBase):
             os.makedirs(cls.image_cache_dir, exist_ok=True)
         else:
             cls.image_cache_dir = None
+
+        tempdir = cfg.get("singularity", "tempdir")
+        if tempdir != "":
+            cls.tempdir = os.path.abspath(tempdir)
+            os.makedirs(cls.tempdir, exist_ok=True)
+        else:
+            cls.tempdir = tempfile.gettempdir()
+
         logger.notice(  # pyre-ignore
             _(
                 "Singularity runtime initialized (BETA)",
@@ -91,7 +99,8 @@ class SingularityContainer(SubprocessBase):
         # Also create a scratch directory and mount to /tmp and /var/tmp
         # For context why this is needed:
         #   https://github.com/hpcng/singularity/issues/5718
-        tempdir = cleanup.enter_context(tempfile.TemporaryDirectory(prefix="miniwdl_singularity_"))
+        tempdir = cleanup.enter_context(tempfile.TemporaryDirectory(
+            prefix="miniwdl_singularity_", dir=self.tempdir))
         os.mkdir(os.path.join(tempdir, "tmp"))
         os.mkdir(os.path.join(tempdir, "var_tmp"))
         mounts.append(("/tmp", os.path.join(tempdir, "tmp"), True))

--- a/WDL/runtime/backend/singularity.py
+++ b/WDL/runtime/backend/singularity.py
@@ -34,8 +34,8 @@ class SingularityContainer(SubprocessBase):
                 f"Unable to check `{' '.join(cmd)}`; verify Singularity installation"
             )
 
-        if cfg.has_option("singularity", "image_cache"):
-            image_cache_dir = cfg.get("singularity", "image_cache")
+        image_cache_dir = cfg.get("singularity", "image_cache")
+        if image_cache_dir != "":
             cls.image_cache_dir = os.path.abspath(image_cache_dir)
             os.makedirs(cls.image_cache_dir, exist_ok=True)
         else:

--- a/WDL/runtime/backend/singularity.py
+++ b/WDL/runtime/backend/singularity.py
@@ -65,7 +65,7 @@ class SingularityContainer(SubprocessBase):
             if not os.path.exists(image_path):
                 return (image_path, self.cli_exe + ["pull", image_path, docker_uri])
             # If path already exists test the image
-            return (image_path, self.cli_exe + ["exec", image_path, "true"])
+            return image_path, []
         # Singularity will cache the image automatically in
         # SINGULARITY_CACHE_DIR it is not needed to save the image elsewhere.
         return (docker_uri, self.cli_exe + ["exec", docker_uri, "true"])

--- a/WDL/runtime/backend/singularity.py
+++ b/WDL/runtime/backend/singularity.py
@@ -17,6 +17,7 @@ class SingularityContainer(SubprocessBase):
     """
 
     image_cache_dir: Optional[str]
+    tempdir: Optional[str]
 
     @classmethod
     def global_init(cls, cfg: config.Loader, logger: logging.Logger) -> None:

--- a/WDL/runtime/backend/singularity.py
+++ b/WDL/runtime/backend/singularity.py
@@ -34,7 +34,8 @@ class SingularityContainer(SubprocessBase):
             )
 
         if cfg.has_option("singularity", "image_cache"):
-            cls.image_cache_dir = cfg.get("singularity", "image_cache")
+            image_cache_dir = cfg.get("singularity", "image_cache")
+            cls.image_cache_dir = os.path.abspath(image_cache_dir)
             os.makedirs(cls.image_cache_dir, exist_ok=True)
         else:
             cls.image_cache_dir = None

--- a/WDL/runtime/backend/singularity.py
+++ b/WDL/runtime/backend/singularity.py
@@ -99,8 +99,9 @@ class SingularityContainer(SubprocessBase):
         # Also create a scratch directory and mount to /tmp and /var/tmp
         # For context why this is needed:
         #   https://github.com/hpcng/singularity/issues/5718
-        tempdir = cleanup.enter_context(tempfile.TemporaryDirectory(
-            prefix="miniwdl_singularity_", dir=self.tempdir))
+        tempdir = cleanup.enter_context(
+            tempfile.TemporaryDirectory(prefix="miniwdl_singularity_", dir=self.tempdir)
+        )
         os.mkdir(os.path.join(tempdir, "tmp"))
         os.mkdir(os.path.join(tempdir, "var_tmp"))
         mounts.append(("/tmp", os.path.join(tempdir, "tmp"), True))

--- a/WDL/runtime/config_templates/default.cfg
+++ b/WDL/runtime/config_templates/default.cfg
@@ -222,8 +222,8 @@ run_options = [
     ]
 
 # Where pulled images should be stored to save image construction time between
-# starting the same task.
-# image_cache=/path/to/my/cache
+# starting the same task. Empty value -> no image cache used.
+image_cache=
 
 [udocker]
 # udocker task runtime -- with `udocker` CLI already set up, set

--- a/WDL/runtime/config_templates/default.cfg
+++ b/WDL/runtime/config_templates/default.cfg
@@ -225,10 +225,6 @@ run_options = [
 # starting the same task. Empty value -> no image cache used.
 image_cache=
 
-# Temporary directory for the /tmp and /var/tmp directories in the container.
-# An empty value means the system default will be used.
-tempdir=
-
 [udocker]
 # udocker task runtime -- with `udocker` CLI already set up, set
 #     [task_scheduler] container_backend = udocker

--- a/WDL/runtime/config_templates/default.cfg
+++ b/WDL/runtime/config_templates/default.cfg
@@ -225,6 +225,10 @@ run_options = [
 # starting the same task. Empty value -> no image cache used.
 image_cache=
 
+# Temporary directory for the /tmp and /var/tmp directories in the container.
+# An empty value means the system default will be used.
+tempdir=
+
 [udocker]
 # udocker task runtime -- with `udocker` CLI already set up, set
 #     [task_scheduler] container_backend = udocker

--- a/WDL/runtime/config_templates/default.cfg
+++ b/WDL/runtime/config_templates/default.cfg
@@ -221,6 +221,10 @@ run_options = [
         "--fakeroot"
     ]
 
+# Where pulled images should be stored to save image construction time between
+# starting the same task.
+# image_cache=/path/to/my/cache
+
 [udocker]
 # udocker task runtime -- with `udocker` CLI already set up, set
 #     [task_scheduler] container_backend = udocker

--- a/tests/singularity.t
+++ b/tests/singularity.t
@@ -19,12 +19,19 @@ DN=$(realpath "$DN")
 cd $DN
 echo "$DN"
 
-plan tests 2
+plan tests 4
 
 export MINIWDL__SCHEDULER__CONTAINER_BACKEND=singularity
 
 $miniwdl run_self_test --dir "$DN"
 is "$?" "0" "run_self_test"
+
+export MINIWDL__SINGULARITY__IMAGE_CACHE=$(mktemp -d)
+
+$miniwdl run_self_test --dir "$DN"
+is "$?" "0" "run_self_test with image cache"
+ls $MINIWDL__SINGULARITY__IMAGE_CACHE/*.sif
+is "$?" "0" "singularity images cached successfully"
 
 git clone --depth=1 https://github.com/broadinstitute/viral-pipelines.git
 cd viral-pipelines
@@ -33,10 +40,3 @@ $miniwdl run pipes/WDL/workflows/assemble_denovo.wdl \
     --path pipes/WDL/tasks --dir "$DN" --verbose \
     -i test/input/WDL/test_inputs-assemble_denovo-local.json
 is "$?" "0" "assemble_denovo success"
-
-export MINIWDL__SINGULARITY__IMAGE_CACHE=$(mktemp -d)
-
-$miniwdl run_self_test --dir "$DN"
-is "$?" "0" "run_self_test with image cache"
-$ls $MINIWDL__SINGULARITY__IMAGE_CACHE/*.sif
-is "$?" "0" "singularity images cached successfully"

--- a/tests/singularity.t
+++ b/tests/singularity.t
@@ -33,3 +33,10 @@ $miniwdl run pipes/WDL/workflows/assemble_denovo.wdl \
     --path pipes/WDL/tasks --dir "$DN" --verbose \
     -i test/input/WDL/test_inputs-assemble_denovo-local.json
 is "$?" "0" "assemble_denovo success"
+
+export MINIWDL__SINGULARITY__IMAGE_CACHE=$(mktemp -d)
+
+$miniwdl run_self_test --dir "$DN"
+is "$?" "0" "run_self_test with image cache"
+$ls $MINIWDL__SINGULARITY__IMAGE_CACHE/*.sif
+is "$?" "0" "singularity images cached successfully"

--- a/tests/singularity.t
+++ b/tests/singularity.t
@@ -19,7 +19,7 @@ DN=$(realpath "$DN")
 cd $DN
 echo "$DN"
 
-plan tests 4
+plan tests 6
 
 export MINIWDL__SCHEDULER__CONTAINER_BACKEND=singularity
 
@@ -32,6 +32,11 @@ $miniwdl run_self_test --dir "$DN"
 is "$?" "0" "run_self_test with image cache"
 ls $MINIWDL__SINGULARITY__IMAGE_CACHE/*.sif
 is "$?" "0" "singularity images cached successfully"
+
+$miniwdl run_self_test --dir "$DN/use_cache"
+is "$?" "0" "run_self_test with image cache"
+grep 'SIF found in image cache directory' $(find "$DN/use_cache" -name workflow.log)
+is "$?" "0" "singularity image used from cache"
 
 git clone --depth=1 https://github.com/broadinstitute/viral-pipelines.git
 cd viral-pipelines


### PR DESCRIPTION
<!---  Thank you for contributing to miniwdl! Please see the CONTRIBUTING.md guidelines and observe the PR checklist below. --->

### Motivation

This is required for supporting miniwdl-slurm and other HPC plugins. When submitting to a HPC there is usually a shared filesystem. The submit node and the worker nodes can access this filesystem. 

The singularity cache cannot and should not be shared between nodes because there may be conflicts. The image should be created by singularity on the submit node, then after that the worker nodes can use this image. The location of the singularity images dir needs to be configurable in order to put it on the shared filesystem.

The same holds true for the temp dir.

### Approach

A configuration parameter has been added under the "[singularity]" section called "image_cache". By default this is turned off. (The miniwdl-slurm plugin will override this default by setting it to some directory in the current working directory).

By default there is no cache. The image will be pulled by running singularity exec, executing the `true` command in a container. This will download the image  to the SINGULARITY_CACHEDIR as specified in the environment. (Or if it is not specified singularity will choose its default cache directory).

When there is a cache, the image is downloaded to the image_dir. Rather than returning the URI of the image, the downloaded `.sif` image is used when invoking singularity commands. This allows singularity commands to be executed on the cluster. 

The tempdir now functions similarly.

### Checklist

<!--- You're welcome to open a draft PR to request guidance on testing or Pyre/Pylint problems. --->
- [x] Add appropriate test(s) to the automatic suite
- [x] Use `make pretty` to reformat the code with [black](https://github.com/python/black)
- [x] Use `make check` to statically check the code using [Pyre](https://pyre-check.org/) and [Pylint](https://www.pylint.org/)
- [x] Send PR from a dedicated branch without unrelated edits
- [x] Ensure compatibility with this project's MIT license
