### PR TITLE
Added support for float input in scientific notation and removed float rounding.

### DIFF
--- a/WDL/Value.py
+++ b/WDL/Value.py
@@ -120,7 +120,7 @@ class Float(Base):
         super().__init__(Type.Float(), value, expr)
 
     def __str__(self) -> str:
-        #converting to string using repr to retain the float value as is and eliminating rounding.
+        # converting to string using repr to retain the float value as is and eliminating rounding.
         return repr(self.value)
 
 
@@ -550,7 +550,7 @@ def from_json(type: Type.Base, value: Any) -> Base:
         return Int(value)
     if isinstance(type, (Type.Float, Type.Any)) and isinstance(value, (float, int)):
         return Float(float(value))
-    if isinstance(type, (Type.Float, Type.Any)) and 'e' in value.lower():
+    if isinstance(type, (Type.Float, Type.Any)) and "e" in value.lower():
         return Float(float(value))
     if isinstance(type, Type.File) and isinstance(value, str):
         return File(value)

--- a/WDL/Value.py
+++ b/WDL/Value.py
@@ -120,7 +120,8 @@ class Float(Base):
         super().__init__(Type.Float(), value, expr)
 
     def __str__(self) -> str:
-        return "{:.6f}".format(self.value)
+        #converting to string using repr to retain the float value as is and eliminating rounding.
+        return repr(self.value)
 
 
 class Int(Base):
@@ -548,6 +549,8 @@ def from_json(type: Type.Base, value: Any) -> Base:
     if isinstance(type, (Type.Int, Type.Any)) and isinstance(value, int):
         return Int(value)
     if isinstance(type, (Type.Float, Type.Any)) and isinstance(value, (float, int)):
+        return Float(float(value))
+    if isinstance(type, (Type.Float, Type.Any)) and 'e' in value.lower():
         return Float(float(value))
     if isinstance(type, Type.File) and isinstance(value, str):
         return File(value)


### PR DESCRIPTION
<!---  Thank you for contributing to miniwdl! Please see the CONTRIBUTING.md guidelines and observe the PR checklist below. --->

### Motivation
There is no support for floating-point inputs with scientific notation in the current implementation of miniWDL. Float values are rounded to 6 decimal points only; for example, floats smaller than 0.000001 are rounded to 0.0. Adding support for float input in scientific notation and removing float rounding using repr method to keep the input float value as is.
NOTE: floats smaller than 0.0001 will be return in scientific notations.
<!--- and/or link to related GitHub issue --->

### Approach
...

### Checklist

<!--- You're welcome to open a draft PR to request guidance on testing or Pyre/Pylint problems. --->
- [ ] Add appropriate test(s) to the automatic suite
- [ ] Use `make pretty` to reformat the code with [black](https://github.com/python/black)
- [ ] Use `make check` to statically check the code using [Pyre](https://pyre-check.org/) and [Pylint](https://www.pylint.org/)
- [ ] Send PR from a dedicated branch without unrelated edits
- [ ] Ensure compatibility with this project's MIT license
