### PR TITLE
Support WDL 1.2 "Extended" File/Directory format

### DIFF
--- a/WDL/CLI.py
+++ b/WDL/CLI.py
@@ -860,7 +860,8 @@ def runner(
             cfg.log_unused_options()
 
     # report
-    outputs_json = {"outputs": values_to_json(output_env, namespace=target.name), "dir": rundir}
+    # TODO: For WDL 1.2, should we output Files and Directories in the "extended" format?
+    outputs_json = {"outputs": values_to_json(output_env, namespace=target.name, extended_format=False), "dir": rundir}
     runner_standard_output(outputs_json, stdout_file, error_json, log_json)
     return outputs_json
 
@@ -1080,11 +1081,13 @@ def runner_input(
                 f"missing required inputs for {target.name}: {', '.join(missing_inputs.keys())}"
             )
 
+    # TODO: Is this where we should fill in the listing fields for Directory inputs that don't come with them?
+
     # make a pass over the Env to create a dict for Cromwell-style input JSON
     return (
         target,
         input_env,
-        values_to_json(input_env, namespace=(target.name if isinstance(target, Workflow) else "")),
+        values_to_json(input_env, namespace=(target.name if isinstance(target, Workflow) else ""), extended_format=True),
     )
 
 
@@ -1144,7 +1147,7 @@ def runner_input_json_file(available_inputs, namespace, input_file, downloadable
         ans = Value.rewrite_env_paths(
             ans,
             lambda v: validate_input_path(
-                v.value, isinstance(v, Value.Directory), downloadable, root
+                v.value["location"], isinstance(v, Value.Directory), downloadable, root
             ),
         )
 
@@ -1299,6 +1302,9 @@ def validate_input_path(path, directory, downloadable, root):
     2. resides within root
     3. contains no symlinks pointing outside or to absolute paths
     """
+
+    print(f"Checking {path}")
+
     if downloadable and downloadable(path, directory):
         return path
 

--- a/WDL/StdLib.py
+++ b/WDL/StdLib.py
@@ -152,7 +152,7 @@ class Base:
         "generate read_* function implementation based on parse"
 
         def f(file: Value.File) -> Value.Base:
-            with open(self._devirtualize_filename(file.value), "r") as infile:
+            with open(self._devirtualize_filename(file.value["location"]), "r") as infile:
                 return parse(infile.read())
 
         return f
@@ -716,7 +716,7 @@ class _Size(EagerFunction):
         ans = []
         for file in files.value:
             if isinstance(file, Value.File):
-                ans.append(os.path.getsize(self.stdlib._devirtualize_filename(file.value)))
+                ans.append(os.path.getsize(self.stdlib._devirtualize_filename(file.value["location"])))
             elif isinstance(file, Value.Null):
                 ans.append(0)
             else:

--- a/WDL/Value.py
+++ b/WDL/Value.py
@@ -8,12 +8,13 @@ Each value is represented by an instance of a Python class inheriting from
    :top-classes: WDL.Value.Base
 """
 
+import os
 import json
 import copy
 import base64
 import hashlib
 from abc import ABC
-from typing import Any, List, Optional, Tuple, Dict, Iterable, Union, Callable, Set, TYPE_CHECKING
+from typing import cast, Any, List, Literal, Mapping, Optional, Tuple, Dict, Iterable, Union, Callable, Set, TypedDict, TYPE_CHECKING
 from contextlib import suppress
 from . import Error, Type, Env
 
@@ -165,21 +166,176 @@ class String(Base):
             raise Error.EvalError(self.expr, msg) if self.expr else Error.RuntimeError(msg)
         return super().coerce(desired_type)
 
+# File values are recommended to support additional attributes by the spec, so
+# we allow passing through unrecognized attributes.
+#
+# So we use a TypedDict to describe the attributes we know about.
+class ExtendedFile(TypedDict, total=False):
+    type: Literal["File"]
+    location: str
+    basename: str
 
-class File(String):
-    """``value`` has Python type ``str``"""
+def _parse_extended_file(value: Mapping[str, Any], parent_location: str | None = None) -> ExtendedFile:
+    """
+    Make a ExtendedFile-typed clone of the given dict, with infer-abel fields
+    filled in, or raise Error.InputError if the input is not the right format.
+    """
+    # We're going to possibly modify the input object, so copy it.
+    value = dict(value)
+    if "type" in value:
+        if value["type"] != "File":
+             raise Error.InputError("WDL.Value.File invalid type: " + str(value["type"]))
+    else:
+        value["type"] = "File"
+    if "basename" in value:
+        if not isinstance(value["basename"], str):
+            raise Error.InputError(f"WDL.Value.File invalid basename type: {type(value['basename'])}")
+        if "/" in value["basename"]:
+            raise Error.InputError(f"WDL.Value.File invalid basename: " + value["basename"])
+    if "location" not in value:
+        if parent_location is None:
+            raise Error.InputError("WDL.Value.File invalid JSON object: missing location without enclosing Directory available")
+        elif "basename" not in value:
+            raise Error.InputError("WDL.Value.File invalid JSON object: missing location and basename")
+        else:
+            value["location"] = os.path.join(parent_location, value["basename"])
+    if not isinstance(value["location"], str):
+        raise Error.InputError(f"WDL.Value.File invalid location type: {type(value['location'])}")
+    if value["location"] != value["location"].rstrip("/"):
+        raise Error.InputError("WDL.Value.File invalid path: " + value["location"])
+    if "basename" not in value:
+        # Remember the basename if it wasn't provided.
+        # TODO: Is this worth doing? Should this be reflected in our value TypedDict?
+        value["basename"] = os.path.basename(value["location"])
 
-    def __init__(self, value: str, expr: "Optional[Expr.Base]" = None) -> None:
-        super().__init__(value, expr=expr, subtype=Type.File())
-        if value != value.rstrip("/"):
-            raise Error.InputError("WDL.Value.File invalid path: " + value)
+    # Now we know it's a valid ExtendedFile
+    return cast(ExtendedFile, value)
 
+class File(Base):
+    """``value`` has Python type ``ExtendedFile``, which is a TypedDict representing the WDL 1.2 "extended" file syntax."""
+    value: ExtendedFile
 
-class Directory(String):
-    """``value`` has Python type ``str``"""
+    def __init__(self, value: str | Mapping[str, Any], expr: "Optional[Expr.Base]" = None) -> None:
+        """
+        Make a File from an input string or parsed JSON object.
+        """
 
-    def __init__(self, value: str, expr: "Optional[Expr.Base]" = None) -> None:
-        super().__init__(value, expr=expr, subtype=Type.Directory())
+        if isinstance(value, str):
+            # Always interpret strings as actual filenames at this level.
+            if value != value.rstrip("/"):
+                raise Error.InputError("WDL.Value.File invalid path: " + value)
+            file_value: ExtendedFile = {"type": "File", "location": value, "basename": os.path.basename(value)}
+        else:
+            file_value = _parse_extended_file(value)
+
+        super().__init__(Type.File(), file_value, expr=expr)
+
+    def __str__(self) -> str:
+        return str(self.coerce(Type.String()))
+
+    def coerce(self, desired_type: Optional[Type.Base] = None) -> Base:
+        if isinstance(desired_type, Type.File):
+            return File(self.value, self.expr)
+        if isinstance(desired_type, Type.String):
+            # TODO: Do we need to think about localizing to a name ending in basename here?
+            return String(self.value["location"], self.expr)
+        return super().coerce(desired_type)
+        
+class ExtendedDirectory(TypedDict, total=False):
+    type: Literal["Directory"]
+    location: str
+    basename: str
+    # TODO: Should we let full File or Directory objects in the listing?
+    listing: List[Union[ExtendedFile, "ExtendedDirectory"]]
+
+def _parse_extended_directory(value: Mapping[str, Any], parent_location: str | None = None) -> ExtendedDirectory:
+    """
+    Make a ExtendedDirectory-typed clone of the given dict, with infer-abel fields
+    filled in, or raise Error.InputError if the input is not the right format.
+    """
+
+    # We don't want to just clone the whole object immediately, so we go key by
+    # key through the keys we care about and then update with the rest.
+    dir_value = {}
+
+    if "type" in value:
+        if value["type"] != "Directory":
+            raise Error.InputError("WDL.Value.Directory invalid type: " + str(value["type"]))
+        dir_value["type"] = value["type"]
+    else:
+        dir_value["type"] = "Directory"
+    if "basename" in value:
+        if not isinstance(value["basename"], str):
+            raise Error.InputError(f"WDL.Value.Directory invalid basename type: {type(value['basename'])}")
+        if "/" in value["basename"]:
+            raise Error.InputError(f"WDL.Value.Directory invalid basename: " + value["basename"])
+        dir_value["basename"] = value["basename"]
+    if "location" in value:
+        if not isinstance(value["location"], str):
+            raise Error.InputError(f"WDL.Value.Directory invalid location type: {type(value['location'])}")
+        dir_value["location"] = value["location"]
+    else:
+        if parent_location is None:
+            raise Error.InputError("WDL.Value.Directory invalid JSON object: missing location without enclosing Directory available")
+        elif "basename" not in value:
+            raise Error.InputError("WDL.Value.Directory invalid JSON object: missing location and basename")
+        else:
+            dir_value["location"] = os.path.join(parent_location, value["basename"])
+    if "basename" not in value:
+        # Remember the basename if it wasn't provided.
+        # TODO: Is this worth doing? Should this be reflected in our value TypedDict?
+        dir_value["basename"] = os.path.basename(dir_value["location"].rstrip("/"))
+
+    if "listing" in value:
+        if not isinstance(value["listing"], list):
+            raise Error.InputError(f"WDL.Value.Directory invalid listing type: {type(value['listing'])}")
+        dir_value["listing"] = []
+        for item in value["listing"]:
+            if not isinstance(item, dict):
+                raise Error.InputError(f"WDL.Value.Directory invalid listing entry type: {type(item)}")
+            if "type" not in item:
+                raise Error.InputError(f"WDL.Value.Directory invalid listing entry has no type")
+            if item["type"] == "File":
+                dir_value["listing"].append(_parse_extended_file(item, dir_value["location"]))
+            elif item["type"] == "Directory":
+                dir_value["listing"].append(_parse_extended_directory(item, dir_value["location"]))
+            else:
+                 raise Error.InputError(f"WDL.Value.Directory invalid listing entry type value: " + str(item["type"]))
+    else:
+        raise Error.InputError("WDL.Value.Directory has no listing")
+
+    # Now we know this is a ExtendedDirectory
+    return cast(ExtendedDirectory, dir_value)
+        
+class Directory(Base):
+    """``value`` has Python type ``ExtendedDirectory``"""
+    value: ExtendedDirectory
+
+    def __init__(self, value: str | Mapping[str, Any], expr: "Optional[Expr.Base]" = None) -> None:
+        """
+        Make a Directory from an input string or parsed JSON object.
+        """
+
+        if isinstance(value, str):
+            # Always interpret strings as actual filenames at this level.
+            dir_value: ExtendedDirectory = {"type": "Directory", "location": value, "basename": os.path.basename(value)}
+            # TODO: fill the listing recursively somewhere where we have access to the config/plugins
+        else:
+            dir_value = _parse_extended_directory(value)
+
+        super().__init__(Type.Directory(), dir_value, expr=expr)
+
+    def __str__(self) -> str:
+        return str(self.coerce(Type.String()))
+
+    def coerce(self, desired_type: Optional[Type.Base] = None) -> Base:
+        if isinstance(desired_type, Type.Directory):
+            return Directory(self.value, self.expr)
+        if isinstance(desired_type, Type.String):
+            # TODO: Do we need to think about localizing to a name ending in basename here?
+            return String(self.value["location"], self.expr)
+        return super().coerce(desired_type)
+
 
 
 class Array(Base):
@@ -553,7 +709,21 @@ def from_json(type: Type.Base, value: Any) -> Base:
         return Int(value)
     if isinstance(type, (Type.Float, Type.Any)) and isinstance(value, (float, int)):
         return Float(float(value))
-    if isinstance(type, Type.File) and isinstance(value, str):
+    if isinstance(type, Type.File) and isinstance(value, (str, dict)):
+        if isinstance(value, str):
+            try:
+                # The spec says an extended-syntax File value can come as a
+                # string encoding a JSON object.
+                parsed_value = json.loads(value)
+                if isinstance(parsed_value, dict):
+                    return File(parsed_value)
+            except Error.InputError as e:
+                # A filename might look like a JSON dict but not describe a
+                # File value.
+                pass
+            except json.JSONDecodeError as e:
+                # A filename probably isn't actually a serialized JSON object.
+                pass
         return File(value)
     if isinstance(type, Type.Directory) and isinstance(value, str):
         return Directory(value)
@@ -650,7 +820,7 @@ def rewrite_paths(v: Base, f: Callable[[Union[File, Directory]], Optional[str]])
             fw = f(w)
             if fw is None:
                 return Null(expr=w.expr)
-            w.value = fw
+            w.value["location"] = fw
         # recursive descent into compound Values
         elif isinstance(w.value, list):
             value2: List[Any] = []
@@ -696,7 +866,7 @@ def rewrite_files(v: Base, f: Callable[[str], Optional[str]]) -> Base:
     (deprecated: use ``rewrite_paths`` to handle Directory values as well)
     """
 
-    return rewrite_paths(v, lambda fd: f(fd.value) if isinstance(fd, File) else fd.value)
+    return rewrite_paths(v, lambda fd: f(fd.value["location"]) if isinstance(fd, File) else fd.value["location"])
 
 
 def rewrite_env_files(

--- a/WDL/__init__.py
+++ b/WDL/__init__.py
@@ -300,23 +300,31 @@ def values_from_json(
 
 def values_to_json(
     values_env: Union[Env.Bindings[Value.Base], Env.Bindings[Tree.Decl], Env.Bindings[Type.Base]],
-    namespace: str = "",
+    namespace: str = "", extended_format: bool | None = None
 ) -> Dict[str, Any]:
     """
     Convert a ``WDL.Env.Bindings[WDL.Value.Base]`` to a dict which ``json.dumps`` to
     Cromwell-style JSON.
 
     :param namespace: prefix this namespace to each key (e.g. workflow name)
+    :param extended_format: If set to True, outputs File and Directory values in WDL 1.2+ extended syntax.
     """
     # also can be used on Env.Bindings[Tree.Decl] or Env.Types, then the right-hand side of
     # each entry will be the type string.
     if namespace and not namespace.endswith("."):
         namespace += "."
+    if extended_format is None:
+        extended_format = False
     ans = {}
     for item in values_env:
         v = item.value
         if isinstance(v, Value.Base):
-            j = v.json
+            if not extended_format and isinstance(v, (Value.File, Value.Directory)):
+                # The JSON property spits out extended syntax. We need
+                # location-only syntax, which comes from string coercion.
+                j = v.coerce(Type.String()).json
+            else:
+                j = v.json
         elif isinstance(item.value, Tree.Decl):
             j = str(item.value.type)
         else:

--- a/WDL/_util.py
+++ b/WDL/_util.py
@@ -221,7 +221,7 @@ def write_values_json(
             values_to_json(values_env, namespace=namespace),
             indent=2,
             sort_keys=True,
-            extended_syntax=True,
+            extended_format=True,
         ),
         filename,
     )

--- a/WDL/_util.py
+++ b/WDL/_util.py
@@ -221,6 +221,7 @@ def write_values_json(
             values_to_json(values_env, namespace=namespace),
             indent=2,
             sort_keys=True,
+            extended_syntax=True,
         ),
         filename,
     )

--- a/WDL/runtime/cache.py
+++ b/WDL/runtime/cache.py
@@ -27,6 +27,9 @@ from .._util import (
 
 
 class CallCache(AbstractContextManager):
+
+    CALL_CACHE_VERSION = 2
+
     _cfg: config.Loader
     _download_cache_dir: str
     _call_cache_dir: str
@@ -94,6 +97,12 @@ class CallCache(AbstractContextManager):
                 outputs = json.loads(file_reader.read())
                 if "miniwdlCallCacheVersion" in outputs:
                     # envelope: previously, there was none and file contained exactly the outputs.
+                    if outputs["miniwdlCallCacheVersion"] > self.CALL_CACHE_VERSION:
+                        # This cache entry is too new to understand
+                        raise ValueError(
+                            f"Call cache version {outputs['miniwdlCallCacheVersion']} "
+                            f"is newer than our maximum understood version of {self.CALL_CACHE_VERSION}"
+                        )
                     run_dir = outputs.get("dir", None)
                     outputs = outputs["outputs"]
                 cache = values_from_json(outputs, output_types)
@@ -141,8 +150,8 @@ class CallCache(AbstractContextManager):
 
         if self._cfg["call_cache"].get_bool("put"):
             envelope = {
-                "miniwdlCallCacheVersion": 1,
-                "outputs": values_to_json(outputs),
+                "miniwdlCallCacheVersion": self.CALL_CACHE_VERSION,
+                "outputs": values_to_json(outputs, extended_format=True),
             }
             if run_dir:
                 envelope["dir"] = run_dir
@@ -358,14 +367,14 @@ def _check_files_coherence(
 
     def check_one(v: Union[Value.File, Value.Directory]):
         assert isinstance(v, (Value.File, Value.Directory))
-        if not downloadable(cfg, v.value):
+        if not downloadable(cfg, v.value["location"]):
             try:
-                if mtime(v.value) > cache_file_mtime:
+                if mtime(v.value["location"]) > cache_file_mtime:
                     raise StopIteration
                 if isinstance(v, Value.Directory):
                     # check everything in directory
                     for root, subdirs, subfiles in os.walk(
-                        v.value, onerror=raiser, followlinks=False
+                        v.value["location"], onerror=raiser, followlinks=False
                     ):
                         for subdir in subdirs:
                             if mtime(os.path.join(root, subdir)) > cache_file_mtime:
@@ -378,7 +387,7 @@ def _check_files_coherence(
                     _(
                         "cache entry invalid due to deleted or modified file/directory",
                         cache_file=cache_file,
-                        changed=v.value,
+                        changed=v.value["location"],
                     )
                 )
                 raise StopIteration

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -300,7 +300,7 @@ def _download_input_files(
     def rewriter(v: Union[Value.Directory, Value.File]) -> str:
         nonlocal downloads, download_bytes, cached_hits
         directory = isinstance(v, Value.Directory)
-        uri = v.value
+        uri = v.value["location"]
         if downloadable(cfg, uri, directory=directory):
             logger.info(_(f"download input {'directory' if directory else 'file'}", uri=uri))
             cached, filename = download(
@@ -391,7 +391,7 @@ def _eval_task_inputs(
 
     # copy posix_inputs with all File & Directory values mapped to their in-container paths
     def map_paths(fn: Union[Value.File, Value.Directory]) -> str:
-        p = fn.value.rstrip("/")
+        p = fn.value["location"].rstrip("/")
         if isinstance(fn, Value.Directory):
             p += "/"
         return container.input_path_map[p]
@@ -454,10 +454,10 @@ def _fspaths(env: Env.Bindings[Value.Base]) -> Set[str]:
 
     def collector(v: Value.Base) -> None:
         if isinstance(v, Value.File):
-            assert not v.value.endswith("/")
-            ans.add(v.value)
+            assert not v.value["location"].endswith("/")
+            ans.add(v.value["location"])
         elif isinstance(v, Value.Directory):
-            ans.add(v.value.rstrip("/") + "/")
+            ans.add(v.value["location"].rstrip("/") + "/")
         for ch in v.children:
             collector(ch)
 
@@ -688,7 +688,7 @@ def _eval_task_outputs(
     # Helpers to rewrite File/Directory from in-container paths to host paths
     # First pass -- convert nonexistent output paths to None/Null
     def rewriter1(v: Union[Value.File, Value.Directory], output_name: str) -> Optional[str]:
-        container_path = v.value
+        container_path = v.value["location"]
         if isinstance(v, Value.Directory) and not container_path.endswith("/"):
             container_path += "/"
         if container.host_path(container_path) is None:
@@ -700,11 +700,11 @@ def _eval_task_outputs(
                 )
             )
             return None
-        return v.value
+        return v.value["location"]
 
     # Second pass -- convert in-container paths to host paths
     def rewriter2(v: Union[Value.File, Value.Directory], output_name: str) -> Optional[str]:
-        container_path = v.value
+        container_path = v.value["location"]
         if isinstance(v, Value.Directory) and not container_path.endswith("/"):
             container_path += "/"
         host_path = container.host_path(container_path)
@@ -830,9 +830,9 @@ def link_outputs(
     def map_paths(v: Value.Base, dn: str) -> Value.Base:
         if isinstance(v, (Value.File, Value.Directory)):
             target = (
-                v.value
-                if os.path.exists(v.value)
-                else cache.get_download(v.value, isinstance(v, Value.Directory))
+                v.value["location"]
+                if os.path.exists(v.value["location"])
+                else cache.get_download(v.value["location"], isinstance(v, Value.Directory))
             )
             if target:
                 target = os.path.realpath(target)
@@ -840,7 +840,7 @@ def link_outputs(
                 if not hardlinks and path_really_within(target, os.path.dirname(run_dir)):
                     # make symlink relative
                     target = os.path.relpath(target, start=os.path.realpath(dn))
-                link = os.path.join(dn, os.path.basename(v.value.rstrip("/")))
+                link = os.path.join(dn, os.path.basename(v.value["location"].rstrip("/")))
                 os.makedirs(dn, exist_ok=False)
                 link1(target, link, isinstance(v, Value.Directory))
                 # Drop a dotfile alongside Directory outputs, to inform a program crawling the out/
@@ -850,7 +850,7 @@ def link_outputs(
                 if isinstance(v, Value.Directory):
                     with open(os.path.join(dn, ".WDL_Directory"), "w") as _dotfile:
                         pass
-                v.value = link
+                v.value["location"] = link
         # recurse into compound values
         elif isinstance(v, Value.Array) and v.value:
             d = int(math.ceil(math.log10(len(v.value))))  # how many digits needed
@@ -898,7 +898,7 @@ def link_outputs(
         lambda binding: Env.Binding(
             binding.name,
             map_paths(
-                Value.rewrite_paths(binding.value, lambda v: v.value),  # nop to deep copy
+                Value.rewrite_paths(binding.value, lambda v: v.value["location"]),  # nop to deep copy
                 os.path.join(run_dir, "out", binding.name),
             ),
         )
@@ -920,9 +920,9 @@ def link_outputs_relative(
 
     def map_path_relative(v: Union[Value.File, Value.Directory]) -> str:
         target = (
-            v.value
-            if os.path.exists(v.value)
-            else cache.get_download(v.value, isinstance(v, Value.Directory))
+            v.value["location"]
+            if os.path.exists(v.value["location"])
+            else cache.get_download(v.value["location"], isinstance(v, Value.Directory))
         )
         if target:
             real_target = os.path.realpath(target)
@@ -962,7 +962,7 @@ def link_outputs_relative(
             link1(real_target, abs_link, isinstance(v, Value.Directory))
             link_destinations[abs_link] = real_target
             return abs_link
-        return v.value
+        return v.value["location"]
 
     return Value.rewrite_env_paths(outputs, map_path_relative)
 
@@ -973,12 +973,12 @@ def _warn_output_basename_collisions(
     targets_by_basename: Dict[str, Set[str]] = {}
 
     def walker(v: Union[Value.File, Value.Directory]) -> str:
-        target = v.value
+        target = v.value["location"]
         if os.path.exists(target):
             target = os.path.realpath(target)
         basename = os.path.basename(target)
         targets_by_basename.setdefault(basename, set()).add(target)
-        return v.value
+        return v.value["location"]
 
     Value.rewrite_env_paths(outputs, walker)
 

--- a/WDL/runtime/workflow.py
+++ b/WDL/runtime/workflow.py
@@ -733,9 +733,9 @@ def _check_path_allowed(
     cfg: config.Loader, allowlist: Set[str], desc: str, v: Union[Value.File, Value.Directory]
 ) -> str:
     isdir = isinstance(v, Value.Directory)
-    fspath = v.value.rstrip("/") + ("/" if isdir else "")
+    fspath = v.value["location"].rstrip("/") + ("/" if isdir else "")
     if fspath in allowlist or downloadable(cfg, fspath, directory=isdir):
-        return v.value
+        return v.value["location"]
     if not cfg.get_bool("file_io", "allow_any_input"):
         raise Error.InputError(
             desc + " uses file/directory not expressly supplied with workflow inputs"
@@ -747,7 +747,7 @@ def _check_path_allowed(
     fspath = os.path.abspath(fspath).rstrip("/")
     if not path_really_within(fspath, cfg["file_io"]["root"]):
         raise Error.InputError(
-            f"{desc} {v.value} must reside within [file_io] root " + cfg["file_io"]["root"]
+            f"{desc} {v.value['location']} must reside within [file_io] root " + cfg["file_io"]["root"]
         )
     return fspath
 
@@ -1137,7 +1137,7 @@ def _download_input_files(
     def scan_uri(v: Union[Value.File, Value.Directory]) -> str:
         nonlocal uris
         directory = isinstance(v, Value.Directory)
-        uri = v.value
+        uri = v.value["location"]
         if uri not in uris and downloadable(cfg, uri, directory=directory):
             uris.add((uri, directory))
         return uri


### PR DESCRIPTION
<!---  Thank you for contributing to miniwdl! Please see the CONTRIBUTING.md guidelines and observe the PR checklist below. --->

### Motivation

This should fix #833 by implementing the "extended" File and Directory format from WDL 1.2.

<!--- and/or link to related GitHub issue --->

### Approach
This changes `File` and `Directory` to have the extended-format dicts as their `value`s, with the actual path being fetched out of or replaced in `["location"]` when needed.

This is still a draft; it still needs:
* [ ] Logic to recursively adjust locations inside Directory listings when adjusting the parent location. (Maybe we should only keep the top-level location set?)
* [ ] Logic to fill in listings when loading a Directory from a path or URL.
* [ ] A way to get the extended format as workflow/task output for the user (though we could get away with not having this)
* [ ] The ability to key the cache on the listing contents (I touched the caching slightly but I don't know if it's really hooked in)
* [ ] Possibly checksum computation; the spec suggests you ought to have it but doesn't define how.
* [ ] The ability to reject the extended format in WDL 1.1- runs (might be able to skip this?).
* [ ] Support for actually presenting the listing as described in the input JSON object, and not whatever's currently on disk at the location, to user code.
* [ ] Support for input Directory values without a location, using the listing instead to construct them.
* [ ] Support for localizing files at the extended-format basename when it is different than the basename of the location.

### Checklist

<!--- You're welcome to open a draft PR to request guidance on testing or Pyre/Pylint problems. --->
- [ ] Add appropriate test(s) to the automatic suite
- [ ] Use `make pretty` to reformat the code with `ruff format`
- [ ] Use `make check` to statically check the code using `ruff check` and `mypy`
- [ ] Send PR from a dedicated branch without unrelated edits
- [ ] Ensure compatibility with this project's MIT license
