### PR TITLE
reorganize grammar keywords

### DIFF
--- a/WDL/_grammar.py
+++ b/WDL/_grammar.py
@@ -4,19 +4,14 @@ from ._grammar_old import productions_common1, productions_pre_1_0, productions_
 # Keywords for each version of the WDL grammar.
 keywords = {}
 keywords["draft-2"] = set(
-    "Array File Float Int Map None Pair String as call command else false if import input left meta object output parameter_meta right runtime scatter task then true workflow".split(
-        " "
-    )
+    "Array File Float Int Map None Pair String"
+    " as call command else false if import input left meta object output"
+    " parameter_meta right runtime scatter task then true workflow".split(" ")
 )
 keywords["1.0"] = keywords["draft-2"] | set(["alias", "struct"])
-keywords["development"] = set(
-    (
-        "Array Directory File Float Int Map None Pair String"
-        " alias as call command else env false if import input left meta"
-        " object output parameter_meta right runtime scatter struct task then true workflow"
-    ).split(" ")
-)
-keywords["1.1"] = keywords["development"]
+keywords["1.1"] = keywords["1.0"]
+keywords["1.2"] = keywords["1.1"] | set(["Directory"])
+keywords["development"] = keywords["1.2"] | set(["env"])
 
 # Grammar versions and their definitions. The productions for WDL 1.2 and development will be
 # defined in this file, while older versions are found in _grammar_old.py.

--- a/WDL/_grammar_old.py
+++ b/WDL/_grammar_old.py
@@ -296,18 +296,15 @@ call_input: CNAME ["=" expr]
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 task: "task" CNAME "{" task_section* command task_section* "}"
-?task_section: task_input_decls
+?task_section: input_decls
              | output_decls
              | meta_section
              | runtime_section
-             | task_env_decl -> noninput_decl
+             | any_decl -> noninput_decl
 
 tasks: task*
 
 input_decls: "input" "{" any_decl* "}"
-task_input_decls: "input" "{" task_env_decl* "}" -> input_decls
-ENV.2: "env"
-task_env_decl: ENV? any_decl
 output_decls: "output" "{" bound_decl* "}"
 
 // WDL task commands: with {} and <<< >>> command and ${} and ~{} placeholder styles


### PR DESCRIPTION
Follow-up to #779: build up the keyword list version-by-version.

Also, take the 1.2/development `env` feature out of the 1.1 grammar.