### PR TITLE
task env declarations

### DIFF
--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -171,7 +171,7 @@ class Decl(WorkflowNode):
     """:type: Optional[WDL.Expr.Base]
 
     Bound expression, if any"""
-    decor: Dict[str, Any]
+    decor: Dict[str, Any]  # EXPERIMENTAL
     ""
 
     def __init__(

--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -171,6 +171,8 @@ class Decl(WorkflowNode):
     """:type: Optional[WDL.Expr.Base]
 
     Bound expression, if any"""
+    decor: Dict[str, Any]
+    ""
 
     def __init__(
         self,
@@ -184,6 +186,7 @@ class Decl(WorkflowNode):
         self.type = type
         self.name = name
         self.expr = expr
+        self.decor = {}
 
     def __str__(self) -> str:
         if self.expr is None:

--- a/WDL/_grammar.py
+++ b/WDL/_grammar.py
@@ -309,15 +309,18 @@ call_input: CNAME ["=" expr]
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 task: "task" CNAME "{" task_section* command task_section* "}"
-?task_section: input_decls
+?task_section: task_input_decls
              | output_decls
              | meta_section
              | runtime_section
-             | any_decl -> noninput_decl
+             | task_env_decl -> noninput_decl
 
 tasks: task*
 
 input_decls: "input" "{" any_decl* "}"
+task_input_decls: "input" "{" task_env_decl* "}" -> input_decls
+ENV.2: "env"
+task_env_decl: ENV? any_decl
 output_decls: "output" "{" bound_decl* "}"
 
 // WDL task commands: with {} and <<< >>> command and ${} and ~{} placeholder styles
@@ -483,9 +486,11 @@ COMMENT: /[ \t]*/ "#" /[^\r\n]*/
 %ignore COMMENT
 """
 keywords["development"] = set(
-    "Array Directory File Float Int Map None Pair String alias as call command else false if import input left meta object output parameter_meta right runtime scatter struct task then true workflow".split(
-        " "
-    )
+    (
+        "Array Directory File Float Int Map None Pair String"
+        " alias as call command else env false if import input left meta"
+        " object output parameter_meta right runtime scatter struct task then true workflow"
+    ).split(" ")
 )
 
 # For now we're defining 1.1 as 'development minus Directory' (the latter enforced in _parser).

--- a/WDL/_parser.py
+++ b/WDL/_parser.py
@@ -333,6 +333,15 @@ class _DocTransformer(_ExprTransformer):
             self._sp(meta), items[0], items[1].value, (items[2] if len(items) > 2 else None)
         )
 
+    def task_env_decl(self, meta, items):
+        if len(items) == 2:
+            assert items[0].value == "env"
+            assert isinstance(items[1], Tree.Decl)
+            items[1].decor["env"] = True
+            return items[1]
+        assert len(items) == 1 and isinstance(items[0], Tree.Decl)
+        return items[0]
+
     def input_decls(self, meta, items):
         return {"inputs": items}
 

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -485,6 +485,7 @@ def _eval_task_runtime(
         logger.info(_("effective runtime", **container.runtime_values))
 
     # add any configured overrides for in-container environment variables
+    container.runtime_values.setdefault("env", {})
     env_vars_override = {}
     env_vars_skipped = []
     for ev_name, ev_value in cfg["task_runtime"].get_dict("env").items():
@@ -516,7 +517,23 @@ def _eval_task_runtime(
         logger.debug(
             _("overriding environment variables (portability warning)", **env_vars_override)
         )
-        container.runtime_values.setdefault("env", {}).update(env_vars_override)
+        container.runtime_values["env"].update(env_vars_override)
+
+    # process decls with "env" decorator
+    env_decls = {}
+    for decl in (task.inputs or []) + task.postinputs:
+        if decl.decor.get("env", False) is True:
+            if not env_decls:
+                logger.warning(
+                    "task env declarations are an experimental feature, subject to change"
+                )
+            v = env[decl.name]
+            if isinstance(v, (Value.String, Value.File, Value.Directory)):
+                v = v.value
+            else:
+                v = json.dumps(v.json)
+            env_decls[decl.name] = v
+    container.runtime_values["env"].update(env_decls)
 
     unused_keys = list(
         key

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -519,7 +519,7 @@ def _eval_task_runtime(
         )
         container.runtime_values["env"].update(env_vars_override)
 
-    # process decls with "env" decorator
+    # process decls with "env" decorator (EXPERIMENTAL)
     env_decls = {}
     for decl in (task.inputs or []) + task.postinputs:
         if decl.decor.get("env", False) is True:

--- a/tests/test_7runner.py
+++ b/tests/test_7runner.py
@@ -1303,4 +1303,27 @@ class TestEnvDecl(RunnerTestCase):
         """, {})
         assert outp["messages"] == ["Hello, Alyssa!", "Hello, Ben!"]
 
-    # TODO: test files, JSONification of compound types
+    def test_more(self):
+        with open(os.path.join(self._dir, "alyssa.txt"), mode="w") as outfile:
+            print("Alyssa", file=outfile)
+        outp = self._run("""
+            version development
+            struct Person {
+                File name
+                Int age
+            }
+            task t {
+                input {
+                    env Person p
+                }
+                env File name = p.name
+                command <<<
+                    echo "Hello, $(cat "$name")!" | tee /dev/stderr
+                    echo "$p" | tr -d ' ' | grep '"age":42' >&2
+                >>>
+                output {
+                    String message = read_string(stdout())
+                }
+            }
+        """, {"p": {"name": os.path.join(self._dir, "alyssa.txt"), "age": 42}})
+        assert outp["message"] == "Hello, Alyssa!"


### PR DESCRIPTION
Prototypes making task declarations populate container environment variables by prefixing the declaration with the `env` keyword

under discussion in https://github.com/openwdl/wdl/pull/504
alternative to #503