### PR TITLE
correct graphviz conda package

### DIFF
--- a/docs/wdlviz.md
+++ b/docs/wdlviz.md
@@ -2,7 +2,7 @@
 
 In this lab, we'll develop a Python program using miniwdl's API to generate a [graphviz](https://www.graphviz.org/) visualization of a WDL workflow's internal dependency structure. We'll keep this example brief and barebones, while a more-elaborate version can be found [in the miniwdl repo](https://github.com/chanzuckerberg/miniwdl/blob/main/examples/wdlviz.py).
 
-Begin by installing (i) graphviz using your OS package manager (e.g. `apt install graphviz`), and (ii) either `pip3 install miniwdl graphviz` or `conda install miniwdl graphviz` as you prefer.
+Begin by installing (i) graphviz using your OS package manager (e.g. `apt install graphviz`), and (ii) either `pip3 install miniwdl graphviz` or `conda install miniwdl python-graphviz` as you prefer.
 
 
 ## Loading the WDL document


### PR DESCRIPTION
<!---  Thank you for contributing to miniwdl! Please see the CONTRIBUTING.md guidelines and observe the PR checklist below. --->

### Motivation

Documentation for wdlviz lists wrong conda package. This is a quick update so that conda users install `python-graphviz` (correct), not `graphviz` (incorrect).

<!--- and/or link to related GitHub issue --->

### Approach

Just substituted the correct package name for the incorrect one.

### Checklist

<!--- You're welcome to open a draft PR to request guidance on testing or Pyre/Pylint problems. --->

Honestly, I haven't completed any of the checklist items. But, because this is just a quick update to the documentation and only consists of adding a few letters, I doubt all of these are necessary. If you need me to complete any of these extra steps though, let me know. Thanks!

- [ ] Add appropriate test(s) to the automatic suite
- [ ] Use `make pretty` to reformat the code with [black](https://github.com/python/black)
- [ ] Use `make check` to statically check the code using [Pyre](https://pyre-check.org/) and [Pylint](https://www.pylint.org/)
- [ ] Send PR from a dedicated branch without unrelated edits
- [ ] Ensure compatibility with this project's MIT license
