### PR TITLE
Add a use_relative_output_paths parameter that flattens output directories.

### DIFF
--- a/WDL/runtime/config_templates/default.cfg
+++ b/WDL/runtime/config_templates/default.cfg
@@ -92,6 +92,9 @@ output_hardlinks = false
 # output files would be deleted too. Input/output JSON, logs, and stdout/stderr are always retained
 # in the task run directory (above the container working directory).
 delete_work = false
+# Create an output directory structure based on the positions of output files relative to the
+# working directory.
+use_relative_output_paths = false
 # Suggest that each task's temporary directory should reside within the mounted task working
 # directory, instead of the storage backing the container's root filesystem. The latter (default)
 # is usually preferred because the working directory is more likely to reside on slower network-

--- a/WDL/runtime/config_templates/default.cfg
+++ b/WDL/runtime/config_templates/default.cfg
@@ -93,7 +93,10 @@ output_hardlinks = false
 # in the task run directory (above the container working directory).
 delete_work = false
 # Create an output directory structure based on the positions of output files relative to the
-# working directory.
+# working directory for each task. For example, a task has the following output:
+# File my_report = "reports/subdir/myreport.txt".
+# By default this will be in out/my_report/my_report.txt. With use_relative_output_paths=true
+# it will be in out/reports/subdir/myreport.txt
 use_relative_output_paths = false
 # Suggest that each task's temporary directory should reside within the mounted task working
 # directory, instead of the storage backing the container's root filesystem. The latter (default)

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -125,8 +125,7 @@ def run_local_task(
                     )
                 # create out/ and outputs.json
                 _outputs = link_outputs(
-                    cache, cached, run_dir, hardlinks=cfg["file_io"].get_bool("output_hardlinks"),
-                    use_relative_output_paths=cfg["file_io"].get_bool("use_relative_output_paths")
+                    cache, cached, run_dir, hardlinks=cfg["file_io"].get_bool("output_hardlinks")
                 )
                 write_values_json(
                     cached, os.path.join(run_dir, "outputs.json"), namespace=task.name
@@ -204,8 +203,7 @@ def run_local_task(
 
                 # create output_links
                 outputs = link_outputs(
-                    cache, outputs, run_dir, hardlinks=cfg["file_io"].get_bool("output_hardlinks"),
-                    use_relative_output_paths=cfg["file_io"].get_bool("use_relative_output_paths")
+                    cache, outputs, run_dir, hardlinks=cfg["file_io"].get_bool("output_hardlinks")
                 )
 
                 # process outputs through plugins

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -755,16 +755,12 @@ def link_outputs(
                     # make symlink relative
                     target = os.path.relpath(target, start=os.path.realpath(dn))
                 link = os.path.join(dn, os.path.basename(v.value.rstrip("/")))
-                if use_relative_output_paths:
-                    known_target = link_destinations.get(link, None)
-                    if known_target:
-                        if known_target != target:
-                            raise FileExistsError(
-                                f"Two files have the same link destination: "
-                                f"{known_target} and {target} are both written "
-                                f"to {link}")
-                    else:
-                        link_destinations[link] = target
+                if link_destinations.get(link, target) != target:
+                    raise FileExistsError(
+                        f"Two files have the same link destination: "
+                        f"{link_destinations[link]} and {target} are both "
+                        f"written to {link}.")
+                link_destinations[link] = target
                 os.makedirs(dn, exist_ok=use_relative_output_paths)
                 if hardlinks:
                     # TODO: what if target is an input from a different filesystem?

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -125,7 +125,8 @@ def run_local_task(
                     )
                 # create out/ and outputs.json
                 _outputs = link_outputs(
-                    cache, cached, run_dir, hardlinks=cfg["file_io"].get_bool("output_hardlinks")
+                    cache, cached, run_dir, hardlinks=cfg["file_io"].get_bool("output_hardlinks"),
+                    use_relative_output_paths=cfg["file_io"].get_bool("use_relative_output_paths"),
                 )
                 write_values_json(
                     cached, os.path.join(run_dir, "outputs.json"), namespace=task.name
@@ -203,7 +204,8 @@ def run_local_task(
 
                 # create output_links
                 outputs = link_outputs(
-                    cache, outputs, run_dir, hardlinks=cfg["file_io"].get_bool("output_hardlinks")
+                    cache, outputs, run_dir, hardlinks=cfg["file_io"].get_bool("output_hardlinks"),
+                    use_relative_output_paths=cfg["file_io"].get_bool("use_relative_output_paths"),
                 )
 
                 # process outputs through plugins
@@ -745,7 +747,8 @@ def link_outputs(
                     # any directories in there are present in the output structure
                     dir_parts = os.path.dirname(target).split(os.sep)
                     for i, part in enumerate(reversed(dir_parts)):
-                        if part == "work":
+                        # Also look for "out" directory in case of hardlinks
+                        if part == "work" or (part == "out" and hardlinks):
                             dn = os.path.join(dn, *dir_parts[len(dir_parts) - i:])
                             break
                 if not hardlinks and path_really_within(target, os.path.dirname(run_dir)):

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -125,7 +125,8 @@ def run_local_task(
                     )
                 # create out/ and outputs.json
                 _outputs = link_outputs(
-                    cache, cached, run_dir, hardlinks=cfg["file_io"].get_bool("output_hardlinks")
+                    cache, cached, run_dir, hardlinks=cfg["file_io"].get_bool("output_hardlinks"),
+                    use_relative_output_paths=cfg["file_io"].get_bool("use_relative_output_paths")
                 )
                 write_values_json(
                     cached, os.path.join(run_dir, "outputs.json"), namespace=task.name
@@ -203,7 +204,8 @@ def run_local_task(
 
                 # create output_links
                 outputs = link_outputs(
-                    cache, outputs, run_dir, hardlinks=cfg["file_io"].get_bool("output_hardlinks")
+                    cache, outputs, run_dir, hardlinks=cfg["file_io"].get_bool("output_hardlinks"),
+                    use_relative_output_paths=cfg["file_io"].get_bool("use_relative_output_paths")
                 )
 
                 # process outputs through plugins
@@ -719,7 +721,8 @@ def _check_directory(host_path: str, output_name: str) -> None:
 
 
 def link_outputs(
-    cache: CallCache, outputs: Env.Bindings[Value.Base], run_dir: str, hardlinks: bool = False
+        cache: CallCache, outputs: Env.Bindings[Value.Base], run_dir: str,
+        hardlinks: bool = False, use_relative_output_paths: bool = False,
 ) -> Env.Bindings[Value.Base]:
     """
     Following a successful run, the output files may be scattered throughout a complex directory

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -822,7 +822,7 @@ def link_outputs(
                 v.value[key] = map_paths(v.value[key], os.path.join(dn, key))
         return v
 
-    def map_paths_relative(v: Value.Base, dn: str):
+    def map_paths_relative(v: Value.Base, dn: str) -> Value.Base:
         if isinstance(v, (Value.File, Value.Directory)):
             # Fall back on map paths to use all the correct linking code.
             return map_paths(v, dn)

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -125,7 +125,10 @@ def run_local_task(
                     )
                 # create out/ and outputs.json
                 _outputs = link_outputs(
-                    cache, cached, run_dir, hardlinks=cfg["file_io"].get_bool("output_hardlinks"),
+                    cache,
+                    cached,
+                    run_dir,
+                    hardlinks=cfg["file_io"].get_bool("output_hardlinks"),
                     use_relative_output_paths=cfg["file_io"].get_bool("use_relative_output_paths"),
                 )
                 write_values_json(
@@ -204,7 +207,10 @@ def run_local_task(
 
                 # create output_links
                 outputs = link_outputs(
-                    cache, outputs, run_dir, hardlinks=cfg["file_io"].get_bool("output_hardlinks"),
+                    cache,
+                    outputs,
+                    run_dir,
+                    hardlinks=cfg["file_io"].get_bool("output_hardlinks"),
                     use_relative_output_paths=cfg["file_io"].get_bool("use_relative_output_paths"),
                 )
 
@@ -721,8 +727,11 @@ def _check_directory(host_path: str, output_name: str) -> None:
 
 
 def link_outputs(
-        cache: CallCache, outputs: Env.Bindings[Value.Base], run_dir: str,
-        hardlinks: bool = False, use_relative_output_paths: bool = False,
+    cache: CallCache,
+    outputs: Env.Bindings[Value.Base],
+    run_dir: str,
+    hardlinks: bool = False,
+    use_relative_output_paths: bool = False,
 ) -> Env.Bindings[Value.Base]:
     """
     Following a successful run, the output files may be scattered throughout a complex directory
@@ -749,7 +758,7 @@ def link_outputs(
                     for i, part in enumerate(reversed(dir_parts)):
                         # Also look for "out" directory in case of hardlinks
                         if part == "work" or (part == "out" and hardlinks):
-                            dn = os.path.join(dn, *dir_parts[len(dir_parts) - i:])
+                            dn = os.path.join(dn, *dir_parts[len(dir_parts) - i :])
                             break
                 if not hardlinks and path_really_within(target, os.path.dirname(run_dir)):
                     # make symlink relative
@@ -759,7 +768,8 @@ def link_outputs(
                     raise FileExistsError(
                         f"Two files have the same link destination: "
                         f"{link_destinations[link]} and {target} are both "
-                        f"written to {link}.")
+                        f"written to {link}."
+                    )
                 link_destinations[link] = target
                 os.makedirs(dn, exist_ok=use_relative_output_paths)
                 if hardlinks:
@@ -838,8 +848,8 @@ def link_outputs(
     if use_relative_output_paths:
         return outputs.map(
             lambda binding: Env.Binding(
-                binding.name,
-                map_paths_relative(copy.deepcopy(binding.value), out_dir))
+                binding.name, map_paths_relative(copy.deepcopy(binding.value), out_dir)
+            )
         )
     return outputs.map(
         lambda binding: Env.Binding(

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -741,15 +741,13 @@ def link_outputs(
                 target = os.path.realpath(target)
                 assert os.path.exists(target)
                 if use_relative_output_paths:
-                    rel_dir = os.path.dirname(target)
-                    while rel_dir and rel_dir != '/':
-                        if os.path.basename(rel_dir) == "work":
-                            relative_output = os.path.relpath(target, rel_dir)
-                            relpath_dir = os.path.dirname(relative_output)
-                            if relpath_dir:
-                                dn = os.path.join(dn, relpath_dir)
+                    # Look for the highest-level "work" directory and make sure
+                    # any directories in there are present in the output structure
+                    dir_parts = os.path.dirname(target).split(os.sep)
+                    for i, part in enumerate(reversed(dir_parts)):
+                        if part == "work":
+                            dn = os.path.join(dn, *dir_parts[len(dir_parts) - i:])
                             break
-                        rel_dir = os.path.dirname(rel_dir)
                 if not hardlinks and path_really_within(target, os.path.dirname(run_dir)):
                     # make symlink relative
                     target = os.path.relpath(target, start=os.path.realpath(dn))

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -740,7 +740,6 @@ def link_outputs(
             if target:
                 target = os.path.realpath(target)
                 assert os.path.exists(target)
-                work_dir = os.path.join(os.path.dirname(run_dir), "work")
                 if use_relative_output_paths:
                     rel_dir = os.path.dirname(target)
                     while rel_dir and rel_dir != '/':

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -745,7 +745,7 @@ def link_outputs(
                 work_dir = os.path.join(os.path.dirname(run_dir), "work")
                 if use_relative_output_paths:
                     rel_dir = os.path.dirname(target)
-                    while rel_dir:
+                    while rel_dir and rel_dir != '/':
                         if os.path.basename(rel_dir) == "work":
                             relative_output = os.path.relpath(target, rel_dir)
                             relpath_dir = os.path.dirname(relative_output)

--- a/WDL/runtime/workflow.py
+++ b/WDL/runtime/workflow.py
@@ -780,7 +780,8 @@ def run_local_workflow(
                     )
                 )
             _outputs = link_outputs(
-                cache, cached, run_dir, hardlinks=cfg["file_io"].get_bool("output_hardlinks")
+                cache, cached, run_dir, hardlinks=cfg["file_io"].get_bool("output_hardlinks"),
+                use_relative_output_paths=cfg["file_io"].get_bool("use_relative_output_paths"),
             )
             write_values_json(
                 cached, os.path.join(run_dir, "outputs.json"), namespace=workflow.name
@@ -932,7 +933,8 @@ def _workflow_main_loop(
 
             # create output_links
             outputs = link_outputs(
-                cache, state.outputs, run_dir, hardlinks=cfg["file_io"].get_bool("output_hardlinks")
+                cache, state.outputs, run_dir, hardlinks=cfg["file_io"].get_bool("output_hardlinks"),
+                use_relative_output_paths=cfg["file_io"].get_bool("use_relative_output_paths"),
             )
 
             # process outputs through plugins

--- a/WDL/runtime/workflow.py
+++ b/WDL/runtime/workflow.py
@@ -780,7 +780,8 @@ def run_local_workflow(
                     )
                 )
             _outputs = link_outputs(
-                cache, cached, run_dir, hardlinks=cfg["file_io"].get_bool("output_hardlinks")
+                cache, cached, run_dir, hardlinks=cfg["file_io"].get_bool("output_hardlinks"),
+                use_relative_output_paths=cfg["file_io"].get_bool("use_relative_output_paths"),
             )
             write_values_json(
                 cached, os.path.join(run_dir, "outputs.json"), namespace=workflow.name

--- a/WDL/runtime/workflow.py
+++ b/WDL/runtime/workflow.py
@@ -780,7 +780,10 @@ def run_local_workflow(
                     )
                 )
             _outputs = link_outputs(
-                cache, cached, run_dir, hardlinks=cfg["file_io"].get_bool("output_hardlinks"),
+                cache,
+                cached,
+                run_dir,
+                hardlinks=cfg["file_io"].get_bool("output_hardlinks"),
                 use_relative_output_paths=cfg["file_io"].get_bool("use_relative_output_paths"),
             )
             write_values_json(
@@ -933,7 +936,10 @@ def _workflow_main_loop(
 
             # create output_links
             outputs = link_outputs(
-                cache, state.outputs, run_dir, hardlinks=cfg["file_io"].get_bool("output_hardlinks"),
+                cache,
+                state.outputs,
+                run_dir,
+                hardlinks=cfg["file_io"].get_bool("output_hardlinks"),
                 # Relative output paths only make sense at the top level, and hence is only used here.
                 use_relative_output_paths=cfg["file_io"].get_bool("use_relative_output_paths"),
             )

--- a/WDL/runtime/workflow.py
+++ b/WDL/runtime/workflow.py
@@ -780,8 +780,7 @@ def run_local_workflow(
                     )
                 )
             _outputs = link_outputs(
-                cache, cached, run_dir, hardlinks=cfg["file_io"].get_bool("output_hardlinks"),
-                use_relative_output_paths=cfg["file_io"].get_bool("use_relative_output_paths"),
+                cache, cached, run_dir, hardlinks=cfg["file_io"].get_bool("output_hardlinks")
             )
             write_values_json(
                 cached, os.path.join(run_dir, "outputs.json"), namespace=workflow.name
@@ -934,6 +933,7 @@ def _workflow_main_loop(
             # create output_links
             outputs = link_outputs(
                 cache, state.outputs, run_dir, hardlinks=cfg["file_io"].get_bool("output_hardlinks"),
+                # Relative output paths only make sense at the top level, and hence is only used here.
                 use_relative_output_paths=cfg["file_io"].get_bool("use_relative_output_paths"),
             )
 

--- a/tests/runner.t
+++ b/tests/runner.t
@@ -11,7 +11,7 @@ source tests/bash-tap/bash-tap-bootstrap
 export PYTHONPATH="$SOURCE_DIR:$PYTHONPATH"
 miniwdl="python3 -m WDL"
 
-plan tests 88
+plan tests 89
 
 $miniwdl run_self_test
 is "$?" "0" "run_self_test"
@@ -162,6 +162,81 @@ cmp -s scatter_echo.wdl scatterrun/wdl/scatter_echo.wdl
 is "$?" "0" "copy_source scatter_echo.wdl"
 cmp -s echo_task.wdl scatterrun/wdl/echo_task.wdl
 is "$?" "0" "copy_source echo_task.wdl"
+
+cat << 'EOF' > create_files.wdl
+version 1.0
+task create_files {
+    command <<<
+        mkdir -p large_matryoshka/medium_matryoskha
+        touch large_matryoshka/medium_matryoskha/small_matryoshka
+        mkdir -p utensils
+        touch utensils/fork utensils/knife utensils/spoon
+        touch unboxed_item
+        mkdir -p turtle/turtle/turtle/turtle/turtle/turtle/
+        touch    turtle/turtle/turtle/turtle/turtle/turtle/turtle
+    >>>
+    output {
+        File small_matryoshka = "large_matryoshka/medium_matryoskha/small_matryoshka"
+        File fork = "utensils/fork"
+        File knife = "utensils/knife"
+        File spoon = "utensils/spoon"
+        File unboxed_item = "unboxed_item"
+        File all_the_way_down = "turtle/turtle/turtle/turtle/turtle/turtle/turtle"
+        # Below arrays will create collisions as these are the same paths as above,
+        # localized to the same links. This should be handled properly.
+        Array[File] utensils = [fork, knife, spoon]
+        Array[File] everything = [small_matryoshka, fork, knife, spoon, unboxed_item, all_the_way_down]
+    }
+}
+EOF
+
+cat << 'EOF' > correct_workflow.wdl
+version 1.0
+import "create_files.wdl" as create_files
+
+workflow filecreator {
+    call create_files.create_files as createFiles {}
+
+    output {
+        Array[File] utensils = createFiles.utensils
+        Array[File] all_stuff = createFiles.everything
+    }
+}
+EOF
+
+OUTPUT_DIR=use_relative_paths/_LAST/out/
+MINIWDL__FILE_IO__USE_RELATIVE_OUTPUT_PATHS=true $miniwdl run --dir use_relative_paths correct_workflow.wdl
+is "$?" "0" relative_output_paths
+test -L $OUTPUT_DIR/large_matryoshka/medium_matryoskha/small_matryoshka
+is "$?" "0" "outputs are relative"
+test -d $OUTPUT_DIR/turtle/turtle/turtle/turtle
+is "$?" "0" "outputs are relative all the way down"
+
+MINIWDL__FILE_IO__USE_RELATIVE_OUTPUT_PATHS=true MINIWDL__FILE_IO__OUTPUT_HARDLINKS=true \
+$miniwdl run --dir use_relative_paths correct_workflow.wdl
+is "$?" "0" relative_output_paths_with_hardlink
+test -f $OUTPUT_DIR/large_matryoshka/medium_matryoskha/small_matryoshka
+is "$?" "0" "outputs are relative using hardlinks"
+test -d $OUTPUT_DIR/turtle/turtle/turtle/turtle
+is "$?" "0" "outputs are relative all the way down using hardlinks"
+
+cat << 'EOF' > colliding_workflow.wdl
+version 1.0
+import "create_files.wdl" as create_files
+
+workflow filecollider {
+    call create_files.create_files as createFiles {}
+    call create_files.create_files as createFiles2 {}
+    output {
+        Array[File] all_stuff1 = createFiles.everything
+        Array[File] all_stuff2 = createFiles2.everything
+    }
+}
+EOF
+
+MINIWDL__FILE_IO__USE_RELATIVE_OUTPUT_PATHS=true $miniwdl run --dir use_relative_paths colliding_workflow.wdl 2> errors.txt
+grep -q "Two files have the same link destination" errors.txt
+is "$?" "0" "use_relative_output_paths throws error on collisions"
 
 cat << 'EOF' > failer2000.wdl
 version 1.0
@@ -524,60 +599,3 @@ workflow outer {
 EOF
 MINIWDL__SCHEDULER__SUBWORKFLOW_CONCURRENCY=2 $miniwdl run --dir nested_deadlock outer.wdl
 is "$?" "0" "avoid deadlocking on nested subworkflows"
-
-cat << 'EOF' > create_files.wdl
-version 1.0
-task create_files {
-    command <<<
-        mkdir -p large_matryoshka/medium_matryoskha
-        touch large_matryoshka/medium_matryoskha/small_matryoshka
-        mkdir -p utensils
-        touch utensils/fork utensils/knife utensils/spoon
-        touch unboxed_item
-        mkdir -p turtle/turtle/turtle/turtle/turtle/turtle/
-        touch    turtle/turtle/turtle/turtle/turtle/turtle/turtle
-    >>>
-    output {
-        File small_matryoshka = "large_matryoshka/medium_matryoskha/small_matryoshka"
-        File fork = "utensils/fork"
-        File knife = "utensils/knife"
-        File spoon = "utensils/spoon"
-        File unboxed_item = "unboxed_item"
-        File all_the_way_down = "turtle/turtle/turtle/turtle/turtle/turtle/turtle"
-        # Below arrays will create collisions as these are the same paths as above,
-        # localized to the same links. This should be handled properly.
-        Array[File] utensils = [fork, knife, spoon]
-        Array[File] everything = [small_matryoshka, fork, knife, spoon, unboxed_item, all_the_way_down]
-    }
-}
-EOF
-
-cat << 'EOF' > correct_workflow.wdl
-version 1.0
-import "create_files.wdl" as create_files
-
-workflow filecreator {
-    call create_files.create_files as createFiles {}
-
-    output {
-        Array[File] utensils = createFiles.utensils
-        Array[File] all_stuff = createFiles.everything
-    }
-}
-EOF
-
-OUTPUT_DIR=use_relative_paths/_LAST/out/
-MINIWDL__FILE_IO__USE_RELATIVE_OUTPUT_PATHS=true $miniwdl run --dir use_relative_paths correct_workflow.wdl
-is "$?" "0" relative_output_paths
-test -L $OUTPUT_DIR/large_matryoshka/medium_matryoskha/small_matryoshka
-is "$?" "0" "outputs are relative"
-test -d $OUTPUT_DIR/turtle/turtle/turtle/turtle
-is "$?" "0" "outputs are relative all the way down"
-
-MINIWDL__FILE_IO__USE_RELATIVE_OUTPUT_PATHS=true MINIWDL__FILE_IO__OUTPUT_HARDLINKS=true \
-$miniwdl run --dir use_relative_paths correct_workflow.wdl
-is "$?" "0" relative_output_paths_with_hardlink
-test -f $OUTPUT_DIR/large_matryoshka/medium_matryoskha/small_matryoshka
-is "$?" "0" "outputs are relative using hardlinks"
-test -d $OUTPUT_DIR/turtle/turtle/turtle/turtle
-is "$?" "0" "outputs are relative all the way down using hardlinks"

--- a/tests/runner.t
+++ b/tests/runner.t
@@ -11,7 +11,7 @@ source tests/bash-tap/bash-tap-bootstrap
 export PYTHONPATH="$SOURCE_DIR:$PYTHONPATH"
 miniwdl="python3 -m WDL"
 
-plan tests 82
+plan tests 88
 
 $miniwdl run_self_test
 is "$?" "0" "run_self_test"
@@ -524,3 +524,60 @@ workflow outer {
 EOF
 MINIWDL__SCHEDULER__SUBWORKFLOW_CONCURRENCY=2 $miniwdl run --dir nested_deadlock outer.wdl
 is "$?" "0" "avoid deadlocking on nested subworkflows"
+
+cat << 'EOF' > create_files.wdl
+version 1.0
+task create_files {
+    command <<<
+        mkdir -p large_matryoshka/medium_matryoskha
+        touch large_matryoshka/medium_matryoskha/small_matryoshka
+        mkdir -p utensils
+        touch utensils/fork utensils/knife utensils/spoon
+        touch unboxed_item
+        mkdir -p turtle/turtle/turtle/turtle/turtle/turtle/
+        touch    turtle/turtle/turtle/turtle/turtle/turtle/turtle
+    >>>
+    output {
+        File small_matryoshka = "large_matryoshka/medium_matryoskha/small_matryoshka"
+        File fork = "utensils/fork"
+        File knife = "utensils/knife"
+        File spoon = "utensils/spoon"
+        File unboxed_item = "unboxed_item"
+        File all_the_way_down = "turtle/turtle/turtle/turtle/turtle/turtle/turtle"
+        # Below arrays will create collisions as these are the same paths as above,
+        # localized to the same links. This should be handled properly.
+        Array[File] utensils = [fork, knife, spoon]
+        Array[File] everything = [small_matryoshka, fork, knife, spoon, unboxed_item, all_the_way_down]
+    }
+}
+EOF
+
+cat << 'EOF' > correct_workflow.wdl
+version 1.0
+import "create_files.wdl" as create_files
+
+workflow filecreator {
+    call create_files.create_files as createFiles {}
+
+    output {
+        Array[File] utensils = createFiles.utensils
+        Array[File] all_stuff = createFiles.everything
+    }
+}
+EOF
+
+OUTPUT_DIR=use_relative_paths/_LAST/out/
+MINIWDL__FILE_IO__USE_RELATIVE_OUTPUT_PATHS=true $miniwdl run --dir use_relative_paths correct_workflow.wdl
+is "$?" "0" relative_output_paths
+test -L $OUTPUT_DIR/large_matryoshka/medium_matryoskha/small_matryoshka
+is "$?" "0" "outputs are relative"
+test -d $OUTPUT_DIR/turtle/turtle/turtle/turtle
+is "$?" "0" "outputs are relative all the way down"
+
+MINIWDL__FILE_IO__USE_RELATIVE_OUTPUT_PATHS=true MINIWDL__FILE_IO__OUTPUT_HARDLINKS=true \
+$miniwdl run --dir use_relative_paths correct_workflow.wdl
+is "$?" "0" relative_output_paths_with_hardlink
+test -f $OUTPUT_DIR/large_matryoshka/medium_matryoskha/small_matryoshka
+is "$?" "0" "outputs are relative using hardlinks"
+test -d $OUTPUT_DIR/turtle/turtle/turtle/turtle
+is "$?" "0" "outputs are relative all the way down using hardlinks"


### PR DESCRIPTION
<!---  Thank you for contributing to miniwdl! Please see the CONTRIBUTING.md guidelines and observe the PR checklist below. --->

### Motivation

#604 

### Approach

As suggested, modify the link_outputs function. I wrote a small map_paths_relative function that is much simpler and for `File` and `Directory` types just defers to map_paths. That way the handling of hardlinks etc. is correctly handled and there is no code duplication. I added a few small code snippets to the `File`/`Directory` section of map_paths to handle the relativity part.
 
I added a test, and also tested using BioWDL's germline-DNA pipeline manually to verify that multiple nested subworkflows do not influence the result.

### Checklist

<!--- You're welcome to open a draft PR to request guidance on testing or Pyre/Pylint problems. --->
- [x] Add appropriate test(s) to the automatic suite
- [x] Use `make pretty` to reformat the code with [black](https://github.com/python/black)
- [x] Use `make check` to statically check the code using [Pyre](https://pyre-check.org/) and [Pylint](https://www.pylint.org/)
- [x] Send PR from a dedicated branch without unrelated edits
- [x] Ensure compatibility with this project's MIT license
