### PR TITLE
allow Any for if-then-else inferred type

### DIFF
--- a/WDL/Expr.py
+++ b/WDL/Expr.py
@@ -912,13 +912,6 @@ class IfThenElse(Base):
         ty = Type.unify(
             [self.consequent.type, self.alternative.type], check_quant=self._check_quant
         )
-        if isinstance(ty, Type.Any):
-            raise Error.StaticTypeMismatch(
-                self,
-                self.consequent.type,
-                self.alternative.type,
-                "(unable to unify consequent & alternative types)",
-            )
         return ty
 
     def _eval(self, env: Env.Bindings[Value.Base], stdlib: StdLib.Base) -> Value.Base:


### PR DESCRIPTION
<!---  Thank you for contributing to miniwdl! Please see the CONTRIBUTING.md guidelines and observe the PR checklist below. --->

### Motivation

There is one case where a ternary operator produces an expression returning an `Any` (Union) type
```
if condition then read_json(file) else None
```
but miniwdl currently disallows this. However, I don't think the WDL spec explicitly forbids Union ternary operator expressions as long as type can be inferred (for example, in an enclosing declaration). A trivial example:
```
task echo {
    command <<<
        echo '{}' > out.json
    >>>

    output {
        Map[String, String]? out = if true then read_json("out.json") else None
    }
}
```

Resolve the error reported in https://github.com/chanzuckerberg/miniwdl/issues/740 so this is allowed.

### Approach

Addresses https://github.com/chanzuckerberg/miniwdl/issues/740 by removing the check for `Any` and raised exception when doing type inference on ternary operator expressions.

### Checklist

<!--- You're welcome to open a draft PR to request guidance on testing or Pyre/Pylint problems. --->
- [ ] Add appropriate test(s) to the automatic suite
- [ ] Use `make pretty` to reformat the code with `ruff format`
- [ ] Use `make check` to statically check the code using `ruff check` and `mypy`
- [ ] Send PR from a dedicated branch without unrelated edits
- [ ] Ensure compatibility with this project's MIT license
