### PR TITLE
Allow existing filenames

### DIFF
--- a/WDL/runtime/workflow.py
+++ b/WDL/runtime/workflow.py
@@ -406,7 +406,8 @@ class StateMachine:
             disallowed_filenames = set(
                 fn
                 for fn in disallowed_filenames
-                if not downloadable(cfg, fn, directory=fn.endswith("/"))
+                if not (downloadable(cfg, fn, directory=fn.endswith("/")) or
+                        os.path.exists(fn))
             )
             if disallowed_filenames:
                 raise Error.InputError(


### PR DESCRIPTION
### Motivation

In BioWDL we have a TSV sample sheet format to prevent our users from having to manually edit JSON files with large numbers of samples. This sheet is converted to JSON and that is feeded into the WDL machinery as structs.

So far so good, and it works fine on cromwell, but it does not on miniwdl. Every filename that was not explicitly mentioned in the inputs JSON is disallowed, unless it is downloadable.

It turns out to be very easy to fix this, but I guess this code was here for a reason in the first place? There was no comment highlighting but I there might be plenty of reasons for miniwdl not to be too greedy when it comes to reading files. If that is the case this option could be made configurable.

### Approach
Simply check if the file exists and if so allow it.

EDIT: This does run into a problem when these files have relative paths. They can not be mounted in a container because that requires absolute paths. Of course we use absolute paths everywhere in production. Except for our testing, there the paths are relative to our git repo. 
I am curious to your thoughts on how to tackle this problem with external samplesheets elegantly.

### Checklist

<!--- You're welcome to open a draft PR to request guidance on testing or Pyre/Pylint problems. --->
- [ ] Add appropriate test(s) to the automatic suite
- [ ] Use `make pretty` to reformat the code with [black](https://github.com/python/black)
- [ ] Use `make check` to statically check the code using [Pyre](https://pyre-check.org/) and [Pylint](https://www.pylint.org/)
- [ ] Send PR from a dedicated branch without unrelated edits
- [ ] Ensure compatibility with this project's MIT license
