### PR TITLE
Additional files can be zipped in with miniwdl zip. Fix for cross-device link error.

### DIFF
--- a/WDL/CLI.py
+++ b/WDL/CLI.py
@@ -2000,6 +2000,13 @@ def fill_zip_subparser(subparsers):
         metavar="JSON_OR_FILE",
         help="input JSON to include as defaults",
     )
+    zip_parser.add_argument(
+        "-a",
+        "--additional",
+        metavar="FILE",
+        help="Additional files to include in the zip. Files will be included "
+             "in the zip root. Can be supplied multiple times."
+    )
     return zip_parser
 
 
@@ -2011,6 +2018,7 @@ def zip_wdl(
     check_quant=True,
     path=None,
     no_outside_imports=False,
+    additional_files=None,
     debug=False,
     **kwargs,
 ):
@@ -2053,7 +2061,8 @@ def zip_wdl(
             die(output + " already exists; add --force to override")
         fmt = "tar" if output.endswith(".tar") else "zip"
 
-        Zip.build(doc, output, logger, meta=meta, inputs=input_dict, archive_format=fmt)
+        Zip.build(doc, output, logger, meta=meta, inputs=input_dict, archive_format=fmt,
+                  additional_files=additional_files)
 
 
 def pkg_version(pkg="miniwdl"):

--- a/WDL/CLI.py
+++ b/WDL/CLI.py
@@ -2005,9 +2005,9 @@ def fill_zip_subparser(subparsers):
         "--additional",
         metavar="FILE",
         help="Additional files to include in the zip. Files will be included "
-             "in the zip root. Can be supplied multiple times.",
+        "in the zip root. Can be supplied multiple times.",
         action="append",
-        dest="additional_files"
+        dest="additional_files",
     )
     return zip_parser
 
@@ -2063,8 +2063,15 @@ def zip_wdl(
             die(output + " already exists; add --force to override")
         fmt = "tar" if output.endswith(".tar") else "zip"
 
-        Zip.build(doc, output, logger, meta=meta, inputs=input_dict, archive_format=fmt,
-                  additional_files=additional_files)
+        Zip.build(
+            doc,
+            output,
+            logger,
+            meta=meta,
+            inputs=input_dict,
+            archive_format=fmt,
+            additional_files=additional_files,
+        )
 
 
 def pkg_version(pkg="miniwdl"):

--- a/WDL/CLI.py
+++ b/WDL/CLI.py
@@ -2005,7 +2005,9 @@ def fill_zip_subparser(subparsers):
         "--additional",
         metavar="FILE",
         help="Additional files to include in the zip. Files will be included "
-             "in the zip root. Can be supplied multiple times."
+             "in the zip root. Can be supplied multiple times.",
+        action="append",
+        dest="additional_files"
     )
     return zip_parser
 

--- a/WDL/Zip.py
+++ b/WDL/Zip.py
@@ -55,7 +55,7 @@ def build(
         if additional_files:
             logger.debug(f"Additional files: {additional_files}")
             for file in additional_files:
-                dest_path =os.path.join(dir_to_zip, os.path.basename(file))
+                dest_path = os.path.join(dir_to_zip, os.path.basename(file))
                 shutil.copy(file, dest_path)
 
         # zip the temp directory (into another temp directory)

--- a/WDL/Zip.py
+++ b/WDL/Zip.py
@@ -69,7 +69,7 @@ def build(
         if dirname:
             os.makedirs(dirname, exist_ok=True)
         logger.info(f"Move archive to destination {archive}")
-        os.rename(spool_zip, archive)
+        shutil.move(spool_zip, archive)
 
 
 def build_source_dir(

--- a/WDL/Zip.py
+++ b/WDL/Zip.py
@@ -56,6 +56,8 @@ def build(
             logger.debug(f"Additional files: {additional_files}")
             for file in additional_files:
                 dest_path = os.path.join(dir_to_zip, os.path.basename(file))
+                if os.path.exists(dest_path):
+                    raise FileExistsError(f"Additional file overwrites existing path: {dest_path}")
                 shutil.copy(file, dest_path)
 
         # zip the temp directory (into another temp directory)

--- a/WDL/Zip.py
+++ b/WDL/Zip.py
@@ -26,6 +26,7 @@ def build(
     inputs: Optional[Dict[str, Any]] = None,
     meta: Optional[Dict[str, Any]] = None,
     archive_format: str = "zip",
+    additional_files: Optional[List[str]] = None,
 ):
     """
     Generate zip archive of the WDL document, all its imports, optional default inputs, and a
@@ -51,6 +52,11 @@ def build(
         with open(os.path.join(dir_to_zip, "MANIFEST.json"), "w") as manifest_file:
             json.dump(manifest, manifest_file, indent=2)
         logger.debug("manifest = " + json.dumps(manifest))
+        if additional_files:
+            logger.debug(f"Additional files: {additional_files}")
+            for file in additional_files:
+                dest_path =os.path.join(dir_to_zip, os.path.basename(file))
+                shutil.copy(file, dest_path)
 
         # zip the temp directory (into another temp directory)
         spool_dir = cleanup.enter_context(tempfile.TemporaryDirectory(prefix="miniwdl_zip_"))

--- a/tests/test_3corpi.py
+++ b/tests/test_3corpi.py
@@ -581,13 +581,16 @@ class TestZip(unittest.TestCase):
             meta = {"foo": "bar"}
             main_wdl = os.path.basename(doc.pos.abspath)
             zip_fn = os.path.join(testdir, main_wdl + ".zip")
+            additional_files = [__file__]
             WDL.Zip.build(
-                doc, zip_fn, logging.getLogger("miniwdl_zip_test"), meta=meta, inputs=inputs
+                doc, zip_fn, logging.getLogger("miniwdl_zip_test"), meta=meta,
+                inputs=inputs, additional_files=additional_files
             )
 
             source_dir, main_wdl, inputs_file = cleanup.enter_context(WDL.Zip.unpack(zip_fn))
             assert not inputs or inputs_file
             WDL.load(os.path.join(source_dir, main_wdl))
+            self.assertTrue(os.path.isfile(os.path.join(source_dir, os.path.basename(__file__))))
 
             # cover misc code paths through WDL.Zip.unpack()
             WDL.load(cleanup.enter_context(WDL.Zip.unpack(source_dir)).main_wdl)


### PR DESCRIPTION
<!---  Thank you for contributing to miniwdl! Please see the CONTRIBUTING.md guidelines and observe the PR checklist below. --->

### Motivation
...
#640 

### Approach
Simply add the flag :wink:. 
There is also one bug fix about an invalid cross-device link that gets triggered because I have my `/home` dir on a separate partition. So `/tmp` and `/home` are on different devices and this triggers an invalid cross-device link warning when os.rename is used. I use the higher level shutil.move instead. This bug fix is in a single commit that can be cherry picked. 

I have not added tests yet because you might have different ideas about how to implement this. I think a "--license" flag to include a license file that also gets added to the manifest would be quite a neat feature for redistributable WDL packages.

### Checklist

<!--- You're welcome to open a draft PR to request guidance on testing or Pyre/Pylint problems. --->
- [ ] Add appropriate test(s) to the automatic suite
- [x] Use `make pretty` to reformat the code with [black](https://github.com/python/black)
- [x] Use `make check` to statically check the code using [Pyre](https://pyre-check.org/) and [Pylint](https://www.pylint.org/)
- [ ] Send PR from a dedicated branch without unrelated edits
- [x] Ensure compatibility with this project's MIT license
