### PR TITLE
Support case insensitive JSON pair definitions

### DIFF
--- a/WDL/Value.py
+++ b/WDL/Value.py
@@ -561,12 +561,19 @@ def from_json(type: Type.Base, value: Any) -> Base:
         return String(value)
     if isinstance(type, Type.Array) and isinstance(value, list):
         return Array(type.item_type, [from_json(type.item_type, item) for item in value])
-    if isinstance(type, Type.Pair) and isinstance(value, dict) and set(v.lower() for v in value.keys()) == {"left", "right"}:
+    if (
+        isinstance(type, Type.Pair)
+        and isinstance(value, dict)
+        and set(v.lower() for v in value.keys()) == {"left", "right"}
+    ):
         lowercased_value = {k.lower(): v for k, v in value.items()}
         return Pair(
             type.left_type,
             type.right_type,
-            (from_json(type.left_type, lowercased_value["left"]), from_json(type.right_type, lowercased_value["right"])),
+            (
+                from_json(type.left_type, lowercased_value["left"]),
+                from_json(type.right_type, lowercased_value["right"]),
+            ),
         )
     if (
         isinstance(type, Type.Map)

--- a/WDL/Value.py
+++ b/WDL/Value.py
@@ -561,11 +561,12 @@ def from_json(type: Type.Base, value: Any) -> Base:
         return String(value)
     if isinstance(type, Type.Array) and isinstance(value, list):
         return Array(type.item_type, [from_json(type.item_type, item) for item in value])
-    if isinstance(type, Type.Pair) and isinstance(value, dict) and set(value) == {"left", "right"}:
+    if isinstance(type, Type.Pair) and isinstance(value, dict) and set(v.lower() for v in value.keys()) == {"left", "right"}:
+        lowercased_value = {k.lower(): v for k, v in value.items()}
         return Pair(
             type.left_type,
             type.right_type,
-            (from_json(type.left_type, value["left"]), from_json(type.right_type, value["right"])),
+            (from_json(type.left_type, lowercased_value["left"]), from_json(type.right_type, lowercased_value["right"])),
         )
     if (
         isinstance(type, Type.Map)


### PR DESCRIPTION
<!---  Thank you for contributing to miniwdl! Please see the CONTRIBUTING.md guidelines and observe the PR checklist below. --->

### Motivation

Resolves #788 

### Approach

When generating Pairs from JSON, the keys are considered in a case-insensitive manner. The JSON standard says keys in dictionaries must be strings, so performing a `.lower()` on the keys should be safe in theory, but another check could be added beforehand.

### Checklist

<!--- You're welcome to open a draft PR to request guidance on testing or Pyre/Pylint problems. --->
- [ ] Add appropriate test(s) to the automatic suite
- [ ] Use `make pretty` to reformat the code with `ruff format`
- [ ] Use `make check` to statically check the code using `ruff check` and `mypy`
- [ ] Send PR from a dedicated branch without unrelated edits
- [ ] Ensure compatibility with this project's MIT license
