### PR TITLE
[experimental] failure-tolerant `call?`

### DIFF
--- a/WDL/Expr.py
+++ b/WDL/Expr.py
@@ -996,6 +996,7 @@ class Ident(Base):
             assert referee.__class__.__name__ in [
                 "Decl",
                 "Call",
+                "CallTry",
                 "Scatter",
                 "Gather",
             ], referee.__class__.__name__

--- a/WDL/Tree.py
+++ b/WDL/Tree.py
@@ -713,6 +713,23 @@ class Call(WorkflowNode):
             yield from _expr_workflow_node_dependencies(expr)
 
 
+class CallTry(Call):
+    """A call whose tolerated runtime failures produce null optional outputs"""
+
+    @property
+    def effective_outputs(self) -> Env.Bindings[Type.Base]:
+        """:type: WDL.Env.Bindings[WDL.Tree.Decl]
+
+        Yields the effective outputs of the callee Task or Workflow, optionalized in a namespace
+        according to the call name.
+        """
+        ans: Env.Bindings[Type.Base] = Env.Bindings()
+        assert self.callee
+        for outp in reversed(list(self.callee.effective_outputs)):
+            ans = ans.bind(self.name + "." + outp.name, outp.value.copy(optional=True), self)
+        return ans
+
+
 class Gather(WorkflowNode):
     """
     A ``Gather`` node symbolizes the operation to gather an array of declared values or call

--- a/WDL/__init__.py
+++ b/WDL/__init__.py
@@ -17,6 +17,7 @@ from .Tree import (  # noqa: F401
     StructTypeDef,
     Task,
     Call,
+    CallTry,
     Scatter,
     Conditional,
     Gather,

--- a/WDL/_grammar.py
+++ b/WDL/_grammar.py
@@ -48,11 +48,14 @@ conditional: "if" "(" expr ")" "{" inner_workflow_element* "}"
 
 call: "call" namespaced_ident ("after" CNAME)* _call_body? -> call
     | "call" namespaced_ident "as" CNAME ("after" CNAME)* _call_body? -> call_as
+    | _CALL_TRY namespaced_ident ("after" CNAME)* _call_body? -> call_try
+    | _CALL_TRY namespaced_ident "as" CNAME ("after" CNAME)* _call_body? -> call_try_as
 namespaced_ident: CNAME ("." CNAME)*
 call_inputs: input_colon? [call_input ("," call_input)*] ","?
 input_colon: "input" ":"
 _call_body: "{" call_inputs? "}"
 call_input: CNAME ["=" expr]
+_CALL_TRY.10: "call?"
 
 ?workflow_outputs: output_decls
 

--- a/WDL/_parser.py
+++ b/WDL/_parser.py
@@ -511,6 +511,53 @@ class _DocTransformer(_ExprTransformer):
             after=after,
         )
 
+    def call_try(self, meta, items):
+        if self._version != "development":
+            raise Error.SyntaxError(
+                self._sp(meta),
+                "call? is only supported with version development",
+                self._version,
+                self._declared_version,
+            )
+        after = []
+        i = 1
+        while i < len(items):
+            if isinstance(items[i], lark.Token):
+                after.append(items[i].value)
+            else:
+                break
+            i += 1
+        assert i == len(items) or isinstance(items[i], dict)
+        return Tree.CallTry(
+            self._sp(meta), items[0], None, items[i] if i < len(items) else dict(), after=after
+        )
+
+    def call_try_as(self, meta, items):
+        if self._version != "development":
+            raise Error.SyntaxError(
+                self._sp(meta),
+                "call? is only supported with version development",
+                self._version,
+                self._declared_version,
+            )
+        self._check_keyword(self._sp(meta), items[1].value)
+        after = list()
+        i = 2
+        while i < len(items):
+            if isinstance(items[i], lark.Token):
+                after.append(items[i].value)
+            else:
+                break
+            i += 1
+        assert i == len(items) or isinstance(items[i], dict)
+        return Tree.CallTry(
+            self._sp(meta),
+            items[0],
+            items[1].value,
+            items[i] if i < len(items) else dict(),
+            after=after,
+        )
+
     def scatter(self, meta, items):
         self._check_keyword(self._sp(meta), items[0].value)
         return Tree.Scatter(self._sp(meta), items[0].value, items[1], items[2:])

--- a/WDL/runtime/workflow.py
+++ b/WDL/runtime/workflow.py
@@ -65,7 +65,15 @@ from .._util import (
 from .._util import StructuredLogMessage as _
 from . import config, _statusbar
 from .cache import CallCache, new as new_call_cache
-from .error import RunFailed, Terminated, error_json
+from .error import (
+    CommandFailed,
+    DownloadFailed,
+    Interrupted,
+    OutputError,
+    RunFailed,
+    Terminated,
+    error_json,
+)
 
 
 class WorkflowOutputs(Tree.WorkflowNode):
@@ -1045,10 +1053,11 @@ def _workflow_main_loop(
                 # no more calls to launch right now; wait for an outstanding call to finish
                 future = next(futures.as_completed(call_futures), None)
                 if future:
-                    __, outputs = future.result()
-                    call_id = call_futures[future]
+                    call_id = call_futures.pop(future)
+                    call_node = state.jobs[call_id].node
+                    assert isinstance(call_node, Tree.Call)
+                    outputs = _resolve_call_future_outputs(future, call_id, call_node, logger)
                     state.call_finished(call_id, outputs)
-                    call_futures.pop(future)
                 else:
                     assert state.outputs is not None
 
@@ -1113,6 +1122,74 @@ def _workflow_main_loop(
         for key in call_futures:
             key.cancel()
         raise wrapper from exn
+
+
+def _resolve_call_future_outputs(
+    future: futures.Future, call_id: str, call_node: Tree.Call, logger: logging.Logger
+) -> Env.Bindings[Value.Base]:
+    """Return the completed call's outputs, or null outputs for tolerated ``call?`` failures.
+
+    Ordinary calls and non-tolerated ``call?`` failures propagate their exception unchanged. When a
+    ``CallTry`` fails for an execution-layer reason classified by ``_tolerated_call_failure``, log
+    the root tolerated error and synthesize null bindings for all callee outputs so the workflow can
+    proceed.
+    """
+    try:
+        __, outputs = future.result()
+        return outputs
+    except Exception as exn:
+        if not isinstance(call_node, Tree.CallTry):
+            raise
+        tol_err = _tolerated_call_failure(exn)
+        if not tol_err:
+            raise
+        logger.warning(
+            _(
+                "call? tolerated failure",
+                job=call_id,
+                error=tol_err.__class__.__name__,
+                message=str(tol_err),
+                dir=getattr(exn, "run_dir", None),
+            )
+        )
+        return _null_call_outputs(call_node)
+
+
+def _exception_chain(exn: BaseException) -> Iterable[BaseException]:
+    visited = set()
+    while exn and id(exn) not in visited:
+        visited.add(id(exn))
+        yield exn
+        exn = exn.__cause__ or exn.__context__  # type: ignore
+
+
+def _tolerated_call_failure(exn: BaseException) -> Optional[BaseException]:
+    """Classify failures that a ``call?`` can downgrade to null outputs.
+
+    These are failures from running, downloading inputs for, or scheduling the callee, including
+    the same failures wrapped through nested subworkflow ``RunFailed`` exceptions. WDL logic errors
+    stay fatal because they indicate invalid expressions, invalid inputs, or invalid outputs rather
+    than an unsuccessful attempt to execute the call. Returns the most relevant cause to log when
+    the failure is tolerated, or ``None`` when the failure must propagate.
+    """
+    for cause in _exception_chain(exn):
+        if isinstance(cause, (Error.EvalError, Error.InputError, OutputError, Terminated)):
+            return None
+        if isinstance(cause, (CommandFailed, DownloadFailed, Interrupted)):
+            return cause
+        if isinstance(cause, Error.RuntimeError) and not isinstance(cause, RunFailed):
+            return cause
+        if cause.__class__.__name__ == "BuildError":
+            return cause
+    return None
+
+
+def _null_call_outputs(call_node: Tree.Call) -> Env.Bindings[Value.Base]:
+    ans: Env.Bindings[Value.Base] = Env.Bindings()
+    assert call_node.callee
+    for outp in reversed(list(call_node.callee.effective_outputs)):
+        ans = ans.bind(outp.name, Value.Null())
+    return ans
 
 
 def _download_input_files(

--- a/tests/test_6workflowrun.py
+++ b/tests/test_6workflowrun.py
@@ -13,7 +13,7 @@ class TestWorkflowRunner(unittest.TestCase):
     def setUpClass(cls):
         logging.basicConfig(level=logging.DEBUG, format='%(name)s %(levelname)s %(message)s')
         logger = logging.getLogger(cls.__name__)
-        cfg = WDL.runtime.config.Loader(logger, [])
+        WDL.runtime.config.Loader(logger, [])
 
     def setUp(self):
         self._dir = tempfile.mkdtemp(prefix="miniwdl_test_workflowrun_")
@@ -1249,3 +1249,185 @@ class TestWorkflowRunner(unittest.TestCase):
         for wdl in cases:
             with pytest.raises(WDL.Error.StaticTypeMismatch):
                 self._test_workflow(wdl)
+
+    def test_call_try_development_only(self):
+        self._test_workflow("""
+        version 1.2
+
+        workflow test_call_try_version {
+            call? ok
+        }
+
+        task ok {
+            command <<< true >>>
+        }
+        """, expected_exception=WDL.Error.SyntaxError)
+
+    def test_call_try_command_failure_outputs_null(self):
+        outputs = self._test_workflow("""
+        version development
+
+        workflow test_call_try {
+            call? fail
+
+            output {
+                String msg = select_first([fail.out, "fallback"])
+                Boolean absent = fail.out == None
+            }
+        }
+
+        task fail {
+            command <<<
+                exit 42
+            >>>
+            output {
+                String out = "unreached"
+            }
+        }
+        """)
+        self.assertEqual(outputs, {"msg": "fallback", "absent": True})
+
+    def test_call_try_outputs_are_optional(self):
+        self._test_workflow("""
+        version development
+
+        workflow test_call_try_type {
+            call? ok
+            output {
+                Int x = ok.x
+            }
+        }
+
+        task ok {
+            command <<< true >>>
+            output {
+                Int x = 1
+            }
+        }
+        """, expected_exception=WDL.Error.StaticTypeMismatch)
+
+    def test_call_try_eval_error_not_suppressed(self):
+        self._test_workflow("""
+        version development
+
+        workflow test_call_try_eval_error {
+            call? ok {
+                input:
+                    x = 1/0
+            }
+        }
+
+        task ok {
+            input {
+                Int x
+            }
+            command <<< true >>>
+        }
+        """, expected_exception=WDL.Error.EvalError)
+
+    def test_call_try_output_error_not_suppressed(self):
+        self._test_workflow("""
+        version development
+
+        workflow test_call_try_output_error {
+            call? bad_output
+        }
+
+        task bad_output {
+            command <<< true >>>
+            output {
+                File x = "missing.txt"
+            }
+        }
+        """, expected_exception=WDL.runtime.OutputError)
+
+    def test_call_try_subworkflow_failure_outputs_null(self):
+        sub_wdl = os.path.join(self._dir, "call_try_subworkflow.wdl")
+        with open(sub_wdl, "w") as outfile:
+            outfile.write("""
+            version development
+
+            workflow sub {
+                call fail
+                output {
+                    String out = fail.out
+                }
+            }
+
+            task fail {
+                command <<<
+                    exit 42
+                >>>
+                output {
+                    String out = "unreached"
+                }
+            }
+            """)
+
+        outputs = self._test_workflow(f"""
+        version development
+
+        import "{sub_wdl}" as subdoc
+
+        workflow test_call_try_subworkflow {{
+            call? subdoc.sub
+
+            output {{
+                String msg = select_first([sub.out, "fallback"])
+            }}
+        }}
+        """)
+        self.assertEqual(outputs, {"msg": "fallback"})
+
+    def test_call_try_nested_subworkflow_failure_outputs_null(self):
+        leaf_wdl = os.path.join(self._dir, "call_try_leaf_subworkflow.wdl")
+        with open(leaf_wdl, "w") as outfile:
+            outfile.write("""
+            version development
+
+            workflow leaf {
+                call fail
+                output {
+                    String out = fail.out
+                }
+            }
+
+            task fail {
+                command <<<
+                    exit 42
+                >>>
+                output {
+                    String out = "unreached"
+                }
+            }
+            """)
+
+        middle_wdl = os.path.join(self._dir, "call_try_middle_subworkflow.wdl")
+        with open(middle_wdl, "w") as outfile:
+            outfile.write(f"""
+            version development
+
+            import "{leaf_wdl}" as leafdoc
+
+            workflow middle {{
+                call leafdoc.leaf
+                output {{
+                    String out = leaf.out
+                }}
+            }}
+            """)
+
+        outputs = self._test_workflow(f"""
+        version development
+
+        import "{middle_wdl}" as middoc
+
+        workflow test_call_try_nested_subworkflow {{
+            call? middoc.middle
+
+            output {{
+                String msg = select_first([middle.out, "fallback"])
+            }}
+        }}
+        """)
+        self.assertEqual(outputs, {"msg": "fallback"})


### PR DESCRIPTION
Introduce `call?`, a variant of `call` that tolerates task execution failures. Outputs of a `call?` are optional to the caller (similar to how values in `if` workflow sections are optional outside), and become `None` in the event of a tolerated failure. Tolerated failures include `CommandFailed`, `DownloadFailed`, and other execution problems; but exclude WDL-level runtime errors such as output file not found, array access beyond length, division by zero, etc.