### PR TITLE
Make export function preserve types

### DIFF
--- a/WDL/_util.py
+++ b/WDL/_util.py
@@ -37,8 +37,8 @@ T = TypeVar("T")
 __all__: List[str] = []
 
 
-def export(obj: T) -> T:  # pyre-ignore
-    __all__.append(obj.__name__)
+def export(obj: T) -> T:
+    __all__.append(obj.__name__)  # pyre-ignore
     return obj
 
 

--- a/WDL/_util.py
+++ b/WDL/_util.py
@@ -69,8 +69,6 @@ def strip_leading_whitespace(txt: str) -> Tuple[int, str]:
     return (to_strip, "\n".join(lines))
 
 
-
-
 @export
 class AdjM(Generic[T]):
     # A sparse adjacency matrix for topological sorting

--- a/WDL/_util.py
+++ b/WDL/_util.py
@@ -32,10 +32,12 @@ from typing import (
 from types import FrameType
 from pythonjsonlogger import jsonlogger
 
+T = TypeVar("T")
+
 __all__: List[str] = []
 
 
-def export(obj) -> str:  # pyre-ignore
+def export(obj: T) -> T:  # pyre-ignore
     __all__.append(obj.__name__)
     return obj
 
@@ -67,7 +69,6 @@ def strip_leading_whitespace(txt: str) -> Tuple[int, str]:
     return (to_strip, "\n".join(lines))
 
 
-T = TypeVar("T")
 
 
 @export


### PR DESCRIPTION
<!---  Thank you for contributing to miniwdl! Please see the CONTRIBUTING.md guidelines and observe the PR checklist below. --->

### Motivation
This should fix #665.

### Approach
I made the `@export` annotation function generic so it returns the same type as its input.

### Checklist

<!--- You're welcome to open a draft PR to request guidance on testing or Pyre/Pylint problems. --->
- [ ] Add appropriate test(s) to the automatic suite
- [X] Use `make pretty` to reformat the code with [black](https://github.com/python/black)
- [ ] Use `make check` to statically check the code using [Pyre](https://pyre-check.org/) and [Pylint](https://www.pylint.org/)
    **Does not work**, `pyre-check==0.0.27` is required according to `requirements-dev.txt`, which is not available for any Python newer than 3.6, which ended security support on 23 Dec 2021. Current `pyre-check` versions do not have the `--show-parse-errors` option used in the script.
- [X] Send PR from a dedicated branch without unrelated edits
- [X] Ensure compatibility with this project's MIT license
