### PR TITLE
refactor multi-line string implementation

### DIFF
--- a/WDL/Error.py
+++ b/WDL/Error.py
@@ -52,6 +52,17 @@ class SyntaxError(Exception):
         self.declared_wdl_version = declared_wdl_version
 
 
+class _BadCharacterEncoding(Exception):
+    """"""
+
+    # Invalid escape sequence in a string literal; this is used internally, eventually resurfaced
+    # as a SyntaxError.
+    pos: SourcePosition
+
+    def __init__(self, pos: SourcePosition):
+        self.pos = pos
+
+
 class ImportError(Exception):
     """Failure to open/retrieve an imported WDL document
 

--- a/WDL/Expr.py
+++ b/WDL/Expr.py
@@ -415,11 +415,7 @@ class String(Base):
             for part in self.parts
         ]
         # concatenate the stringified parts and trim the surrounding delimiters
-        delim = parts[0]
-        assert isinstance(delim, str)
-        assert delim in ("'", '"')
-        delim2 = parts[-1]
-        assert delim2 == delim
+        assert len(parts) >= 2 and parts[0] in ("'", '"') and parts[-1] == parts[0]
         return Value.String("".join(parts)[1:-1])
 
     @property
@@ -449,8 +445,9 @@ class String(Base):
     @staticmethod
     def _dedent(parts: List[Any]) -> List[Any]:
         """"""
-        # Helper: given a list of parts (strs or placeholders [anything but str]), remove common
-        # leading whitespace from non-blank lines, passing placeholders through.
+        # Helper for dedenting task commands and multi-line strings: given a list of parts (strs or
+        # placeholders [anything but str]), remove common leading whitespace from non-blank lines,
+        # passing placeholders through.
 
         # Detect common leading whitespace on the non-blank lines. For this purpose, use a
         # pseudo-string with dummy "~{}" substituted for placeholders, which is simpler than tracking

--- a/WDL/Expr.py
+++ b/WDL/Expr.py
@@ -407,7 +407,7 @@ class String(Base):
 
     def _eval(self, env: Env.Bindings[Value.Base], stdlib: StdLib.Base) -> Value.String:
         """"""
-        # eval parts & decode escape sequences
+        # eval placeholders & decode escape sequences
         parts = [
             part.eval(env, stdlib).value
             if isinstance(part, Placeholder)
@@ -417,11 +417,10 @@ class String(Base):
         # concatenate the stringified parts and trim the surrounding delimiters
         delim = parts[0]
         assert isinstance(delim, str)
-        assert delim in ("'", '"', "{", "<<<")
+        assert delim in ("'", '"')
         delim2 = parts[-1]
-        assert isinstance(delim2, str)
-        assert delim2 in ("'", '"', "}", ">>>") and len(delim) == len(delim2)
-        return Value.String("".join(parts)[len(delim) : -len(delim)])
+        assert delim2 == delim
+        return Value.String("".join(parts)[1:-1])
 
     @property
     def literal(self) -> Optional[Value.Base]:
@@ -503,6 +502,7 @@ class TaskCommand(String):
     def _eval(
         self, env: Env.Bindings[Value.Base], stdlib: StdLib.Base, dedent: bool = True
     ) -> Value.String:
+        """"""
         # in contrast to Expr.String._eval:
         # 1. dedents
         # 2. doesn't decode escape sequences
@@ -511,6 +511,56 @@ class TaskCommand(String):
             "".join(
                 part.eval(env, stdlib).value if isinstance(part, Placeholder) else part
                 for part in (String._dedent(self.parts) if dedent else self.parts)
+            )
+        )
+
+
+class MultiLineString(String):
+    """
+    Specialization of ``String`` for WDL 1.2 multi-line string literals, with special evaluation
+    rules: trim whitespace following the ``<<<`` and preceding the ``>>>`` delimiters and dedent
+    the remaining non-blank lines, while allowing newlines to be escaped.
+    """
+
+    def _eval(self, env: Env.Bindings[Value.Base], stdlib: StdLib.Base) -> Value.String:
+        """"""
+        # From each str part, remove escaped newlines and any whitespace following them. Escaped
+        # newlines are preceded by an odd number of backslashes.
+        parts: List[Union[str, Placeholder]] = []
+        for part in self.parts:
+            if isinstance(part, str):
+                part_lines = part.split("\n")
+                for j in range(len(part_lines) - 1):
+                    part_line = part_lines[j]
+                    if (len(part_line) - len(part_line.rstrip("\\"))) % 2 == 1:
+                        part_lines[j] = part_line[:-1]
+                        if j < len(part_lines) - 1:
+                            part_lines[j + 1] = part_lines[j + 1].lstrip(" \t")
+                    else:
+                        part_lines[j] += "\n"
+                parts.append("".join(part_lines))
+            else:
+                parts.append(part)
+
+        # Trim whitespace from the left of the first line and the right of the last line (including
+        # the first/last newline, if any).
+        assert parts[0] == "<<<" and parts[-1] == ">>>"
+        if len(parts) > 2 and isinstance(parts[1], str):
+            parts[1] = parts[1].lstrip(" \t")
+            if parts[1] and parts[1][0] == "\n":
+                parts[1] = parts[1][1:]
+        if len(parts) > 2 and isinstance(parts[-2], str):
+            parts[-2] = parts[-2].rstrip(" \t")
+            if parts[-2] and parts[-2][-1] == "\n":
+                parts[-2] = parts[-2][:-1]
+
+        # dedent (without delimiters), eval placeholders, decode escape sequences, concatenate
+        return Value.String(
+            "".join(
+                part.eval(env, stdlib).value
+                if isinstance(part, Placeholder)
+                else String._decode_escapes(self.pos, part)
+                for part in String._dedent(parts[1:-1])
             )
         )
 


### PR DESCRIPTION
Introduce `WDL.Expr.MultiLineString` which hosts most of the specialized evaluation logic that had been in the parser. (Follow-up to #734)