### PR TITLE
refactor internal placeholder_regex passing

### DIFF
--- a/WDL/Expr.py
+++ b/WDL/Expr.py
@@ -353,7 +353,7 @@ class Placeholder(Base):
 
     def _eval(self, env: Env.Bindings[Value.Base], stdlib: StdLib.Base) -> Value.String:
         ans = self._eval_impl(env, stdlib)
-        placeholder_regex: Optional[regex.Pattern] = getattr(stdlib, "_placeholder_regex", None)
+        placeholder_regex = stdlib.eval_context.placeholder_regex
         if placeholder_regex and not placeholder_regex.fullmatch(ans.value):
             raise Error.InputError(
                 "Task command placeholder value forbidden by configuration [task_runtime] placeholder_regex"

--- a/WDL/StdLib.py
+++ b/WDL/StdLib.py
@@ -1,9 +1,10 @@
 # pylint: disable=protected-access,exec-used
+from dataclasses import dataclass, replace
 import math
 import os
 import json
 import tempfile
-from typing import List, Tuple, Dict, Callable, IO, Optional, Union
+from typing import List, Tuple, Dict, Callable, IO, Optional, Union, Any
 from abc import ABC, abstractmethod
 from contextlib import suppress
 import regex
@@ -16,6 +17,31 @@ from ._util import (
     round_half_up,
     wdl_version_geq,
 )
+
+
+@dataclass(frozen=True)
+class EvalContext:
+    """
+    Evaluation-scoped policy that isn't part of the WDL standard library function namespace.
+
+    For historical reasons this hangs off StdLib.Base: the stdlib object was already threaded
+    through all Expr.eval() calls. In a clean-sheet design we might invert this (StdLib as a
+    member of EvalContext to be passed throughout the eval() tree).
+
+    The context is immutable and composable. Callers that need to add or replace one contextual
+    value should use replace(), preserving any other values already layered into the context.
+    """
+
+    placeholder_regex: Optional[regex.Pattern] = None
+
+    def replace(self, **overrides: Any) -> "EvalContext":
+        """
+        Return a copy of this context with selected fields replaced.
+
+        Unknown field names are rejected by dataclasses.replace(), which keeps future additions
+        explicit while allowing callers to layer one setting without discarding the rest.
+        """
+        return replace(self, **overrides)
 
 
 class Base:
@@ -31,10 +57,14 @@ class Base:
 
     wdl_version: str
     _write_dir: str  # directory in which write_* functions create files
+    eval_context: EvalContext
 
-    def __init__(self, wdl_version: str, write_dir: str = ""):
+    def __init__(
+        self, wdl_version: str, write_dir: str = "", eval_context: Optional[EvalContext] = None
+    ):
         self.wdl_version = wdl_version
         self._write_dir = write_dir if write_dir else tempfile.gettempdir()
+        self.eval_context = eval_context or EvalContext()
 
         # language built-ins
         self._at = _At()

--- a/WDL/runtime/task.py
+++ b/WDL/runtime/task.py
@@ -195,16 +195,16 @@ def run_local_task(  # type: ignore[return]
                 placeholder_re = regex.compile(
                     cfg["task_runtime"]["placeholder_regex"], flags=regex.POSIX
                 )
-                setattr(
-                    stdlib,
-                    "_placeholder_regex",
-                    placeholder_re,
-                )  # hack to pass regex to WDL.Expr.Placeholder._eval
+                command_stdlib = InputStdLib(
+                    task.effective_wdl_version,
+                    logger,
+                    container,
+                    eval_context=stdlib.eval_context.replace(placeholder_regex=placeholder_re),
+                )
                 assert isinstance(task.command, Expr.TaskCommand)
                 command = task.command.eval(
-                    container_env, stdlib, dedent=not old_command_dedent
+                    container_env, command_stdlib, dedent=not old_command_dedent
                 ).value
-                delattr(stdlib, "_placeholder_regex")
                 if old_command_dedent:  # see issue #674
                     command = _util.strip_leading_whitespace(command)[1]
                 logger.debug(_("command", command=command.strip()))
@@ -1049,8 +1049,13 @@ class _StdLib(StdLib.Base):
         logger: logging.Logger,
         container: "TaskContainer",
         inputs_only: bool,
+        eval_context: Optional[StdLib.EvalContext] = None,
     ) -> None:
-        super().__init__(wdl_version, write_dir=os.path.join(container.host_dir, "write_"))
+        super().__init__(
+            wdl_version,
+            write_dir=os.path.join(container.host_dir, "write_"),
+            eval_context=eval_context,
+        )
         self.logger = logger
         self.container = container
         self.inputs_only = inputs_only
@@ -1080,8 +1085,9 @@ class InputStdLib(_StdLib):
         wdl_version: str,
         logger: logging.Logger,
         container: "TaskContainer",
+        eval_context: Optional[StdLib.EvalContext] = None,
     ) -> None:
-        super().__init__(wdl_version, logger, container, True)
+        super().__init__(wdl_version, logger, container, True, eval_context=eval_context)
 
 
 class OutputStdLib(_StdLib):
@@ -1091,8 +1097,9 @@ class OutputStdLib(_StdLib):
         wdl_version: str,
         logger: logging.Logger,
         container: "TaskContainer",
+        eval_context: Optional[StdLib.EvalContext] = None,
     ) -> None:
-        super().__init__(wdl_version, logger, container, False)
+        super().__init__(wdl_version, logger, container, False, eval_context=eval_context)
 
         setattr(
             self,

--- a/WDL/runtime/workflow.py
+++ b/WDL/runtime/workflow.py
@@ -682,9 +682,18 @@ class _StdLib(StdLib.Base):
     cache: CallCache
 
     def __init__(
-        self, wdl_version: str, cfg: config.Loader, state: StateMachine, cache: CallCache
+        self,
+        wdl_version: str,
+        cfg: config.Loader,
+        state: StateMachine,
+        cache: CallCache,
+        eval_context: Optional[StdLib.EvalContext] = None,
     ) -> None:
-        super().__init__(wdl_version, write_dir=os.path.join(state.run_dir, "write_"))
+        super().__init__(
+            wdl_version,
+            write_dir=os.path.join(state.run_dir, "write_"),
+            eval_context=eval_context,
+        )
         self.cfg = cfg
         self.state = state
         self.cache = cache

--- a/tests/test_7runner.py
+++ b/tests/test_7runner.py
@@ -944,6 +944,27 @@ class MiscRegressionTests(RunnerTestCase):
         cfg = WDL.runtime.config.Loader(logging.getLogger(self.id()), [])
         cfg.override({"task_runtime": {"placeholder_regex": "[^']*"}})
         self._run(wdl, {"s": malicious}, cfg=cfg, expected_exception=WDL.Error.InputError)
+
+        wdl_non_command_interpolation = """
+        version 1.1
+        task ordinary_interpolation {
+            input {
+                String s
+                String t = "~{s}"
+            }
+            command <<<
+                echo ok
+            >>>
+            output {
+                String out = "~{t}"
+            }
+        }
+        """
+        self.assertEqual(
+            self._run(wdl_non_command_interpolation, {"s": malicious}, cfg=cfg)["out"],
+            malicious,
+        )
+
         cfg.override({"task_runtime": {"placeholder_regex": "[0-9A-Za-z:/._-]*"}})
         self._run(wdl, {"s": malicious}, cfg=cfg, expected_exception=WDL.Error.InputError)
 


### PR DESCRIPTION
Clean up a dirty old hack for internally propagating `placeholder_regex` into the `eval()` tree where it's ultimately needed.