### PR TITLE
fix: guard against out-of-range uid/gid in Docker Swarm backend

### DIFF
--- a/WDL/runtime/backend/docker_swarm.py
+++ b/WDL/runtime/backend/docker_swarm.py
@@ -448,19 +448,34 @@ class SwarmContainer(TaskContainer):
             resources = docker.types.Resources(**resources)
         user = None
         if self.cfg["task_runtime"].get_bool("as_user"):
-            user = f"{os.geteuid()}:{os.getegid()}"
+            euid = os.geteuid()
+            egid = os.getegid()
+            if euid > 2147483647 or egid > 2147483647:
+                raise Error.RuntimeError(
+                    f"cannot use --as-me with uid:gid {euid}:{egid}"
+                    " (Docker requires values in range 0-2147483647)"
+                )
+            user = f"{euid}:{egid}"
             logger.info(_("docker user", uid_gid=user))
-            if os.geteuid() == 0:
+            if euid == 0:
                 logger.warning(
                     "container command will run explicitly as root, since you are root and set --as-me"
                 )
         # add invoking user's group to ensure that command can access the mounted working
         # directory even if the docker image assumes some arbitrary uid
-        groups = [str(os.getegid())]
-        if groups == ["0"]:
+        egid = os.getegid()
+        if egid > 2147483647:
+            logger.warning(
+                f"not adding supplementary group {egid} to container (exceeds Docker's 32-bit limit)"
+            )
+            groups = []
+        elif egid == 0:
+            groups = ["0"]
             logger.warning(
                 "container command will run as a root/wheel group member, since this is your primary group (gid=0)"
             )
+        else:
+            groups = [str(egid)]
         if self.runtime_values.get("gpu", False):
             logger.warning(
                 "ignoring runtime.gpu, but see https://miniwdl.readthedocs.io/en/latest/runner_reference.html#using-nvidia-gpu"

--- a/tests/test_4taskrun.py
+++ b/tests/test_4taskrun.py
@@ -1335,3 +1335,67 @@ class TestConfigLoader(unittest.TestCase):
         cfg.plugin_defaults({"file_io": {"copy_input_files": True}, "x": {"y":"z"}})
         self.assertEqual(cfg["file_io"]["copy_input_files"], "false")
         self.assertEqual(cfg.get("x","y"), "z")
+
+
+class TestSwarmMiscConfigUidGid(unittest.TestCase):
+    """Test that SwarmContainer.misc_config handles out-of-range uid/gid values."""
+
+    def _make_container(self, as_user: bool = False) -> "WDL.runtime.backend.docker_swarm.SwarmContainer":
+        from WDL.runtime.backend.docker_swarm import SwarmContainer
+        cfg = WDL.runtime.config.Loader(
+            logging.getLogger(self.id()),
+            overrides={"task_runtime": {"as_user": as_user}},
+        )
+        container = SwarmContainer.__new__(SwarmContainer)
+        container.cfg = cfg
+        container.runtime_values = {}
+        # misc_config only needs cfg and runtime_values, so we skip full __init__
+        yield container
+
+    def test_normal_gid(self):
+        """Normal gid should be passed as supplementary group."""
+        from unittest.mock import patch
+        for container in self._make_container():
+            with patch("os.geteuid", return_value=1000), patch("os.getegid", return_value=1000):
+                logger = logging.getLogger(self.id())
+                _resources, user, groups = container.misc_config(logger)
+                self.assertIsNone(user)
+                self.assertEqual(groups, ["1000"])
+
+    def test_large_gid_no_as_user(self):
+        """Large gid (> 2^31-1) should be skipped when as_user is false."""
+        from unittest.mock import patch
+        for container in self._make_container():
+            with patch("os.geteuid", return_value=1000), patch("os.getegid", return_value=3721906406):
+                logger = logging.getLogger(self.id())
+                _resources, user, groups = container.misc_config(logger)
+                self.assertIsNone(user)
+                self.assertEqual(groups, [])
+
+    def test_large_gid_with_as_user(self):
+        """Large gid with --as-me should raise a clear error."""
+        from unittest.mock import patch
+        for container in self._make_container(as_user=True):
+            with patch("os.geteuid", return_value=1000), patch("os.getegid", return_value=3721906406):
+                logger = logging.getLogger(self.id())
+                with self.assertRaises(WDL.Error.RuntimeError):
+                    container.misc_config(logger)
+
+    def test_large_uid_with_as_user(self):
+        """Large uid with --as-me should raise a clear error."""
+        from unittest.mock import patch
+        for container in self._make_container(as_user=True):
+            with patch("os.geteuid", return_value=3721906406), patch("os.getegid", return_value=1000):
+                logger = logging.getLogger(self.id())
+                with self.assertRaises(WDL.Error.RuntimeError):
+                    container.misc_config(logger)
+
+    def test_root_gid(self):
+        """gid=0 should still produce the root/wheel warning."""
+        from unittest.mock import patch
+        for container in self._make_container():
+            with patch("os.geteuid", return_value=0), patch("os.getegid", return_value=0):
+                logger = logging.getLogger(self.id())
+                _resources, user, groups = container.misc_config(logger)
+                self.assertIsNone(user)
+                self.assertEqual(groups, ["0"])


### PR DESCRIPTION
## Summary
- Docker requires uid/gid values in range 0-2147483647 (signed 32-bit int). The Docker Swarm backend unconditionally adds `os.getegid()` as a supplementary group to every container, which fails for users whose gid exceeds this limit (e.g. GCP VMs with Google-managed accounts like `ext_*@company.com` that get gids like 3721906406).
- Skip the supplementary group when the gid is out of range, and raise a clear error when `--as-me` is used with an out-of-range uid or gid.

## Test plan
- [ ] Verify normal-range uid/gid behavior is unchanged
- [ ] Verify that a user with gid > 2147483647 can now run tasks without the "uids and gids must be in range" error
- [ ] Verify that `--as-me` with an out-of-range uid/gid produces a clear error message