### PR TITLE
Add MANIFEST.in for packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,10 @@
+# setuptools-scm seeds the sdist with every tracked file, including files in
+# initialized submodules. Keep runtime sources, top-level project metadata,
+# and reasonably small documentation/examples; exclude development-only trees.
+# Tests are omitted because they are not usable without test_corpi and spec.
+prune .github
+prune spec
+prune stubs
+prune test_corpi
+prune tests
+prune tools_image


### PR DESCRIPTION
Recent changes to setuptools-scm (specifically, upgrading to vcs-versioning 2.x) cause all submodule contents to be included in the sdist tarball by default, making our sdist unreasonably large. Add MANIFEST.in to prune submodules and other nonessential stuff from our sdist.