### PR TITLE
[experimental] `try` workflow section

### DIFF
--- a/WDL/CLI.py
+++ b/WDL/CLI.py
@@ -32,6 +32,7 @@ from . import (
     Call,
     Scatter,
     Conditional,
+    Try,
     parse_document,
     copy_source,
     values_from_json,
@@ -365,6 +366,11 @@ def outline(
     # if
     elif isinstance(obj, Conditional):
         print("{}if".format(s), file=file)
+        for elt in obj.body:
+            descend(elt)
+    # try
+    elif isinstance(obj, Try):
+        print("{}try".format(s), file=file)
         for elt in obj.body:
             descend(elt)
     # decl

--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -903,7 +903,7 @@ class Scatter(WorkflowSection):
         inner_outputs: Env.Bindings[Type.Base] = Env.Bindings()
         for elt in self.body:
             if not isinstance(elt, Decl):
-                assert isinstance(elt, (Call, Scatter, Conditional))
+                assert isinstance(elt, (Call, WorkflowSection))
                 inner_outputs = Env.merge(elt.effective_outputs, inner_outputs)
 
         def arrayize(binding: Env.Binding[Type.Base]) -> Env.Binding[Type.Base]:
@@ -983,6 +983,48 @@ class Conditional(WorkflowSection):
         yield from _expr_workflow_node_dependencies(self.expr)
 
 
+class Try(WorkflowSection):
+    """Experimental workflow try section"""
+
+    def __init__(self, pos: SourcePosition, body: List[WorkflowNode]) -> None:
+        super().__init__(body, "try-L{}C{}".format(pos.line, pos.column), pos)
+
+    def add_to_type_env(
+        self, struct_types: Env.Bindings[Dict[str, Type.Base]], type_env: Env.Bindings[Type.Base]
+    ) -> Env.Bindings[Type.Base]:
+        inner_type_env: Env.Bindings[Type.Base] = Env.Bindings()
+        for elt in self.body:
+            inner_type_env = elt.add_to_type_env(struct_types, inner_type_env)
+
+        def optionalize(binding: Env.Binding[Type.Base]) -> Env.Binding[Type.Base]:
+            return Env.Binding(
+                binding.name,
+                binding.value.copy(optional=True),
+                self.gathers[binding.info.workflow_node_id],
+            )
+
+        return Env.merge(inner_type_env.map(optionalize), type_env)
+
+    @property
+    def effective_outputs(self) -> Env.Bindings[Type.Base]:
+        inner_outputs: Env.Bindings[Type.Base] = Env.Bindings()
+        for elt in self.body:
+            if isinstance(elt, (Call, WorkflowSection)):
+                inner_outputs = Env.merge(elt.effective_outputs, inner_outputs)
+
+        def optionalize(binding: Env.Binding[Type.Base]) -> Env.Binding[Type.Base]:
+            return Env.Binding(
+                binding.name,
+                binding.value.copy(optional=True),
+                self.gathers[binding.info.workflow_node_id],
+            )
+
+        return inner_outputs.map(optionalize)
+
+    def _workflow_node_dependencies(self) -> Iterable[str]:
+        return []
+
+
 class Workflow(SourceNode):
     name: str
     ":type: str"
@@ -991,7 +1033,7 @@ class Workflow(SourceNode):
 
     Declarations in the ``input{}`` workflow section, if it's present"""
     body: List[WorkflowNode]
-    """:type: List[Union[WDL.Tree.Decl,WDL.Tree.Call,WDL.Tree.Scatter,WDL.Tree.Conditional]]
+    """:type: List[Union[WDL.Tree.Decl,WDL.Tree.Call,WDL.Tree.Scatter,WDL.Tree.Conditional,WDL.Tree.Try]]
 
     Workflow body in between ``input{}`` and ``output{}`` sections, if any
     """
@@ -1722,6 +1764,8 @@ def _build_workflow_type_env(
         )
         if not self.expr.type.coerces(Type.Boolean()):
             raise Error.StaticTypeMismatch(self.expr, Type.Boolean(), self.expr.type)
+    elif isinstance(self, Try):
+        pass
     else:
         assert False
 

--- a/WDL/Walker.py
+++ b/WDL/Walker.py
@@ -48,6 +48,8 @@ class Base:
             ans = self.scatter(obj)
         elif isinstance(obj, Tree.Conditional):
             ans = self.conditional(obj)
+        elif isinstance(obj, Tree.Try):
+            ans = self.try_section(obj)
         elif isinstance(obj, Tree.Gather):
             ans = self.gather(obj)
         elif isinstance(obj, Tree.Decl):
@@ -87,6 +89,9 @@ class Base:
         self._descend(obj)
 
     def conditional(self, obj: Tree.Conditional) -> Any:
+        self._descend(obj)
+
+    def try_section(self, obj: Tree.Try) -> Any:
         self._descend(obj)
 
     def gather(self, obj: Tree.Gather) -> Any:
@@ -139,6 +144,10 @@ class Multi(Base):
     def conditional(self, obj: Tree.Conditional) -> Any:
         for w in self._walkers:
             w.conditional(obj)
+
+    def try_section(self, obj: Tree.Try) -> Any:
+        for w in self._walkers:
+            w.try_section(obj)
 
     def gather(self, obj: Tree.Gather) -> Any:
         for w in self._walkers:
@@ -214,6 +223,14 @@ class SetParents(Base):
     def conditional(self, obj: Tree.Conditional) -> None:
         self._parent_stack.append(obj)
         super().conditional(obj)
+        self._parent_stack.pop()
+        obj.parent = None
+        for elt in obj.children:
+            elt.parent = obj
+
+    def try_section(self, obj: Tree.Try) -> None:
+        self._parent_stack.append(obj)
+        super().try_section(obj)
         self._parent_stack.pop()
         obj.parent = None
         for elt in obj.children:

--- a/WDL/__init__.py
+++ b/WDL/__init__.py
@@ -19,6 +19,7 @@ from .Tree import (  # noqa: F401
     Call,
     Scatter,
     Conditional,
+    Try,
     Gather,
     Workflow,
     Document,

--- a/WDL/_grammar.py
+++ b/WDL/_grammar.py
@@ -11,7 +11,7 @@ keywords["draft-2"] = set(
 keywords["1.0"] = keywords["draft-2"] | set(["alias", "struct"])
 keywords["1.1"] = keywords["1.0"]
 keywords["1.2"] = keywords["1.1"] | set(["Directory", "env", "hints", "requirements"])
-keywords["development"] = keywords["1.2"]
+keywords["development"] = keywords["1.2"] | set(["try"])
 
 # Grammar versions and their definitions. The productions for WDL 1.2 and development will be
 # defined in this file, while older versions are found in _grammar_old.py.
@@ -40,11 +40,12 @@ import_alias: "alias" CNAME "as" CNAME
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 workflow: "workflow" CNAME "{" workflow_element* "}"
-?workflow_element: input_decls | any_decl | call | scatter | conditional | workflow_outputs | meta_section | hints_section
+?workflow_element: input_decls | any_decl | call | scatter | conditional | try_section | workflow_outputs | meta_section | hints_section
 
 scatter: "scatter" "(" CNAME "in" expr ")" "{" inner_workflow_element* "}"
 conditional: "if" "(" expr ")" "{" inner_workflow_element* "}"
-?inner_workflow_element: any_decl | call | scatter | conditional
+try_section: "try" "{" inner_workflow_element* "}"
+?inner_workflow_element: any_decl | call | scatter | conditional | try_section
 
 call: "call" namespaced_ident ("after" CNAME)* _call_body? -> call
     | "call" namespaced_ident "as" CNAME ("after" CNAME)* _call_body? -> call_as

--- a/WDL/_parser.py
+++ b/WDL/_parser.py
@@ -518,6 +518,9 @@ class _DocTransformer(_ExprTransformer):
     def conditional(self, meta, items):
         return Tree.Conditional(self._sp(meta), items[0], items[1:])
 
+    def try_section(self, meta, items):
+        return Tree.Try(self._sp(meta), items)
+
     def workflow_wildcard_output(self, meta, items):
         return items[0] + ["*"]
         # return Expr.Ident(items[0].pos, items[0].namespace + [items[0].name, "*"])
@@ -575,7 +578,7 @@ class _DocTransformer(_ExprTransformer):
                     hints_section = item["hints"]
                 else:
                     assert False
-            elif isinstance(item, (Tree.Call, Tree.Conditional, Tree.Decl, Tree.Scatter)):
+            elif isinstance(item, (Tree.Call, Tree.Conditional, Tree.Decl, Tree.Scatter, Tree.Try)):
                 elements.append(item)
             else:
                 assert False

--- a/WDL/runtime/workflow.py
+++ b/WDL/runtime/workflow.py
@@ -6,8 +6,8 @@ Overview
 --------
 
 Workflow execution proceeds according to the AST's ``WorkflowNode`` graph, in which each Decl,
-Call, Scatter, Conditional, and (implicit) Gather operation has its own node which advertises its
-dependencies on the other nodes.
+Call, Scatter, Conditional, Try, and (implicit) Gather operation has its own node which advertises
+its dependencies on the other nodes.
 
 Abstractly, we plan to "visit" each node after visiting all of its dependencies. The node's type
 prescribes some job to do upon visitation, such as evaluating a Decl's WDL expression, running a
@@ -23,9 +23,9 @@ jobs can be scheduled as well, with their dependencies multiplexed to the corres
 jobs. Nodes outside of the scatter section depend on the Gather nodes rather than reaching into the
 body subgraph directly.
 
-Conditional sections are treated similarly, but only zero or one instance of its body subgraph will
-be launched. Scatter and Conditional sections may be nested, inducing a multi-level tree of Gather
-operations.
+Conditional and experimental Try sections are treated similarly, but only zero or one instance of
+the body subgraph will be launched. Scatter, Conditional, and Try sections may be nested, inducing a
+multi-level tree of Gather operations.
 """
 
 import logging
@@ -65,7 +65,14 @@ from .._util import (
 from .._util import StructuredLogMessage as _
 from . import config, _statusbar
 from .cache import CallCache, new as new_call_cache
-from .error import RunFailed, Terminated, error_json
+from .error import (
+    RunFailed,
+    Terminated,
+    CommandFailed,
+    DownloadFailed,
+    Interrupted,
+    error_json,
+)
 
 
 class WorkflowOutputs(Tree.WorkflowNode):
@@ -139,6 +146,7 @@ class StateMachine:
     jobs: Dict[str, _Job]
     job_outputs: Dict[str, Env.Bindings[Value.Base]]
     finished: Set[str]
+    failed: Set[str]
     running: Set[str]
     waiting: Set[str]
 
@@ -165,6 +173,7 @@ class StateMachine:
         self.jobs = {}
         self.job_outputs = {}
         self.finished = set()
+        self.failed = set()
         self.running = set()
         self.waiting = set()
         self.fspath_allowlist = _fspaths(inputs)
@@ -240,6 +249,7 @@ class StateMachine:
             ("id", str),
             ("callee", Union[Tree.Task, Tree.Workflow]),
             ("inputs", Env.Bindings[Value.Base]),
+            ("allow_failure", bool),
         ],
     )
     """
@@ -309,6 +319,8 @@ class StateMachine:
             self.job_outputs[job.id] = res
             self.running.remove(job.id)
             self.finished.add(job.id)
+            if job.dependencies & self.failed:
+                self.failed.add(job.id)
 
     def call_finished(self, job_id: str, outputs: Env.Bindings[Value.Base]) -> None:
         """
@@ -330,6 +342,23 @@ class StateMachine:
         self.fspath_allowlist |= _fspaths(outputs)
         self.finished.add(job_id)
         self.running.remove(job_id)
+
+    def call_failed(self, job_id: str, exn: BaseException) -> None:
+        """
+        Deliver notice that a call in a try section failed, suppressing the failure with null
+        outputs.
+        """
+        assert job_id in self.running
+        call_node = self.jobs[job_id].node
+        assert isinstance(call_node, Tree.Call)
+        self.logger.warning(_("call failure suppressed by try", job=job_id, message=str(exn)))
+        self.job_outputs[job_id] = _null_outputs(call_node)
+        self.failed.add(job_id)
+        self.finished.add(job_id)
+        self.running.remove(job_id)
+
+    def call_can_fail(self, job_id: str) -> bool:
+        return self._job_in_try(self.jobs[job_id])
 
     def _schedule(self, job: _Job) -> None:
         self.logger.debug(_("schedule", node=job.id, dependencies=list(job.dependencies)))
@@ -360,7 +389,14 @@ class StateMachine:
             )
         )
 
-        if isinstance(job.node, (Tree.Scatter, Tree.Conditional)):
+        if self._job_in_try(job) and job.dependencies & self.failed:
+            if isinstance(job.node, Tree.WorkflowSection):
+                for newjob in _section_gathers(job.node, job.scatter_stack):
+                    self._schedule(newjob)
+                return Env.Bindings()
+            return _null_outputs(job.node)
+
+        if isinstance(job.node, (Tree.Scatter, Tree.Conditional, Tree.Try)):
             for newjob in _scatter(
                 self.workflow,
                 job.node,
@@ -442,10 +478,21 @@ class StateMachine:
             )
 
             return StateMachine.CallInstructions(
-                id=job.id, callee=job.node.callee, inputs=call_inputs
+                id=job.id,
+                callee=job.node.callee,
+                inputs=call_inputs,
+                allow_failure=self._job_in_try(job),
             )
 
         raise NotImplementedError()
+
+    def _job_in_try(self, job: _Job) -> bool:
+        node: Optional[Tree.SourceNode] = job.node
+        while node is not None:
+            if isinstance(node, Tree.Try):
+                return True
+            node = getattr(node, "parent", None)
+        return False
 
     @property
     def logger(self) -> logging.Logger:
@@ -463,7 +510,7 @@ class StateMachine:
 
 def _scatter(
     workflow: Tree.Workflow,
-    section: Union[Tree.Scatter, Tree.Conditional],
+    section: Union[Tree.Scatter, Tree.Conditional, Tree.Try],
     env: Env.Bindings[Value.Base],
     scatter_stack: List[Tuple[str, Env.Binding[Value.Base]]],
     stdlib: StdLib.Base,
@@ -479,17 +526,21 @@ def _scatter(
                 multiplex[subgather.workflow_node_id] = set()
 
     # evaluate scatter array or boolean condition
-    v = section.expr.eval(env, stdlib=stdlib)
     array: List[Optional[Value.Base]] = []
     if isinstance(section, Tree.Scatter):
+        v = section.expr.eval(env, stdlib=stdlib)
         assert isinstance(v, Value.Array)
         for v_i in v.value:
             array.append(v_i)
-    else:
+    elif isinstance(section, Tree.Conditional):
+        v = section.expr.eval(env, stdlib=stdlib)
         assert isinstance(v, Value.Boolean)
         if v.value:
             # condition is satisfied, so we'll "scatter" over a length-1 array
             array = [None]
+    else:
+        assert isinstance(section, Tree.Try)
+        array = [None]
     digits = math.ceil(math.log10(len(array))) if len(array) > 1 else 1
 
     # for each array element, schedule an instance of the body subgraph
@@ -554,6 +605,18 @@ def _scatter(
             id=_append_scatter_indices(gather.workflow_node_id, [p[0] for p in scatter_stack]),
             node=gather,
             dependencies=multiplex[body_node_id],
+            scatter_stack=scatter_stack,
+        )
+
+
+def _section_gathers(
+    section: Tree.WorkflowSection, scatter_stack: List[Tuple[str, Env.Binding[Value.Base]]]
+) -> Iterable[_Job]:
+    for gather in section.gathers.values():
+        yield _Job(
+            id=_append_scatter_indices(gather.workflow_node_id, [p[0] for p in scatter_stack]),
+            node=gather,
+            dependencies=set(),
             scatter_stack=scatter_stack,
         )
 
@@ -666,12 +729,34 @@ def _gather(
         if isinstance(gather.section, Tree.Scatter):
             rhs: Value.Base = Value.Array((v0.type if v0 else Type.Any()), values)
         else:
-            assert isinstance(gather.section, Tree.Conditional)
+            assert isinstance(gather.section, (Tree.Conditional, Tree.Try))
             assert len(values) <= 1
             rhs = v0 if v0 is not None else Value.Null()
         ans = ans.bind(".".join(ns + [name]), rhs)
 
     return ans
+
+
+def _null_outputs(node: Tree.WorkflowNode) -> Env.Bindings[Value.Base]:
+    if isinstance(node, Tree.Decl):
+        return Env.Bindings(Env.Binding(node.name, Value.Null()))
+    if isinstance(node, Tree.Call):
+        ans: Env.Bindings[Value.Base] = Env.Bindings()
+        for b in node.effective_outputs.enter_namespace(node.name):
+            ans = ans.bind(b.name, Value.Null())
+        return ans.wrap_namespace(node.name)
+    if isinstance(node, Tree.WorkflowSection):
+        return Env.Bindings()
+    if isinstance(node, Tree.Gather):
+        leaf = node.final_referee
+        if isinstance(leaf, Tree.Decl):
+            return Env.Bindings(Env.Binding(leaf.name, Value.Null()))
+        if isinstance(leaf, Tree.Call):
+            ans = Env.Bindings()
+            for b in leaf.effective_outputs.enter_namespace(leaf.name):
+                ans = ans.bind(leaf.name + "." + b.name, Value.Null())
+            return ans
+    raise NotImplementedError()
 
 
 class _StdLib(StdLib.Base):
@@ -1045,9 +1130,15 @@ def _workflow_main_loop(
                 # no more calls to launch right now; wait for an outstanding call to finish
                 future = next(futures.as_completed(call_futures), None)
                 if future:
-                    __, outputs = future.result()
                     call_id = call_futures[future]
-                    state.call_finished(call_id, outputs)
+                    try:
+                        __, outputs = future.result()
+                        state.call_finished(call_id, outputs)
+                    except Exception as exn:
+                        if state.call_can_fail(call_id) and _try_suppresses_exception(exn):
+                            state.call_failed(call_id, exn)
+                        else:
+                            raise
                     call_futures.pop(future)
                 else:
                     assert state.outputs is not None
@@ -1113,6 +1204,30 @@ def _workflow_main_loop(
         for key in call_futures:
             key.cancel()
         raise wrapper from exn
+
+
+def _try_suppresses_exception(exn: BaseException) -> bool:
+    """
+    Decide whether an exception from a call in a try section is execution-side failure that should
+    be suppressed. WDL expression/input evaluation errors should continue to propagate.
+    """
+    cause = exn
+    seen: Set[int] = set()
+    while isinstance(cause, RunFailed) and cause.__cause__ and id(cause) not in seen:
+        seen.add(id(cause))
+        cause = cause.__cause__
+
+    if isinstance(cause, Terminated):
+        return False
+    if isinstance(cause, (Error.EvalError, Error.InputError)):
+        return False
+    if isinstance(cause, (CommandFailed, DownloadFailed, Interrupted)):
+        return True
+
+    # Some backend/container failures use the base WDL runtime error directly, for example a
+    # missing Docker image or rejected Docker service. Keep this exact-type check narrow so EvalError
+    # and InputError subclasses don't get swept up.
+    return type(cause) is Error.RuntimeError
 
 
 def _download_input_files(

--- a/tests/test_6workflowrun.py
+++ b/tests/test_6workflowrun.py
@@ -7,19 +7,21 @@ import sys
 import pytest
 from .context import WDL
 
-class TestWorkflowRunner(unittest.TestCase):
 
+class TestWorkflowRunner(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        logging.basicConfig(level=logging.DEBUG, format='%(name)s %(levelname)s %(message)s')
+        logging.basicConfig(level=logging.DEBUG, format="%(name)s %(levelname)s %(message)s")
         logger = logging.getLogger(cls.__name__)
-        cfg = WDL.runtime.config.Loader(logger, [])
+        WDL.runtime.config.Loader(logger, [])
 
     def setUp(self):
         self._dir = tempfile.mkdtemp(prefix="miniwdl_test_workflowrun_")
 
-    def _test_workflow(self, wdl:str, inputs = None, expected_exception: Exception = None, cfg = None):
-        sys.setrecursionlimit(200)  # set artificially low in unit tests to detect excessive recursion (issue #239)
+    def _test_workflow(self, wdl: str, inputs=None, expected_exception: Exception = None, cfg=None):
+        sys.setrecursionlimit(
+            200
+        )  # set artificially low in unit tests to detect excessive recursion (issue #239)
         logger = logging.getLogger(self.id())
         cfg = cfg or WDL.runtime.config.Loader(logger, [])
         try:
@@ -29,8 +31,16 @@ class TestWorkflowRunner(unittest.TestCase):
             doc = WDL.load(wdlfn)
             assert len(doc.workflow.required_inputs.subtract(doc.workflow.available_inputs)) == 0
             if isinstance(inputs, dict):
-                inputs = WDL.values_from_json(inputs, doc.workflow.available_inputs, doc.workflow.required_inputs)
-            rundir, outputs = WDL.runtime.run(cfg, doc.workflow, (inputs or WDL.Env.Bindings()), run_dir=self._dir, _test_pickle=True)
+                inputs = WDL.values_from_json(
+                    inputs, doc.workflow.available_inputs, doc.workflow.required_inputs
+                )
+            rundir, outputs = WDL.runtime.run(
+                cfg,
+                doc.workflow,
+                (inputs or WDL.Env.Bindings()),
+                run_dir=self._dir,
+                _test_pickle=True,
+            )
             self._rundir = rundir
         except WDL.runtime.RunFailed as exn:
             while isinstance(exn, WDL.runtime.RunFailed):
@@ -53,14 +63,18 @@ class TestWorkflowRunner(unittest.TestCase):
         return WDL.values_to_json(outputs)
 
     def test_hello(self):
-        self.assertEqual(self._test_workflow("""
+        self.assertEqual(
+            self._test_workflow("""
         version 1.0
 
         workflow nop {
         }
-        """), {})
+        """),
+            {},
+        )
 
-        self.assertEqual(self._test_workflow("""
+        self.assertEqual(
+            self._test_workflow("""
         version 1.0
 
         workflow nop {
@@ -68,9 +82,12 @@ class TestWorkflowRunner(unittest.TestCase):
                 String msg = "hello"
             }
         }
-        """), {"msg": "hello"})
+        """),
+            {"msg": "hello"},
+        )
 
-        outputs = self._test_workflow("""
+        outputs = self._test_workflow(
+            """
         version 1.0
 
         workflow hellowf {
@@ -106,12 +123,17 @@ class TestWorkflowRunner(unittest.TestCase):
                 Int meaning_of_life = x+1
             }
         }
-        """, {"x": 41})
-        self.assertEqual(outputs["messages"], ["Hello Alice", "Hello Bob", "Hello Alyssa", "Hello Ben"])
+        """,
+            {"x": 41},
+        )
+        self.assertEqual(
+            outputs["messages"], ["Hello Alice", "Hello Bob", "Hello Alyssa", "Hello Ben"]
+        )
         self.assertEqual(outputs["meanings"], [42, 42])
 
     def test_scatters(self):
-        outputs = self._test_workflow("""
+        outputs = self._test_workflow(
+            """
         version 1.0
 
         workflow hellowf {
@@ -125,10 +147,13 @@ class TestWorkflowRunner(unittest.TestCase):
                 Array[Int] sqs = sq
             }
         }
-        """, {"n": 10})
+        """,
+            {"n": 10},
+        )
         self.assertEqual(outputs["sqs"], [0, 1, 4, 9, 16, 25, 36, 49, 64, 81])
 
-        outputs = self._test_workflow("""
+        outputs = self._test_workflow(
+            """
         version 1.0
 
         workflow hellowf {
@@ -155,10 +180,13 @@ class TestWorkflowRunner(unittest.TestCase):
                 Int k_sq = k*k
             }
         }
-        """, {"n": 10})
+        """,
+            {"n": 10},
+        )
         self.assertEqual(outputs["sqs"], [0, 1, 4, 9, 16, 25, 36, 49, 64, 81])
 
-        outputs = self._test_workflow("""
+        outputs = self._test_workflow(
+            """
         version 1.0
 
         workflow crossrange {
@@ -175,19 +203,25 @@ class TestWorkflowRunner(unittest.TestCase):
                 Array[Pair[Int,Int]] pairs = flatten(p)
             }
         }
-        """, {"m": 4, "n": 2})
-        self.assertEqual(outputs["pairs"], [
-            {"left": 0, "right": 0},
-            {"left": 0, "right": 1},
-            {"left": 1, "right": 0},
-            {"left": 1, "right": 1},
-            {"left": 2, "right": 0},
-            {"left": 2, "right": 1},
-            {"left": 3, "right": 0},
-            {"left": 3, "right": 1}
-        ])
+        """,
+            {"m": 4, "n": 2},
+        )
+        self.assertEqual(
+            outputs["pairs"],
+            [
+                {"left": 0, "right": 0},
+                {"left": 0, "right": 1},
+                {"left": 1, "right": 0},
+                {"left": 1, "right": 1},
+                {"left": 2, "right": 0},
+                {"left": 2, "right": 1},
+                {"left": 3, "right": 0},
+                {"left": 3, "right": 1},
+            ],
+        )
 
-        outputs = self._test_workflow("""
+        outputs = self._test_workflow(
+            """
         version 1.0
 
         workflow crossrange {
@@ -221,17 +255,22 @@ class TestWorkflowRunner(unittest.TestCase):
                 Pair[Int,Int] pair = (lhs,rhs)
             }
         }
-        """, {"m": 4, "n": 2})
-        self.assertEqual(outputs["pairs"], [
-            {"left": 0, "right": 0},
-            {"left": 0, "right": 1},
-            {"left": 1, "right": 0},
-            {"left": 1, "right": 1},
-            {"left": 2, "right": 0},
-            {"left": 2, "right": 1},
-            {"left": 3, "right": 0},
-            {"left": 3, "right": 1}
-        ])
+        """,
+            {"m": 4, "n": 2},
+        )
+        self.assertEqual(
+            outputs["pairs"],
+            [
+                {"left": 0, "right": 0},
+                {"left": 0, "right": 1},
+                {"left": 1, "right": 0},
+                {"left": 1, "right": 1},
+                {"left": 2, "right": 0},
+                {"left": 2, "right": 1},
+                {"left": 3, "right": 0},
+                {"left": 3, "right": 1},
+            ],
+        )
 
     def test_scatter_tags(self):
         outputs = self._test_workflow("""
@@ -267,8 +306,14 @@ class TestWorkflowRunner(unittest.TestCase):
             }
         }
         """)
-        for tag in ("-0-AlyssaP-0-Hacker/", "-0-AlyssaP-1-Bit_diddle012345/", "-0-AlyssaP-2-it_diddle0123456/",
-                    "-1-Ben-0-Hacker/", "-1-Ben-1-Bit_diddle012345/", "-1-Ben-2-it_diddle0123456/"):
+        for tag in (
+            "-0-AlyssaP-0-Hacker/",
+            "-0-AlyssaP-1-Bit_diddle012345/",
+            "-0-AlyssaP-2-it_diddle0123456/",
+            "-1-Ben-0-Hacker/",
+            "-1-Ben-1-Bit_diddle012345/",
+            "-1-Ben-2-it_diddle0123456/",
+        ):
             self.assertTrue(next(True for fn in outputs["messages"] if tag in os.path.realpath(fn)))
 
     def test_ifs(self):
@@ -389,6 +434,236 @@ class TestWorkflowRunner(unittest.TestCase):
         """)
         self.assertEqual(outputs, {"out": [[0, 1], None, [4, 5]]})
 
+    def test_try(self):
+        outputs = self._test_workflow("""
+        version 1.2
+
+        workflow trywf {
+            try {
+                call fail
+                Int plus = fail.x + 1
+                call sum {
+                    input:
+                        lhs = plus,
+                        rhs = 1
+                }
+            }
+            output {
+                Array[Int] failed = select_all([fail.x, plus, sum.ans])
+            }
+        }
+
+        task fail {
+            command <<<
+                exit 42
+            >>>
+            runtime {
+                docker: "ubuntu:20.04"
+            }
+            output {
+                Int x = 1
+            }
+        }
+
+        task sum {
+            input {
+                Int lhs
+                Int rhs
+            }
+            command <<<
+                echo ok
+            >>>
+            runtime {
+                docker: "ubuntu:20.04"
+            }
+            output {
+                Int ans = lhs + rhs
+            }
+        }
+        """)
+        self.assertEqual(outputs, {"failed": []})
+
+    def test_try_subworkflow_task_failure(self):
+        with open(os.path.join(self._dir, "inner.wdl"), "w") as outfile:
+            outfile.write(
+                """
+        version 1.2
+
+        workflow inner {
+            call fail
+            output {
+                Int x = fail.x
+            }
+        }
+
+        task fail {
+            command <<<
+                exit 42
+            >>>
+            runtime {
+                docker: "ubuntu:20.04"
+            }
+            output {
+                Int x = 1
+            }
+        }
+        """
+            )
+        outputs = self._test_workflow("""
+        version 1.2
+        import "inner.wdl" as lib
+
+        workflow outer {
+            try {
+                call lib.inner
+            }
+            output {
+                Array[Int] failed = select_all([inner.x])
+            }
+        }
+        """)
+        self.assertEqual(outputs, {"failed": []})
+
+    def test_try_eval_errors_propagate(self):
+        exn = self._test_workflow(
+            """
+        version 1.2
+
+        workflow trywf {
+            try {
+                Int bad = 1 / 0
+            }
+            output {
+                Int? out = bad
+            }
+        }
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )
+        self.assertEqual(exn.job_id, "decl-bad")
+
+        exn = self._test_workflow(
+            """
+        version 1.2
+
+        workflow trywf {
+            try {
+                call sum {
+                    input:
+                        lhs = 1 / 0,
+                        rhs = 1
+                }
+            }
+            output {
+                Int? out = sum.ans
+            }
+        }
+
+        task sum {
+            input {
+                Int lhs
+                Int rhs
+            }
+            command {}
+            output {
+                Int ans = lhs + rhs
+            }
+        }
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )
+        self.assertEqual(exn.job_id, "call-sum")
+
+        exn = self._test_workflow(
+            """
+        version 1.2
+
+        workflow trywf {
+            try {
+                call bad_output
+            }
+            output {
+                Int? out = bad_output.x
+            }
+        }
+
+        task bad_output {
+            command <<<
+                echo ok
+            >>>
+            runtime {
+                docker: "ubuntu:20.04"
+            }
+            output {
+                Int x = 1 / 0
+            }
+        }
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )
+        self.assertEqual(exn.job_id, "decl-x")
+
+    def test_try_output_errors_propagate(self):
+        exn = self._test_workflow(
+            """
+        version 1.2
+
+        workflow trywf {
+            try {
+                call bad_output
+            }
+            output {
+                File? out = bad_output.missing
+            }
+        }
+
+        task bad_output {
+            command <<<
+                echo ok
+            >>>
+            runtime {
+                docker: "ubuntu:20.04"
+            }
+            output {
+                File missing = "missing.txt"
+            }
+        }
+        """,
+            expected_exception=WDL.runtime.OutputError,
+        )
+        self.assertEqual(exn.job_id, "decl-missing")
+
+    def test_try_failure_classification(self):
+        with tempfile.NamedTemporaryFile(dir=self._dir, suffix=".wdl", delete=False) as outfile:
+            outfile.write(
+                """
+        version 1.2
+        workflow w {}
+        """.encode("utf-8")
+            )
+            wdlfn = outfile.name
+        doc = WDL.load(wdlfn)
+        suppresses = WDL.runtime.workflow._try_suppresses_exception
+
+        self.assertTrue(
+            suppresses(WDL.runtime.CommandFailed(42, "/tmp/stderr.txt", "/tmp/stdout.txt"))
+        )
+        self.assertTrue(suppresses(WDL.runtime.DownloadFailed("s3://example/file.txt")))
+        self.assertFalse(suppresses(WDL.Error.EvalError(doc.workflow, "bad expression")))
+        self.assertFalse(suppresses(WDL.Error.InputError("bad input")))
+        self.assertFalse(suppresses(WDL.runtime.OutputError("bad output")))
+
+        try:
+            try:
+                raise WDL.runtime.CommandFailed(42, "/tmp/stderr.txt", "/tmp/stdout.txt")
+            except WDL.runtime.CommandFailed as exn:
+                raise WDL.runtime.RunFailed(doc.workflow, "inner", self._dir) from exn
+        except WDL.runtime.RunFailed as exn:
+            try:
+                raise WDL.runtime.RunFailed(doc.workflow, "outer", self._dir) from exn
+            except WDL.runtime.RunFailed as wrapped:
+                self.assertTrue(suppresses(wrapped))
+
     def test_io(self):
         txt = """
         version 1.0
@@ -407,7 +682,8 @@ class TestWorkflowRunner(unittest.TestCase):
         self.assertEqual(self._test_workflow(txt, {"x": 1}), {"out": [1, 2, 3]})
         self.assertEqual(self._test_workflow(txt, {"x": 1, "z": 42}), {"out": [1, 2, 42]})
 
-        outputs = self._test_workflow("""
+        outputs = self._test_workflow(
+            """
         version 1.0
 
         workflow inputs {
@@ -439,8 +715,10 @@ class TestWorkflowRunner(unittest.TestCase):
                 Int ans = lhs + rhs
             }
         }
-        """, {"x": 3})
-        self.assertEqual(outputs, { "y.ans": 4, "sum.ans": [ 5, 6, 7 ] })
+        """,
+            {"x": 3},
+        )
+        self.assertEqual(outputs, {"y.ans": 4, "sum.ans": [5, 6, 7]})
 
         # setting optional input of call inside scatter
         txt = """
@@ -474,8 +752,8 @@ class TestWorkflowRunner(unittest.TestCase):
             }
         }
         """
-        self.assertEqual(self._test_workflow(txt, {"x":3}), { "ans": [ 0, 2, 4] })
-        self.assertEqual(self._test_workflow(txt, {"x":3, "sum.more": 1}), { "ans": [ 1, 3, 5] })
+        self.assertEqual(self._test_workflow(txt, {"x": 3}), {"ans": [0, 2, 4]})
+        self.assertEqual(self._test_workflow(txt, {"x": 3, "sum.more": 1}), {"ans": [1, 3, 5]})
 
         txt = """
         version 1.0
@@ -529,16 +807,20 @@ class TestWorkflowRunner(unittest.TestCase):
         self.assertEqual(outputs["null2"], [None, None, None])
 
     def test_errors(self):
-        exn = self._test_workflow("""
+        exn = self._test_workflow(
+            """
         version 1.0
 
         workflow bogus {
             Int y = range(4)[99]
         }
-        """, expected_exception=WDL.Error.EvalError)
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )
         self.assertEqual(exn.job_id, "decl-y")
 
-        exn = self._test_workflow("""
+        exn = self._test_workflow(
+            """
         version 1.0
 
         workflow inputs {
@@ -560,7 +842,9 @@ class TestWorkflowRunner(unittest.TestCase):
                 Int y = range(4)[99]
             }
         }
-        """, expected_exception=WDL.Error.EvalError)
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )
         self.assertEqual(exn.job_id, "decl-y")
 
     def test_order(self):
@@ -623,7 +907,8 @@ class TestWorkflowRunner(unittest.TestCase):
         with open(os.path.join(self._dir, "sum_sq.wdl"), "w") as outfile:
             outfile.write(subwf)
 
-        outputs = self._test_workflow("""
+        outputs = self._test_workflow(
+            """
         version 1.0
         import "sum_sq.wdl" as lib
 
@@ -646,7 +931,9 @@ class TestWorkflowRunner(unittest.TestCase):
                 Int sum = sum_all.ans
             }
         }
-        """, {"n": 3})
+        """,
+            {"n": 3},
+        )
         self.assertEqual(outputs["sums"], [1, 5, 14])
         self.assertEqual(outputs["sum"], 20)
 
@@ -665,7 +952,8 @@ class TestWorkflowRunner(unittest.TestCase):
         self._test_workflow(subwf_input, {"summer.sum_sq.n": 3})
 
     def test_host_file_access(self):
-        exn = self._test_workflow("""
+        exn = self._test_workflow(
+            """
         version 1.0
         workflow hacker9000 {
             input {
@@ -676,10 +964,13 @@ class TestWorkflowRunner(unittest.TestCase):
                 File your_passwords = half1 + half2
             }
         }
-        """, expected_exception=WDL.Error.InputError)
+        """,
+            expected_exception=WDL.Error.InputError,
+        )
         self.assertTrue("not expressly supplied with workflow inputs" in str(exn))
 
-        exn = self._test_workflow("""
+        exn = self._test_workflow(
+            """
         version 1.0
         workflow hacker9000 {
             input {
@@ -695,10 +986,13 @@ class TestWorkflowRunner(unittest.TestCase):
                 cat ~{file}
             }
         }
-        """, expected_exception=WDL.Error.InputError)
+        """,
+            expected_exception=WDL.Error.InputError,
+        )
         self.assertTrue("not expressly supplied with workflow inputs" in str(exn))
 
-        exn = self._test_workflow("""
+        exn = self._test_workflow(
+            """
         version 1.0
         struct Box {
             Array[String] str
@@ -729,13 +1023,16 @@ class TestWorkflowRunner(unittest.TestCase):
                 cat ~{file}
             }
         }
-        """, expected_exception=WDL.Error.InputError)
+        """,
+            expected_exception=WDL.Error.InputError,
+        )
         self.assertTrue("not expressly supplied with workflow inputs" in str(exn))
 
         # positive control
         with open(os.path.join(self._dir, "allowed.txt"), "w") as outfile:
             outfile.write("yo")
-        outputs = self._test_workflow("""
+        outputs = self._test_workflow(
+            """
         version 1.0
         struct Box {
             Array[File] str
@@ -776,7 +1073,9 @@ class TestWorkflowRunner(unittest.TestCase):
                 String tweet = read_string(stdout())
             }
         }
-        """, inputs={"box": { "str": [os.path.join(self._dir, "allowed.txt")] }})
+        """,
+            inputs={"box": {"str": [os.path.join(self._dir, "allowed.txt")]}},
+        )
         self.assertEqual(outputs["tweets"], ["yo", "Hello, world!"])
 
         with tempfile.NamedTemporaryFile("w") as tmp:
@@ -812,22 +1111,28 @@ class TestWorkflowRunner(unittest.TestCase):
             outp = self._test_workflow(hacker9000.replace("XXX", tmp.name), cfg=cfg)
             self.assertEqual("foobar", outp["tweet"].strip())
 
-            exn = self._test_workflow(hacker9000.replace("XXX", "/nonexistentPath999"),
-                                      cfg=cfg, expected_exception=WDL.Error.InputError)
+            exn = self._test_workflow(
+                hacker9000.replace("XXX", "/nonexistentPath999"),
+                cfg=cfg,
+                expected_exception=WDL.Error.InputError,
+            )
             self.assertTrue("uses nonexistent" in str(exn))
 
             cfg.override({"file_io": {"root": "/home"}})
-            exn = self._test_workflow(hacker9000.replace("XXX", tmp.name),
-                                      cfg=cfg, expected_exception=WDL.Error.InputError)
+            exn = self._test_workflow(
+                hacker9000.replace("XXX", tmp.name),
+                cfg=cfg,
+                expected_exception=WDL.Error.InputError,
+            )
             self.assertTrue("must reside within" in str(exn))
-
 
     def test_stdlib_io(self):
         with open(os.path.join(self._dir, "who.txt"), "w") as outfile:
             outfile.write("Alyssa\n")
             outfile.write("Ben\n")
 
-        outputs = self._test_workflow("""
+        outputs = self._test_workflow(
+            """
             version 1.0
             workflow hello {
                 input {
@@ -841,20 +1146,26 @@ class TestWorkflowRunner(unittest.TestCase):
                     Array[String] messages = message
                 }
             }
-            """, {"who": os.path.join(self._dir, "who.txt")})
+            """,
+            {"who": os.path.join(self._dir, "who.txt")},
+        )
         self.assertEqual(outputs["messages"], ["Hello, Alyssa!", "Hello, Ben!"])
 
-        exn = self._test_workflow("""
+        exn = self._test_workflow(
+            """
         version 1.0
         workflow hacker9000 {
             input {
             }
             Array[String] your_passwords = read_lines("/etc/passwd")
         }
-        """, expected_exception=WDL.Error.EvalError)
+        """,
+            expected_exception=WDL.Error.EvalError,
+        )
         self.assertTrue("not expressly supplied with workflow inputs" in str(exn))
 
-        outputs = self._test_workflow("""
+        outputs = self._test_workflow(
+            """
             version 1.0
             workflow hello {
                 input {
@@ -883,7 +1194,9 @@ class TestWorkflowRunner(unittest.TestCase):
                     String message = read_string(stdout())
                 }
             }
-        """, {"who": ["Alyssa", "Ben"]})
+        """,
+            {"who": ["Alyssa", "Ben"]},
+        )
         self.assertEqual(outputs["messages"], ["Hello, Alyssa!", "Hello, Ben!"])
         self.assertEqual(outputs["who2"], ["Alyssa", "Ben"])
 
@@ -997,11 +1310,12 @@ class TestWorkflowRunner(unittest.TestCase):
                                    File message = glob("message.*")[0]
                                }
                            }
-                           """, {"who": os.path.join(self._dir, "who.txt"), "sleepTime": sleep_time}
+                           """,
+            {"who": os.path.join(self._dir, "who.txt"), "sleepTime": sleep_time},
         )
 
         end = time.time()
-        test_time = round(end-start)
+        test_time = round(end - start)
 
         assert len(outputs["messages"]) == 9
         with open(outputs["messages"][0], "r") as infile:
@@ -1066,8 +1380,9 @@ class TestWorkflowRunner(unittest.TestCase):
                                    File message = glob("message.*")[0]
                                }
                            }
-                           """, {"who": os.path.join(self._dir, "who.txt")},
-            expected_exception=WDL.Error.EvalError
+                           """,
+            {"who": os.path.join(self._dir, "who.txt")},
+            expected_exception=WDL.Error.EvalError,
         )
 
         end = time.time()
@@ -1123,7 +1438,9 @@ class TestWorkflowRunner(unittest.TestCase):
         """
         outputs = self._test_workflow(txt)
         self.assertGreaterEqual(outputs["finish_time"], outputs["start_time"] + 20)
-        self.assertTrue(os.path.isfile(os.path.join(self._rundir, "call-finish", "work2", "iwuzhere")))
+        self.assertTrue(
+            os.path.isfile(os.path.join(self._rundir, "call-finish", "work2", "iwuzhere"))
+        )
         self.assertTrue(os.path.isfile(outputs["stdout_txt"]))
         self.assertTrue(outputs["stdout_txt"].endswith(".txt"))
         self.assertFalse(outputs["stdout_txt"].endswith("stdout.txt"))
@@ -1131,7 +1448,9 @@ class TestWorkflowRunner(unittest.TestCase):
             stdout_lines = stdout_txt.read().strip().split("\n")
             self.assertEqual(len(stdout_lines), 1)
         cfg = WDL.runtime.config.Loader(logging.getLogger(self.id()), [])
-        cfg.override({"file_io": {"delete_work": "failure"}, "task_runtime": {"_mock_interruptions": 2}})
+        cfg.override(
+            {"file_io": {"delete_work": "failure"}, "task_runtime": {"_mock_interruptions": 2}}
+        )
         outputs = self._test_workflow(txt, cfg=cfg)
         self.assertGreaterEqual(outputs["finish_time"], outputs["start_time"] + 20)
         self.assertFalse(os.path.isdir(os.path.join(self._rundir, "call-finish", "work2")))
@@ -1174,7 +1493,6 @@ class TestWorkflowRunner(unittest.TestCase):
         """
         outputs = self._test_workflow(wdl)
         self.assertEqual(outputs["my_d"], {"a_struct": {"s": "hello"}, "i": 10})
-
 
     def test_struct_to_struct_coercion_negatives(self):
         cases = []


### PR DESCRIPTION
The `try` workflow section tolerates certain kinds of failures within, without failing the workflow.

Tolerated failures include `DownloadFailed`, `CommandFailed`, and container/scheduling/OOM problems. And exclude WDL EvalError, InputError, OutputError, and other problems intrinsic to the WDL logic.

Call outputs and values within a `try` section are exposed as optional, much like the existing `if` section, and become `None` in the event of a tolerated failure.

Within the `try` section body, nodes depending on a failed node are also considered failed.