### PR TITLE
Fix input path mounting on retry

### DIFF
--- a/WDL/runtime/backend/cli_subprocess.py
+++ b/WDL/runtime/backend/cli_subprocess.py
@@ -144,6 +144,10 @@ class SubprocessBase(TaskContainer):
         # them individually
         self._bind_input_files = False
 
+    def reset(self, logger: logging.Logger) -> None:
+        super().reset(logger)
+        self._bind_input_files = True
+
     def prepare_mounts(self) -> List[Tuple[str, str, bool]]:
         mounts = []
         # mount stdout, stderr, and working directory read/write
@@ -168,9 +172,7 @@ class SubprocessBase(TaskContainer):
         if self._bind_input_files:
             for host_path, container_path in self.input_path_map.items():
                 assert (not container_path.endswith("/")) or os.path.isdir(host_path.rstrip("/"))
-                host_mount_point = os.path.join(
-                    self.host_dir, os.path.relpath(container_path.rstrip("/"), self.container_dir)
-                )
+                host_mount_point = self._container_work_path_host(container_path)
                 if not os.path.exists(host_mount_point):
                     self.touch_mount_point(
                         host_mount_point + ("/" if container_path.endswith("/") else "")

--- a/WDL/runtime/backend/cli_subprocess.py
+++ b/WDL/runtime/backend/cli_subprocess.py
@@ -174,7 +174,7 @@ class SubprocessBase(TaskContainer):
         if self._bind_input_files:
             for host_path, container_path in self.input_path_map.items():
                 assert (not container_path.endswith("/")) or os.path.isdir(host_path.rstrip("/"))
-                host_mount_point = self._container_work_path_host(container_path)
+                host_mount_point = self.host_work_path(container_path)
                 if not os.path.exists(host_mount_point):
                     self.touch_mount_point(
                         host_mount_point + ("/" if container_path.endswith("/") else "")

--- a/WDL/runtime/backend/cli_subprocess.py
+++ b/WDL/runtime/backend/cli_subprocess.py
@@ -146,6 +146,8 @@ class SubprocessBase(TaskContainer):
 
     def reset(self, logger: logging.Logger) -> None:
         super().reset(logger)
+        # copy_input_files() disables input bind mounts for the current attempt. A retry has a new
+        # host work dir, so it must either copy the inputs again or bind them while preparing mounts.
         self._bind_input_files = True
 
     def prepare_mounts(self) -> List[Tuple[str, str, bool]]:

--- a/WDL/runtime/backend/docker_swarm.py
+++ b/WDL/runtime/backend/docker_swarm.py
@@ -166,6 +166,10 @@ class SwarmContainer(TaskContainer):
         # them individually
         self._bind_input_files = False
 
+    def reset(self, logger: logging.Logger) -> None:
+        super().reset(logger)
+        self._bind_input_files = True
+
     def _run(self, logger: logging.Logger, terminating: Callable[[], bool], command: str) -> int:
         self._observed_states = set()
         with open(os.path.join(self.host_dir, "command"), "w") as outfile:
@@ -367,9 +371,7 @@ class SwarmContainer(TaskContainer):
                     )
                     perm_warn = False
                 assert (not container_path.endswith("/")) or stat.S_ISDIR(st.st_mode)
-                host_mount_point = os.path.join(
-                    self.host_dir, os.path.relpath(container_path.rstrip("/"), self.container_dir)
-                )
+                host_mount_point = self._container_work_path_host(container_path)
                 if not os.path.exists(host_mount_point):
                     self.touch_mount_point(
                         host_mount_point + ("/" if container_path.endswith("/") else "")

--- a/WDL/runtime/backend/docker_swarm.py
+++ b/WDL/runtime/backend/docker_swarm.py
@@ -373,7 +373,7 @@ class SwarmContainer(TaskContainer):
                     )
                     perm_warn = False
                 assert (not container_path.endswith("/")) or stat.S_ISDIR(st.st_mode)
-                host_mount_point = self._container_work_path_host(container_path)
+                host_mount_point = self.host_work_path(container_path)
                 if not os.path.exists(host_mount_point):
                     self.touch_mount_point(
                         host_mount_point + ("/" if container_path.endswith("/") else "")

--- a/WDL/runtime/backend/docker_swarm.py
+++ b/WDL/runtime/backend/docker_swarm.py
@@ -168,6 +168,8 @@ class SwarmContainer(TaskContainer):
 
     def reset(self, logger: logging.Logger) -> None:
         super().reset(logger)
+        # copy_input_files() disables input bind mounts for the current attempt. A retry has a new
+        # host work dir, so it must either copy the inputs again or bind them while preparing mounts.
         self._bind_input_files = True
 
     def _run(self, logger: logging.Logger, terminating: Callable[[], bool], command: str) -> int:

--- a/WDL/runtime/task_container.py
+++ b/WDL/runtime/task_container.py
@@ -628,6 +628,10 @@ class TaskContainer(ABC):
     def _container_work_path_host(self, container_path: str) -> str:
         """
         Map a path under the fixed in-container work directory to the current host work directory.
+
+        The container always sees ``{container_dir}/work``, but retries advance the host-side
+        backing directory from ``work`` to ``work2`` and so on. Relativize the container path to
+        ``{container_dir}/work`` and append that relative path to the current ``host_work_dir()``.
         """
         container_work_dir = os.path.join(self.container_dir, "work")
         container_path_strip = container_path.rstrip("/")

--- a/WDL/runtime/task_container.py
+++ b/WDL/runtime/task_container.py
@@ -205,9 +205,7 @@ class TaskContainer(ABC):
         # called once per task run (attempt)
         for host_path, container_path in self.input_path_map.items():
             assert container_path.startswith(self.container_dir)
-            host_copy_path = os.path.join(
-                self.host_dir, os.path.relpath(container_path.rstrip("/"), self.container_dir)
-            )
+            host_copy_path = self._container_work_path_host(container_path.rstrip("/"))
 
             logger.info(_("copy host input file", input=host_path, copy=host_copy_path))
             os.makedirs(os.path.dirname(host_copy_path), exist_ok=True)
@@ -626,6 +624,25 @@ class TaskContainer(ABC):
         return os.path.join(
             self.host_dir, f"work{self.try_counter if self.try_counter > 1 else ''}"
         )
+
+    def _container_work_path_host(self, container_path: str) -> str:
+        """
+        Map a path under the fixed in-container work directory to the current host work directory.
+        """
+        container_work_dir = os.path.join(self.container_dir, "work")
+        container_path_strip = container_path.rstrip("/")
+        container_relpath = os.path.relpath(container_path_strip, container_work_dir)
+        assert container_relpath == "." or not (
+            container_relpath == ".." or container_relpath.startswith("../")
+        )
+        ans = (
+            self.host_work_dir()
+            if container_relpath == "."
+            else os.path.join(self.host_work_dir(), container_relpath)
+        )
+        if container_path.endswith("/") and not ans.endswith("/"):
+            ans += "/"
+        return ans
 
     def host_stdout_txt(self):
         return os.path.join(

--- a/WDL/runtime/task_container.py
+++ b/WDL/runtime/task_container.py
@@ -205,7 +205,7 @@ class TaskContainer(ABC):
         # called once per task run (attempt)
         for host_path, container_path in self.input_path_map.items():
             assert container_path.startswith(self.container_dir)
-            host_copy_path = self._container_work_path_host(container_path.rstrip("/"))
+            host_copy_path = self.host_work_path(container_path.rstrip("/"))
 
             logger.info(_("copy host input file", input=host_path, copy=host_copy_path))
             os.makedirs(os.path.dirname(host_copy_path), exist_ok=True)
@@ -625,7 +625,7 @@ class TaskContainer(ABC):
             self.host_dir, f"work{self.try_counter if self.try_counter > 1 else ''}"
         )
 
-    def _container_work_path_host(self, container_path: str) -> str:
+    def host_work_path(self, container_path: str) -> str:
         """
         Map a path under the fixed in-container work directory to the current host work directory.
 

--- a/tests/test_4taskrun.py
+++ b/tests/test_4taskrun.py
@@ -2,6 +2,7 @@ import unittest
 import logging
 import tempfile
 import os
+import shutil
 import docker
 import signal
 import time
@@ -9,6 +10,8 @@ import json
 import platform
 import multiprocessing
 from .context import WDL
+from WDL.runtime.backend.cli_subprocess import SubprocessBase
+from WDL.runtime.task_container import TaskContainer
 from testfixtures import log_capture
 
 class TestTaskRunner(unittest.TestCase):
@@ -1411,6 +1414,120 @@ class TestConfigLoader(unittest.TestCase):
         cfg.plugin_defaults({"file_io": {"copy_input_files": True}, "x": {"y":"z"}})
         self.assertEqual(cfg["file_io"]["copy_input_files"], "false")
         self.assertEqual(cfg.get("x","y"), "z")
+
+
+class TestTaskContainerRetryPaths(unittest.TestCase):
+    class TaskContainerForTest(TaskContainer):
+        @classmethod
+        def global_init(cls, cfg, logger):
+            pass
+
+        @classmethod
+        def detect_resource_limits(cls, cfg, logger):
+            return {"cpu": 1, "mem_bytes": 1}
+
+        def _run(self, logger, terminating, command):
+            return 0
+
+    class SubprocessContainerForTest(SubprocessBase):
+        @classmethod
+        def global_init(cls, cfg, logger):
+            pass
+
+        @property
+        def cli_name(self):
+            return "test"
+
+        def _run_invocation(self, logger, cleanup, image):
+            return []
+
+    def setUp(self):
+        self._dir = tempfile.mkdtemp(prefix="miniwdl_test_retry_paths_")
+        self._logger = logging.getLogger(self.id())
+        self._cfg = WDL.runtime.config.Loader(self._logger, [])
+        self._input_file = os.path.join(self._dir, "input.txt")
+        with open(self._input_file, "w") as outfile:
+            outfile.write("hello\n")
+        self._input_dir = os.path.join(self._dir, "input_dir")
+        os.makedirs(self._input_dir)
+        with open(os.path.join(self._input_dir, "nested.txt"), "w") as outfile:
+            outfile.write("nested\n")
+
+    def tearDown(self):
+        shutil.rmtree(self._dir)
+
+    def _container(self, cls):
+        ans = cls(self._cfg, "test-run", os.path.join(self._dir, "run"))
+        ans.add_paths([self._input_file])
+        return ans
+
+    def _container_with_directory_input(self, cls):
+        ans = cls(self._cfg, "test-run", os.path.join(self._dir, "run"))
+        ans.add_paths([self._input_dir + "/"])
+        return ans
+
+    def _assert_input_path(self, container, work_dir):
+        self.assertTrue(
+            os.path.isfile(
+                os.path.join(container.host_dir, work_dir, "_miniwdl_inputs", "0", "input.txt")
+            )
+        )
+
+    def test_copy_input_files_retry_uses_current_host_work_dir(self):
+        container = self._container(self.TaskContainerForTest)
+
+        for work_dir in ("work", "work2", "work3"):
+            container.copy_input_files(self._logger)
+            self._assert_input_path(container, work_dir)
+            container.reset(self._logger)
+
+    def test_copy_input_directory_retry_uses_current_host_work_dir(self):
+        container = self._container_with_directory_input(self.TaskContainerForTest)
+
+        for work_dir in ("work", "work2", "work3"):
+            container.copy_input_files(self._logger)
+            self.assertTrue(
+                os.path.isfile(
+                    os.path.join(
+                        container.host_dir,
+                        work_dir,
+                        "_miniwdl_inputs",
+                        "0",
+                        "input_dir",
+                        "nested.txt",
+                    )
+                )
+            )
+            container.reset(self._logger)
+
+    def test_subprocess_mount_placeholders_retry_use_current_host_work_dir(self):
+        container = self._container(self.SubprocessContainerForTest)
+
+        for work_dir in ("work", "work2", "work3"):
+            container.prepare_mounts()
+            self._assert_input_path(container, work_dir)
+            container.reset(self._logger)
+
+    def test_subprocess_copy_input_files_can_retry_after_reset(self):
+        container = self._container(self.SubprocessContainerForTest)
+
+        for work_dir in ("work", "work2", "work3"):
+            container.copy_input_files(self._logger)
+            self._assert_input_path(container, work_dir)
+            self.assertFalse(container._bind_input_files)
+            container.reset(self._logger)
+            self.assertTrue(container._bind_input_files)
+
+    def test_swarm_reset_restores_input_binds(self):
+        from WDL.runtime.backend.docker_swarm import SwarmContainer
+
+        container = SwarmContainer(self._cfg, "test-run", os.path.join(self._dir, "run"))
+        container.add_paths([self._input_file])
+        container.copy_input_files(self._logger)
+        self.assertFalse(container._bind_input_files)
+
+        container.reset(self._logger)
+        self.assertTrue(container._bind_input_files)
 
 
 class TestSwarmMiscConfigUidGid(unittest.TestCase):


### PR DESCRIPTION
Task retries keep the same container-side work path, but the host-side directory advances from work to work2 (workN...). Input copies and mount-point placeholders were still being placed under the old work directory, so retry containers could miss their inputs.

Map container work paths through the current host work directory, and reset backend input-bind state between attempts. Add unit coverage for copy-input and mount-placeholder retries.
