### PR TITLE
fix asyncio.get_event_loop() error (#791)

### DIFF
--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -1588,7 +1588,10 @@ def _load(
     import_max_depth: int = 10,
     importer: Optional[Document] = None,
 ) -> Document:
-    return asyncio.get_event_loop().run_until_complete(
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    doc = loop.run_until_complete(
         _load_async(
             uri,
             path=path,
@@ -1598,6 +1601,9 @@ def _load(
             import_max_depth=import_max_depth,
         )
     )
+    loop.run_until_complete(loop.shutdown_asyncgens())
+    loop.close()
+    return doc
 
 
 #


### PR DESCRIPTION
<!---  Thank you for contributing to miniwdl! Please see the CONTRIBUTING.md guidelines and observe the PR checklist below. --->

### Motivation
Testing the `WDL` package in an interactive REPL like `ipython` using Python 3.12 fails when calling `WDL.load()` since there is no main event loop. This is because the asyncio method `asyncio.get_event_loop()` was deprecated in Python 3.9 and throws an error in Python >=3.11.

<!--- and/or link to related GitHub issue --->
https://github.com/chanzuckerberg/miniwdl/issues/791

### Approach
Apply the fix noted here:
https://stackoverflow.com/a/73367187

to the `_load()` function defined in `Tree.py`.

Built and tested a local version of `miniwdl/WDL` in `ipython` in Python 3.12.

### Checklist

<!--- You're welcome to open a draft PR to request guidance on testing or Pyre/Pylint problems. --->
- [ ] Add appropriate test(s) to the automatic suite
- [ ] Use `make pretty` to reformat the code with `ruff format`
- [ ] Use `make check` to statically check the code using `ruff check` and `mypy`
- [ x ] Send PR from a dedicated branch without unrelated edits
- [ x ] Ensure compatibility with this project's MIT license
