### PR TITLE
Docker and singularity login at runtime

### DIFF
--- a/WDL/runtime/backend/cli_subprocess.py
+++ b/WDL/runtime/backend/cli_subprocess.py
@@ -132,7 +132,7 @@ class SubprocessBase(TaskContainer):
         return (image, self.cli_exe + ["pull", image])
 
     @abstractmethod
-    def _login_invocation(self, logger: logging.Logger, cleanup: ExitStack, image: str) -> List[str]:
+    def _login_invocation(self, logger: logging.Logger) -> Optional[List[str]]:
         pass
 
     @abstractmethod
@@ -235,7 +235,9 @@ class SubprocessBase(TaskContainer):
                             check=True,
                         )
 
-                        logger.info(_(f"retry {self.cli_name} pull", command=" ".join(pull_invocation)))
+                        logger.info(
+                            _(f"retry {self.cli_name} pull", command=" ".join(pull_invocation))
+                        )
                         subprocess.run(
                             pull_invocation,
                             stdout=subprocess.PIPE,

--- a/WDL/runtime/backend/cli_subprocess.py
+++ b/WDL/runtime/backend/cli_subprocess.py
@@ -128,10 +128,12 @@ class SubprocessBase(TaskContainer):
         return [self.cli_name]
 
     def _pull_invocation(self, logger: logging.Logger, cleanup: ExitStack) -> Tuple[str, List[str]]:
-        image = self.runtime_values.get(
-            "docker", self.cfg.get_dict("task_runtime", "defaults")["docker"]
-        )
+        image = self._get_runtime_image()
         return (image, self.cli_exe + ["pull", image])
+
+    @abstractmethod
+    def _login_invocation(self, logger: logging.Logger, cleanup: ExitStack, image: str) -> List[str]:
+        pass
 
     @abstractmethod
     def _run_invocation(self, logger: logging.Logger, cleanup: ExitStack, image: str) -> List[str]:
@@ -183,7 +185,7 @@ class SubprocessBase(TaskContainer):
         Pull the image under a global lock, ensuring we'll only download it once even if used by
         many parallel tasks all starting at the same time.
         """
-        image, invocation = self._pull_invocation(logger, cleanup)
+        image, pull_invocation = self._pull_invocation(logger, cleanup)
         with self._pulled_images_lock:
             if image in self._pulled_images:
                 logger.info(_(f"{self.cli_name} image already pulled", image=image))
@@ -197,13 +199,13 @@ class SubprocessBase(TaskContainer):
                     logger.info(_(f"{self.cli_name} image already pulled", image=image))
                     return image
 
-            if not invocation:
+            if not pull_invocation:
                 # No action required, image could be cached externally.
                 return image
-            logger.info(_(f"begin {self.cli_name} pull", command=" ".join(invocation)))
+            logger.info(_(f"begin {self.cli_name} pull", command=" ".join(pull_invocation)))
             try:
                 subprocess.run(
-                    invocation,
+                    pull_invocation,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     universal_newlines=True,
@@ -217,7 +219,43 @@ class SubprocessBase(TaskContainer):
                         stdout=cpe.stdout.strip().split("\n"),
                     )
                 )
-                raise DownloadFailed(image) from None
+                raise_error = True
+
+                logger.info("Pull failed, try to login")
+                # I didn't find a way to test in advance if registry login is needed for a specific registry
+                # using singularity cli, therefore we try to login if pull fails and pull again
+                login_invocation = self._login_invocation(logger)
+                if login_invocation:
+                    try:
+                        subprocess.run(
+                            login_invocation,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            universal_newlines=True,
+                            check=True,
+                        )
+
+                        logger.info(_(f"retry {self.cli_name} pull", command=" ".join(pull_invocation)))
+                        subprocess.run(
+                            pull_invocation,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            universal_newlines=True,
+                            check=True,
+                        )
+                        raise_error = False
+                    except subprocess.CalledProcessError as cpe:
+                        logger.error(
+                            _(
+                                f"Retry {self.cli_name} pull failed",
+                                stderr=cpe.stderr.strip().split("\n"),
+                                stdout=cpe.stdout.strip().split("\n"),
+                            )
+                        )
+
+                if raise_error:
+                    raise DownloadFailed(image) from None
+
             with self._pulled_images_lock:
                 self._pulled_images.add(image)
 

--- a/WDL/runtime/backend/docker_swarm.py
+++ b/WDL/runtime/backend/docker_swarm.py
@@ -35,12 +35,6 @@ from ..task_container import TaskContainer
 logging.getLogger("botocore").setLevel(logging.WARNING)
 
 
-class SupportedProviders(Enum):
-    AWS = "aws"
-    GCP = "gcp"
-    UNKNOWN = None
-
-
 class SwarmContainer(TaskContainer):
     """
     TaskContainer docker (swarm) runtime
@@ -344,16 +338,10 @@ class SwarmContainer(TaskContainer):
                 # docker.errors.APIError is thrown if permissions are missing
                 client.images.get_registry_data(image_tag)  # type: ignore[attr-defined]
             except docker.errors.APIError:
-                logger.debug(f"Need to login to {image_tag} registry")
-                registry_name, provider = self.get_registry_name_and_provider(logger, image_tag)
-                if registry_name and provider is SupportedProviders.AWS:
-                    self.aws_ecr_login(logger, client, registry_name)
-                if registry_name and provider is SupportedProviders.GCP:
-                    self.gcp_docker_registry_login(client, registry_name)
-                if provider is SupportedProviders.UNKNOWN:
-                    logger.warning(
-                        f"{image_tag} registry pattern unrecognized. If login is needed do it before running the workflow"
-                    )
+                user, password, registry_name = super().get_image_registry_credentials(logger, image_tag, client)
+                if all((user, password, registry_name)):
+                    self.docker_login(logger, client, user, password, registry_name)
+                                
             try:
                 logger.info(_("docker pull", tag=image_tag))
                 client.images.pull(image_tag)
@@ -371,60 +359,10 @@ class SwarmContainer(TaskContainer):
         logger.notice(_("docker image", **image_log))
         return image_tag
 
-    def get_registry_name_and_provider(
-        self, logger: logging.Logger, image_tag: str
-    ) -> Tuple[str | None, SupportedProviders]:
-        logger.debug(f"Get registry name and provider for {image_tag}")
-        # GCP:
-        #   - <LOCATION>-docker.pkg.dev/<PROJECT-ID>/<REPOSITORY>
-        #   - <LOCATION>.gcr.io/<PROJECT-ID> (legacy)
-        gcp_registry_pattern = (
-            r"^(?P<gcp>[a-z-]+[0-9]+-docker\.pkg\.dev/[a-z0-9-]+/[a-z0-9-]+|[a-z\.]*gcr\.io)/.*$"
-        )
-        # AWS:
-        #   - <AWS_ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com
-        aws_registry_pattern = r"^(?P<aws>[0-9]{12}\.dkr\.ecr\.[a-z-]+[0-9]+\.amazonaws\.com)/.*$"
-
-        pattern_match = re.match(gcp_registry_pattern, image_tag) or re.match(
-            aws_registry_pattern, image_tag
-        )
-        registry_name = pattern_match.group(1) if pattern_match else None
-        provider = SupportedProviders(
-            list(pattern_match.groupdict().keys())[0] if pattern_match else None
-        )
-        logger.debug(f"Registry: {registry_name}. Provider: {provider}")
-        return registry_name, provider
-
-    def aws_ecr_login(
-        self, logger: logging.Logger, docker_client: docker.DockerClient, registry_name: str
-    ) -> None:
-        logger.debug(f"Get region and account ID from registry name {registry_name}")
-        aws_account_id, _, _, aws_region, _, _ = registry_name.split(".")
-        logger.debug(f"AWS account: {aws_account_id}. Region: {aws_region}")
-        ecr_client = boto3.client("ecr", region_name=aws_region)
-        logger.debug(f"Get ECR token for {registry_name}")
-        response = ecr_client.get_authorization_token(registryIds=[aws_account_id])
-        ecr_password = (
-            base64.b64decode(response["authorizationData"][0]["authorizationToken"])
-            .replace(b"AWS:", b"")
-            .decode("utf-8")
-        )
-        logger.debug(f"Login to {registry_name}")
-        self.docker_login(docker_client, "AWS", ecr_password, registry_name)
-
-    def gcp_docker_registry_login(self, client: docker.DockerClient, registry_name: str) -> None:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            creds, _ = google.auth.default(
-                scopes=["https://www.googleapis.com/auth/cloud-platform"]
-            )
-            auth_req = google.auth.transport.requests.Request()
-            creds.refresh(auth_req)
-            self.docker_login(client, "oauth2accesstoken", creds.token, registry_name)
-
     def docker_login(
-        self, client: docker.DockerClient, username: str, password: str, registry_name: str
+        self, logger: logging.Logger, client: docker.DockerClient, username: str, password: str, registry_name: str
     ) -> None:
+        logger.debug(f"Login to {registry_name} registry")
         client.login(username, password, registry=registry_name, reauth=True)  # type: ignore[attr-defined]
 
     def prepare_mounts(self, logger: logging.Logger) -> List[docker.types.Mount]:

--- a/WDL/runtime/backend/docker_swarm.py
+++ b/WDL/runtime/backend/docker_swarm.py
@@ -425,7 +425,7 @@ class SwarmContainer(TaskContainer):
     def docker_login(
         self, client: docker.DockerClient, username: str, password: str, registry_name: str
     ) -> None:
-        client.login(username, password, registry=registry_name)  # type: ignore[attr-defined]
+        client.login(username, password, registry=registry_name, reauth=True)  # type: ignore[attr-defined]
 
     def prepare_mounts(self, logger: logging.Logger) -> List[docker.types.Mount]:
         def escape(s):

--- a/WDL/runtime/backend/docker_swarm.py
+++ b/WDL/runtime/backend/docker_swarm.py
@@ -3,7 +3,6 @@ Default TaskContainer implementation using Docker Swarm
 """
 
 import os
-import re
 import json
 import stat
 import time
@@ -13,17 +12,12 @@ import base64
 import random
 import hashlib
 import logging
-import warnings
 import threading
 import traceback
 import contextlib
-from enum import Enum
 from io import BytesIO
 from typing import List, Dict, Set, Optional, Any, Callable, Tuple, Iterable
-import boto3
 import docker
-import google.auth
-import google.auth.transport.requests
 from ... import Error
 from ..._util import chmod_R_plus, TerminationSignalFlag
 from ..._util import StructuredLogMessage as _
@@ -338,10 +332,12 @@ class SwarmContainer(TaskContainer):
                 # docker.errors.APIError is thrown if permissions are missing
                 client.images.get_registry_data(image_tag)  # type: ignore[attr-defined]
             except docker.errors.APIError:
-                user, password, registry_name = super().get_image_registry_credentials(logger, image_tag, client)
+                user, password, registry_name = super().get_image_registry_credentials(
+                    logger, image_tag, client
+                )
                 if all((user, password, registry_name)):
-                    self.docker_login(logger, client, user, password, registry_name)
-                                
+                    self.docker_login(logger, client, user, password, registry_name)  # type: ignore[arg-type]
+
             try:
                 logger.info(_("docker pull", tag=image_tag))
                 client.images.pull(image_tag)
@@ -360,7 +356,12 @@ class SwarmContainer(TaskContainer):
         return image_tag
 
     def docker_login(
-        self, logger: logging.Logger, client: docker.DockerClient, username: str, password: str, registry_name: str
+        self,
+        logger: logging.Logger,
+        client: docker.DockerClient,
+        username: str,
+        password: str,
+        registry_name: str,
     ) -> None:
         logger.debug(f"Login to {registry_name} registry")
         client.login(username, password, registry=registry_name, reauth=True)  # type: ignore[attr-defined]

--- a/WDL/runtime/backend/docker_swarm.py
+++ b/WDL/runtime/backend/docker_swarm.py
@@ -3,27 +3,44 @@ Default TaskContainer implementation using Docker Swarm
 """
 
 import os
+import re
 import json
 import stat
 import time
-import shlex
 import uuid
+import shlex
 import base64
+import docker
 import random
 import hashlib
 import logging
+import warnings
 import threading
 import traceback
 import contextlib
+import subprocess
+from enum import Enum
 from io import BytesIO
 from typing import List, Dict, Set, Optional, Any, Callable, Tuple, Iterable
+import boto3
 import docker
+import google.auth
+import google.auth.transport.requests
 from ... import Error
 from ..._util import chmod_R_plus, TerminationSignalFlag
 from ..._util import StructuredLogMessage as _
 from .. import config
 from ..error import Interrupted, Terminated
 from ..task_container import TaskContainer
+
+
+logging.getLogger("botocore").setLevel(logging.WARNING)
+
+
+class SupportedProviders(Enum):
+   AWS = "aws"
+   GCP = "gcp"
+   UNKNOWN = None
 
 
 class SwarmContainer(TaskContainer):
@@ -326,6 +343,18 @@ class SwarmContainer(TaskContainer):
             image_attrs = client.images.get(image_tag).attrs
         except docker.errors.ImageNotFound:
             try:
+                  # docker.errors.APIError is thrown if permissions are missing
+                  client.images.get_registry_data(image_tag)
+            except docker.errors.APIError:
+                  logger.debug(f"Need to login to {image_tag} registry")
+                  registry_name, provider = self.get_registry_name_and_provider(logger, image_tag)
+                  if registry_name and provider is SupportedProviders.AWS:
+                    self.aws_ecr_login(logger, client, registry_name)
+                  if registry_name and provider is SupportedProviders.GCP:
+                    self.gcp_docker_registry_login(client, registry_name)
+                  if provider is SupportedProviders.UNKNOWN:
+                    logger.warning(f"{image_tag} registry pattern unrecognized. If login is needed do it before running the workflow")
+            try:
                 logger.info(_("docker pull", tag=image_tag))
                 client.images.pull(image_tag)
                 image_attrs = client.images.get(image_tag).attrs
@@ -341,6 +370,42 @@ class SwarmContainer(TaskContainer):
         image_log["RepoDigest"] = image_digest
         logger.notice(_("docker image", **image_log))
         return image_tag
+
+    def get_registry_name_and_provider(self, logger: logging.Logger, image_tag: str) -> Tuple[str, str]:
+        logger.debug(f"Get registry name and provider for {image_tag}")
+        # LOCATION-docker.pkg.dev/PROJECT-ID/REPOSITORY
+        gcp_registry_pattern = r"^(?P<gcp>[a-z-]+[0-9]+-docker\.pkg\.dev/[a-z0-9-]+/[a-z0-9-]+)/.*$"
+        # aws_account_id.dkr.ecr.us-west-2.amazonaws.com
+        aws_registry_pattern = r"^(?P<aws>[0-9]{12}\.dkr\.ecr\.[a-z-]+[0-9]+\.amazonaws\.com)/.*$"
+        
+        pattern_match = re.match(gcp_registry_pattern, image_tag) or re.match(aws_registry_pattern, image_tag)
+        registry_name = pattern_match.group(1) if pattern_match else None
+        provider = SupportedProviders(list(pattern_match.groupdict().keys())[0] if pattern_match else None)
+        logger.debug(f"Registry: {registry_name}. Provider: {provider}")
+        return registry_name, provider
+
+    def aws_ecr_login(self, logger: logging.Logger, docker_client: docker.DockerClient, registry_name: str) -> None:
+        logger.debug(f"Get region and account ID from registry name {registry_name}")
+        aws_account_id, _, _, aws_region, _, _ = registry_name.split(".")
+        logger.debug(f"AWS account: {aws_account_id}. Region: {aws_region}")
+        ecr_client = boto3.client("ecr", region_name=aws_region)
+        logger.debug(f"Get ECR token for {registry_name}")
+        response = ecr_client.get_authorization_token(registryIds=[aws_account_id])
+        ecr_password = base64.b64decode(response["authorizationData"][0]["authorizationToken"]).replace(b"AWS:", b"").decode("utf-8")
+        logger.debug(f"Login to {registry_name}")
+        self.docker_login(docker_client, "AWS", ecr_password, registry_name)
+
+ 
+    def gcp_docker_registry_login(self, client: docker.DockerClient, registry_name: str) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            creds, _ = google.auth.default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
+            auth_req = google.auth.transport.requests.Request()
+            creds.refresh(auth_req)
+            self.docker_login(client, "oauth2accesstoken", creds.token, registry_name)
+
+    def docker_login(self, client: docker.DockerClient, username: str, password: str, registry_name: str) -> None:
+        client.login(username, password, registry=registry_name)
 
     def prepare_mounts(self, logger: logging.Logger) -> List[docker.types.Mount]:
         def escape(s):

--- a/WDL/runtime/backend/docker_swarm.py
+++ b/WDL/runtime/backend/docker_swarm.py
@@ -373,9 +373,12 @@ class SwarmContainer(TaskContainer):
 
     def get_registry_name_and_provider(self, logger: logging.Logger, image_tag: str) -> Tuple[str, str]:
         logger.debug(f"Get registry name and provider for {image_tag}")
-        # LOCATION-docker.pkg.dev/PROJECT-ID/REPOSITORY
-        gcp_registry_pattern = r"^(?P<gcp>[a-z-]+[0-9]+-docker\.pkg\.dev/[a-z0-9-]+/[a-z0-9-]+)/.*$"
-        # aws_account_id.dkr.ecr.us-west-2.amazonaws.com
+        # GCP:
+        #   - <LOCATION>-docker.pkg.dev/<PROJECT-ID>/<REPOSITORY>
+        #   - <LOCATION>.gcr.io/<PROJECT-ID> (legacy)
+        gcp_registry_pattern = r"^(?P<gcp>[a-z-]+[0-9]+-docker\.pkg\.dev/[a-z0-9-]+/[a-z0-9-]+|[a-z\.]*gcr\.io)/.*$"
+        # AWS:
+        #   - <AWS_ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com
         aws_registry_pattern = r"^(?P<aws>[0-9]{12}\.dkr\.ecr\.[a-z-]+[0-9]+\.amazonaws\.com)/.*$"
         
         pattern_match = re.match(gcp_registry_pattern, image_tag) or re.match(aws_registry_pattern, image_tag)

--- a/WDL/runtime/backend/singularity.py
+++ b/WDL/runtime/backend/singularity.py
@@ -72,14 +72,22 @@ class SingularityContainer(SubprocessBase):
         logger.info(_("Singularity SIF found in image cache directory", sif=image_path))
         return image_path, []
 
-    def _login_invocation(self, logger: logging.Logger):
-            login_invocation = None
-            image = super()._get_runtime_image()
-            user, password, registry_name = super().get_image_registry_credentials(logger, image)
-            registry_name = registry_name.split("/")[0]
-            if all((user, password, registry_name)):
-                login_invocation = self.cli_exe + ["registry", "login", "--username", user, "--password", password, "docker://" + registry_name]
-            return login_invocation
+    def _login_invocation(self, logger: logging.Logger) -> Optional[List[str]]:
+        login_invocation = None
+        image = super()._get_runtime_image()
+        user, password, registry_name = super().get_image_registry_credentials(logger, image)
+        if all((user, password, registry_name)):
+            registry_name = registry_name.split("/")[0]  # type: ignore[union-attr]
+            login_invocation = self.cli_exe + [
+                "registry",
+                "login",
+                "--username",
+                user,
+                "--password",
+                password,
+                "docker://" + registry_name,
+            ]
+        return login_invocation  # type: ignore[return-value]
 
     def _run_invocation(self, logger: logging.Logger, cleanup: ExitStack, image: str) -> List[str]:
         """

--- a/WDL/runtime/backend/singularity.py
+++ b/WDL/runtime/backend/singularity.py
@@ -59,7 +59,7 @@ class SingularityContainer(SubprocessBase):
         return self.cfg.get_list("singularity", "exe")
 
     def _pull_invocation(self, logger: logging.Logger, cleanup: ExitStack) -> Tuple[str, List[str]]:
-        image, invocation = super()._pull_invocation(logger, cleanup)
+        image = super()._get_runtime_image()
         docker_uri = "docker://" + image
         pulldir = self.image_cache_dir or cleanup.enter_context(
             tempfile.TemporaryDirectory(prefix="miniwdl_sif_")
@@ -71,6 +71,15 @@ class SingularityContainer(SubprocessBase):
         # If path already exists, no need to use a pull invocation.
         logger.info(_("Singularity SIF found in image cache directory", sif=image_path))
         return image_path, []
+
+    def _login_invocation(self, logger: logging.Logger):
+            login_invocation = None
+            image = super()._get_runtime_image()
+            user, password, registry_name = super().get_image_registry_credentials(logger, image)
+            registry_name = registry_name.split("/")[0]
+            if all((user, password, registry_name)):
+                login_invocation = self.cli_exe + ["registry", "login", "--username", user, "--password", password, "docker://" + registry_name]
+            return login_invocation
 
     def _run_invocation(self, logger: logging.Logger, cleanup: ExitStack, image: str) -> List[str]:
         """

--- a/WDL/runtime/task_container.py
+++ b/WDL/runtime/task_container.py
@@ -7,7 +7,7 @@ import logging
 import shutil
 import threading
 import typing
-from typing import Callable, Iterable, Any, Dict, Optional, ContextManager, Set,Tuple
+from typing import Callable, Iterable, Any, Dict, Optional, ContextManager, Set, Tuple
 from abc import ABC, abstractmethod
 from contextlib import suppress
 from .. import Error, Value, Type
@@ -313,7 +313,12 @@ class TaskContainer(ABC):
         )
         return image
 
-    def get_image_registry_credentials(self, logger: logging.Logger, image_tag: str, docker_client: docker.DockerClient = None) -> Tuple[str, str]:
+    def get_image_registry_credentials(
+        self,
+        logger: logging.Logger,
+        image_tag: str,
+        docker_client: Optional[docker.DockerClient] = None,
+    ) -> Tuple[Optional[str], Optional[str], Optional[str]]:
         close_docker_client = False
         if not docker_client:
             docker_client = docker.from_env(version="auto")
@@ -328,7 +333,7 @@ class TaskContainer(ABC):
             logger.warning(
                 f"{image_tag} registry pattern unrecognized. If login is needed do it before running the workflow"
             )
-            user, password = None, None
+            user, password = None, None  # type: ignore[assignment]
         # close the docker client in case it was instantiated in the scope of the function
         if close_docker_client:
             docker_client.close()
@@ -358,9 +363,7 @@ class TaskContainer(ABC):
         logger.debug(f"Registry: {registry_name}. Provider: {provider}")
         return registry_name, provider
 
-    def _aws_ecr_login_args(
-        self, logger: logging.Logger, registry_name: str
-    ) -> Tuple[str, str]:
+    def _aws_ecr_login_args(self, logger: logging.Logger, registry_name: str) -> Tuple[str, str]:
         logger.debug(f"Get region and account ID from registry name {registry_name}")
         aws_account_id, _, _, aws_region, _, _ = registry_name.split(".")
         logger.debug(f"AWS account: {aws_account_id}. Region: {aws_region}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "psutil>=5,<7",
     "google-auth>=2.32.0",
     "boto3>=1.34.153",
+    "boto3-stubs>=1.34.153",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,9 @@ dependencies = [
     "python-json-logger>=2,<3",
     "lark~=1.1",
     "bullet>=2,<3",
-    "psutil>=5,<7"
+    "psutil>=5,<7",
+    "google-auth>=2.32.0",
+    "boto3>=1.34.153",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
### Motivation
Right now `miniwdl` requires that the login to the docker registry will be done before the start of the workflow, in case it uses private images, and the image is pulled at runtime, if not already present locally.
In case the login is done with short-lived credentials, they could expire before the workflow get to the task and then fail.

### Approach
After the changes in the PR the workflow will:
- check if the image is present locally (this was not changed by the PR)
- if the image is not present, check if the registry is accessible
- if not accessible check the registry name pattern and see if it is from a supported provider
- if the provider is supported, try to login to the docker registry and fail if missing permissions

Right now GCP Artifact Registry, GCP Docker Registry, and AWS Elastic Container Registry are supported.
Only for docker swarm  and singularity backends.

### Checklist
- [ ] Add appropriate test(s) to the automatic suite
- [x] Use `make pretty` to reformat the code with [black](https://github.com/python/black)
- [x] Use `make check` to statically check the code using [Pyre](https://pyre-check.org/) and [Pylint](https://www.pylint.org/)
- [x] Send PR from a dedicated branch without unrelated edits
- [x] Ensure compatibility with this project's MIT license

I don't know how to add tests for this, it will require to create private repositories and pass credentials to the CI.