### PR TITLE
Fix input mount paths to track per-attempt work dir on retries

### DIFF
--- a/WDL/runtime/backend/cli_subprocess.py
+++ b/WDL/runtime/backend/cli_subprocess.py
@@ -168,9 +168,7 @@ class SubprocessBase(TaskContainer):
         if self._bind_input_files:
             for host_path, container_path in self.input_path_map.items():
                 assert (not container_path.endswith("/")) or os.path.isdir(host_path.rstrip("/"))
-                host_mount_point = os.path.join(
-                    self.host_dir, os.path.relpath(container_path.rstrip("/"), self.container_dir)
-                )
+                host_mount_point = self.host_input_path(container_path)
                 if not os.path.exists(host_mount_point):
                     self.touch_mount_point(
                         host_mount_point + ("/" if container_path.endswith("/") else "")

--- a/WDL/runtime/backend/docker_swarm.py
+++ b/WDL/runtime/backend/docker_swarm.py
@@ -367,9 +367,7 @@ class SwarmContainer(TaskContainer):
                     )
                     perm_warn = False
                 assert (not container_path.endswith("/")) or stat.S_ISDIR(st.st_mode)
-                host_mount_point = os.path.join(
-                    self.host_dir, os.path.relpath(container_path.rstrip("/"), self.container_dir)
-                )
+                host_mount_point = self.host_input_path(container_path)
                 if not os.path.exists(host_mount_point):
                     self.touch_mount_point(
                         host_mount_point + ("/" if container_path.endswith("/") else "")

--- a/WDL/runtime/task_container.py
+++ b/WDL/runtime/task_container.py
@@ -205,9 +205,7 @@ class TaskContainer(ABC):
         # called once per task run (attempt)
         for host_path, container_path in self.input_path_map.items():
             assert container_path.startswith(self.container_dir)
-            host_copy_path = os.path.join(
-                self.host_dir, os.path.relpath(container_path.rstrip("/"), self.container_dir)
-            )
+            host_copy_path = self.host_input_path(container_path)
 
             logger.info(_("copy host input file", input=host_path, copy=host_copy_path))
             os.makedirs(os.path.dirname(host_copy_path), exist_ok=True)
@@ -626,6 +624,18 @@ class TaskContainer(ABC):
         return os.path.join(
             self.host_dir, f"work{self.try_counter if self.try_counter > 1 else ''}"
         )
+
+    def host_input_path(self, container_path: str) -> str:
+        """
+        Host-side path for an input file/directory mount point (or copy target) given its in-
+        container path. Inputs live inside the working directory, which is bind-mounted at the fixed
+        container path ``{container_dir}/work`` but resides on the host under ``host_work_dir()``
+        (``work``, ``work2``, ... across retry attempts). Rebasing onto ``host_work_dir()`` — rather
+        than naively stripping ``container_dir`` and assuming ``work`` — keeps mount points and
+        copies in the correct per-attempt directory on retries.
+        """
+        rel = os.path.relpath(container_path.rstrip("/"), os.path.join(self.container_dir, "work"))
+        return os.path.join(self.host_work_dir(), rel)
 
     def host_stdout_txt(self):
         return os.path.join(

--- a/tests/test_4taskrun.py
+++ b/tests/test_4taskrun.py
@@ -1475,3 +1475,41 @@ class TestSwarmMiscConfigUidGid(unittest.TestCase):
                 _resources, user, groups = container.misc_config(logger)
                 self.assertIsNone(user)
                 self.assertEqual(groups, ["0"])
+
+
+class TestHostInputPath(unittest.TestCase):
+    """
+    host_input_path() must track the per-attempt host work dir (work, work2, ...). Inputs are bind-
+    mounted/copied inside the working directory, whose host location changes on each retry while its
+    in-container mount path stays fixed at {container_dir}/work. A regression here only surfaces at
+    the Docker level on macOS (virtiofs refuses to create the missing mount point), since Linux runc
+    silently creates it -- so this unit test guards the behavior on all platforms.
+    """
+
+    def _make_container(self, try_counter):
+        from WDL.runtime.backend.docker_swarm import SwarmContainer
+
+        container = SwarmContainer.__new__(SwarmContainer)
+        container.container_dir = "/mnt/miniwdl_task_container"
+        container.host_dir = "/host/run"
+        container.try_counter = try_counter
+        return container
+
+    def test_first_attempt(self):
+        container = self._make_container(try_counter=1)
+        self.assertEqual(
+            container.host_input_path("/mnt/miniwdl_task_container/work/_miniwdl_inputs/0/in.txt"),
+            "/host/run/work/_miniwdl_inputs/0/in.txt",
+        )
+
+    def test_retry_attempt(self):
+        container = self._make_container(try_counter=2)
+        self.assertEqual(
+            container.host_input_path("/mnt/miniwdl_task_container/work/_miniwdl_inputs/0/in.txt"),
+            "/host/run/work2/_miniwdl_inputs/0/in.txt",
+        )
+        # directory inputs (trailing slash) rebase the same way
+        self.assertEqual(
+            container.host_input_path("/mnt/miniwdl_task_container/work/_miniwdl_inputs/0/d/"),
+            "/host/run/work2/_miniwdl_inputs/0/d",
+        )


### PR DESCRIPTION
On retry, TaskContainer.reset() bumps try_counter so host_work_dir() advances work -> work2, and the work-dir bind mount follows. But input mount-point placeholders and copy_input_files derived the host path as host_dir/relpath(container_path, container_dir), which hardcodes "work" (the fixed container-side mount path) and never advances to "work2". On retry the placeholder/copy landed in work/ while the container's work mount resolved to work2/, leaving the mount point missing in work2.

Linux runc silently creates the missing mount point (masking the bug), but Docker Desktop VirtioFS refuses ("is outside of rootfs"), so retries with input files failed on macOS. Copy-input-files mode was also silently broken on retries (copies landed in the wrong work dir).

Add TaskContainer.host_input_path() to rebase onto host_work_dir() and use it in copy_input_files and both the docker_swarm and cli_subprocess backends. Add TestHostInputPath unit test guarding the behavior on all platforms (the Docker-level symptom is macOS-only).