### PR TITLE
clarify read_tsv implementation

### DIFF
--- a/WDL/StdLib.py
+++ b/WDL/StdLib.py
@@ -337,7 +337,6 @@ def _parse_tsv(s: str) -> Value.Array:
             Type.Array(Type.String()), [Value.String(field) for field in line.value.split("\t")]
         )
         for line in _parse_lines(s).value
-        if line.value
     ]
     return Value.Array(Type.Array(Type.String()), ans)
 

--- a/WDL/StdLib.py
+++ b/WDL/StdLib.py
@@ -337,7 +337,7 @@ def _parse_tsv(s: str) -> Value.Array:
             Type.Array(Type.String()), [Value.String(field) for field in line.value.split("\t")]
         )
         for line in _parse_lines(s).value
-        if line
+        if line.value
     ]
     return Value.Array(Type.Array(Type.String()), ans)
 

--- a/tests/test_0eval.py
+++ b/tests/test_0eval.py
@@ -2,6 +2,10 @@ import unittest, inspect, json, random
 from .context import WDL
 
 class TestEval(unittest.TestCase):
+    def test_parse_tsv_ignores_blank_lines(self):
+        parsed = WDL.StdLib._parse_tsv("a\tb\n\nc\td\n")
+        self.assertEqual(parsed.json, [["a", "b"], ["c", "d"]])
+
     def test_expr_render(self):
         # types
         self.assertEqual(str(WDL.parse_expr("false")), "false")

--- a/tests/test_0eval.py
+++ b/tests/test_0eval.py
@@ -2,10 +2,6 @@ import unittest, inspect, json, random
 from .context import WDL
 
 class TestEval(unittest.TestCase):
-    def test_parse_tsv_preserves_blank_lines(self):
-        parsed = WDL.StdLib._parse_tsv("a\tb\n\nc\td\n")
-        self.assertEqual(parsed.json, [["a", "b"], [""], ["c", "d"]])
-
     def test_expr_render(self):
         # types
         self.assertEqual(str(WDL.parse_expr("false")), "false")

--- a/tests/test_0eval.py
+++ b/tests/test_0eval.py
@@ -2,9 +2,9 @@ import unittest, inspect, json, random
 from .context import WDL
 
 class TestEval(unittest.TestCase):
-    def test_parse_tsv_ignores_blank_lines(self):
+    def test_parse_tsv_preserves_blank_lines(self):
         parsed = WDL.StdLib._parse_tsv("a\tb\n\nc\td\n")
-        self.assertEqual(parsed.json, [["a", "b"], ["c", "d"]])
+        self.assertEqual(parsed.json, [["a", "b"], [""], ["c", "d"]])
 
     def test_expr_render(self):
         # types

--- a/tests/test_5stdlib.py
+++ b/tests/test_5stdlib.py
@@ -42,6 +42,10 @@ class TestStdLib(unittest.TestCase):
             self.assertFalse(str(expected_exception) + " not raised")
         return WDL.values_to_json(outputs)
 
+    def test_parse_tsv_preserves_blank_lines(self):
+        parsed = WDL.StdLib._parse_tsv("a\tb\n\nc\td\n")
+        self.assertEqual(parsed.json, [["a", "b"], [""], ["c", "d"]])
+
     def test_eq_opt(self):
         # regression test issue #634
         wdl = """


### PR DESCRIPTION
The WDL spec does NOT state that `read_tsv()` should ignore blank lines. Our implementation was accidentally correct, in that it was trying to remove them, but inefectually so (`line` is always truthy; it meant to check `line.value`). Strike the confusing attempt and add a "regression" test.